### PR TITLE
refactor: avoid hard coding tmp dir

### DIFF
--- a/adaptor/src/image.rs
+++ b/adaptor/src/image.rs
@@ -1,7 +1,7 @@
-use std::{env, path::{Path, PathBuf}, sync::Arc};
+use std::{path::{Path, PathBuf}, sync::Arc};
 
 use anyhow::Result;
-use config::PREVIEW;
+use config::{MANAGER, PREVIEW};
 use image::{imageops::FilterType, DynamicImage, ImageFormat};
 use md5::{Digest, Md5};
 use shared::tty_ratio;
@@ -57,8 +57,8 @@ impl Image {
 
 	#[inline]
 	pub fn cache(path: &Path) -> PathBuf {
-		env::temp_dir()
-			.join("yazi")
+		MANAGER
+			.cache
 			.join(format!("{:x}", Md5::new_with_prefix(path.to_string_lossy().as_bytes()).finalize()))
 	}
 }

--- a/adaptor/src/image.rs
+++ b/adaptor/src/image.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}, sync::Arc};
+use std::{env, path::{Path, PathBuf}, sync::Arc};
 
 use anyhow::Result;
 use config::PREVIEW;
@@ -57,7 +57,8 @@ impl Image {
 
 	#[inline]
 	pub fn cache(path: &Path) -> PathBuf {
-		format!("/tmp/yazi/{:x}", Md5::new_with_prefix(path.to_string_lossy().as_bytes()).finalize())
-			.into()
+		env::temp_dir()
+			.join("yazi")
+			.join(format!("{:x}", Md5::new_with_prefix(path.to_string_lossy().as_bytes()).finalize()))
 	}
 }

--- a/config/src/manager/manager.rs
+++ b/config/src/manager/manager.rs
@@ -30,7 +30,7 @@ impl Manager {
 		let mut manager = toml::from_str::<Outer>(&MERGED_YAZI).unwrap().manager;
 
 		manager.cwd = env::current_dir().unwrap_or("/".into());
-		manager.cache = "/tmp/yazi".into();
+		manager.cache = env::temp_dir().join("yazi");
 		if !manager.cache.is_dir() {
 			fs::create_dir(&manager.cache).unwrap();
 		}


### PR DESCRIPTION
Avoid hard coding `/tmp`, which makes cross-platform friendly.