### PR TITLE
chore: rename bin

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,3 +23,7 @@ tokio             = { version = "^1", features = [ "parking_lot" ] }
 tracing            = "^0"
 tracing-appender   = "^0"
 tracing-subscriber = "^0"
+
+[[bin]]
+name = "yazi"
+path = "src/main.rs"


### PR DESCRIPTION
We can use `./target/{debug, release}/yazi` now.