### PR TITLE
feat: show current dir name in tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "unicode-width",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,6 +18,7 @@ libc              = "^0"
 ratatui        		 = "^0"
 signal-hook-tokio = { version = "^0", features = [ "futures-v0_3" ] }
 tokio             = { version = "^1", features = [ "parking_lot" ] }
+unicode-width     = "^0"
 
 # Logging
 tracing            = "^0"

--- a/app/src/header/tabs.rs
+++ b/app/src/header/tabs.rs
@@ -19,11 +19,18 @@ impl<'a> Widget for Tabs<'a> {
 			tabs
 				.iter()
 				.enumerate()
-				.map(|(i, _)| {
+				.map(|(i, tab)| {
+					let mut text = format!(" {} ", i + 1);
+					if THEME.tab.max_width > 0 {
+						text
+							.push_str(&tab.current_name().chars().take(THEME.tab.max_width).collect::<String>());
+						text.push(' ');
+					}
+
 					if i == tabs.idx() {
-						Span::styled(format!(" {} ", i + 1), THEME.tab.active.get())
+						Span::styled(text, THEME.tab.active.get())
 					} else {
-						Span::styled(format!(" {} ", i + 1), THEME.tab.inactive.get())
+						Span::styled(text, THEME.tab.inactive.get())
 					}
 				})
 				.collect::<Vec<_>>(),

--- a/app/src/header/tabs.rs
+++ b/app/src/header/tabs.rs
@@ -1,5 +1,8 @@
+use std::ops::ControlFlow;
+
 use config::THEME;
 use ratatui::{buffer::Buffer, layout::{Alignment, Rect}, text::{Line, Span}, widgets::{Paragraph, Widget}};
+use unicode_width::UnicodeWidthStr;
 
 use crate::Ctx;
 
@@ -21,9 +24,24 @@ impl<'a> Widget for Tabs<'a> {
 				.enumerate()
 				.map(|(i, tab)| {
 					let mut text = format!(" {} ", i + 1);
-					if THEME.tab.max_width > 0 {
-						text
-							.push_str(&tab.current_name().chars().take(THEME.tab.max_width).collect::<String>());
+					if let Some(dir_name) = tab.current_name() {
+						text.push_str(dir_name);
+					}
+
+					let threshold = THEME.tab.max_width.max(3) - 1;
+					let truncated = text.chars().try_fold(String::with_capacity(threshold), |mut text, c| {
+						if text.width() > threshold {
+							ControlFlow::Break(text)
+						} else {
+							text.push(c);
+							ControlFlow::Continue(text)
+						}
+					});
+					let mut text = match truncated {
+						ControlFlow::Break(text) => text,
+						ControlFlow::Continue(text) => text,
+					};
+					if !text.ends_with(' ') {
 						text.push(' ');
 					}
 

--- a/app/src/header/tabs.rs
+++ b/app/src/header/tabs.rs
@@ -23,12 +23,13 @@ impl<'a> Widget for Tabs<'a> {
 				.iter()
 				.enumerate()
 				.map(|(i, tab)| {
-					let mut text = format!(" {} ", i + 1);
+					let mut text = format!("{}", i + 1);
 					if let Some(dir_name) = tab.current_name() {
+						text.push(' ');
 						text.push_str(dir_name);
 					}
 
-					let threshold = THEME.tab.max_width.max(3) - 1;
+					let threshold = THEME.tab.max_width.max(1);
 					let truncated = text.chars().try_fold(String::with_capacity(threshold), |mut text, c| {
 						if text.width() > threshold {
 							ControlFlow::Break(text)
@@ -37,18 +38,15 @@ impl<'a> Widget for Tabs<'a> {
 							ControlFlow::Continue(text)
 						}
 					});
-					let mut text = match truncated {
+					let text = match truncated {
 						ControlFlow::Break(text) => text,
 						ControlFlow::Continue(text) => text,
 					};
-					if !text.ends_with(' ') {
-						text.push(' ');
-					}
 
 					if i == tabs.idx() {
-						Span::styled(text, THEME.tab.active.get())
+						Span::styled(format!(" {text} "), THEME.tab.active.get())
 					} else {
-						Span::styled(text, THEME.tab.inactive.get())
+						Span::styled(format!(" {text} "), THEME.tab.inactive.get())
 					}
 				})
 				.collect::<Vec<_>>(),

--- a/config/preset/theme.toml
+++ b/config/preset/theme.toml
@@ -1,6 +1,7 @@
 [tab]
-active   = { fg = "#1E2031", bg = "#80AEFA" }
-inactive = { fg = "#C8D3F8", bg = "#484D66" }
+active    = { fg = "#1E2031", bg = "#80AEFA" }
+inactive  = { fg = "#C8D3F8", bg = "#484D66" }
+max_width = 0
 
 [status]
 primary	  = { normal = "#80AEFA", select = "#CD9EFC", unset = "#FFA577" }

--- a/config/preset/theme.toml
+++ b/config/preset/theme.toml
@@ -1,7 +1,7 @@
 [tab]
 active    = { fg = "#1E2031", bg = "#80AEFA" }
 inactive  = { fg = "#C8D3F8", bg = "#484D66" }
-max_width = 3
+max_width = 1
 
 [status]
 primary	  = { normal = "#80AEFA", select = "#CD9EFC", unset = "#FFA577" }

--- a/config/preset/theme.toml
+++ b/config/preset/theme.toml
@@ -1,7 +1,7 @@
 [tab]
 active    = { fg = "#1E2031", bg = "#80AEFA" }
 inactive  = { fg = "#C8D3F8", bg = "#484D66" }
-max_width = 0
+max_width = 3
 
 [status]
 primary	  = { normal = "#80AEFA", select = "#CD9EFC", unset = "#FFA577" }

--- a/config/src/theme/theme.rs
+++ b/config/src/theme/theme.rs
@@ -8,8 +8,9 @@ use crate::MERGED_THEME;
 
 #[derive(Deserialize)]
 pub struct Tab {
-	pub active:   Style,
-	pub inactive: Style,
+	pub active:    Style,
+	pub inactive:  Style,
+	pub max_width: usize,
 }
 
 #[derive(Deserialize)]

--- a/core/src/manager/tab.rs
+++ b/core/src/manager/tab.rs
@@ -270,6 +270,10 @@ impl Tab {
 		};
 		true
 	}
+
+	pub fn current_name(&self) -> &str {
+		self.current.cwd.file_name().and_then(|name| name.to_str()).unwrap_or_default()
+	}
 }
 
 impl Tab {

--- a/core/src/manager/tab.rs
+++ b/core/src/manager/tab.rs
@@ -271,8 +271,13 @@ impl Tab {
 		true
 	}
 
-	pub fn current_name(&self) -> &str {
-		self.current.cwd.file_name().and_then(|name| name.to_str()).unwrap_or_default()
+	pub fn current_name(&self) -> Option<&str> {
+		self
+			.current
+			.cwd
+			.file_name()
+			.and_then(|name| name.to_str())
+			.or_else(|| self.current.cwd.to_str())
 	}
 }
 


### PR DESCRIPTION
This PR introduces a new option `max_width` in `[tab]` section for controlling the max width of current directory name in tab. Default value is `0` which means directory name won't be displayed in tab. This matches current behavior.

Here is an example for setting value to `10`:

![image](https://github.com/sxyazi/yazi/assets/17216317/334c6d5f-e328-4518-8460-f827856989e9)

The first tab's directory is "raffia" whose length is less than the threshold we set; the second tab's directory is "swc-plugin-react-remove-properties" whose length is greater than the threshold, so it's truncated and only the first 10 chars are displayed. (Should we add ellipses for this case?)