### PR TITLE
feat: add preset command to the `shell`

### DIFF
--- a/app/src/executor.rs
+++ b/app/src/executor.rs
@@ -106,7 +106,10 @@ impl Executor {
 			}
 			"create" => cx.manager.create(),
 			"rename" => cx.manager.rename(),
-			"shell" => cx.manager.shell(exec.named.contains_key("block")),
+			"shell" => cx.manager.shell(
+				exec.named.contains_key("block"),
+				exec.args.get(0).map(|s| s.as_str()).unwrap_or(""),
+			),
 			"hidden" => cx.manager.current_mut().hidden(match exec.args.get(0).map(|s| s.as_str()) {
 				Some("show") => Some(true),
 				Some("hide") => Some(false),

--- a/app/src/executor.rs
+++ b/app/src/executor.rs
@@ -107,9 +107,9 @@ impl Executor {
 			"create" => cx.manager.create(),
 			"rename" => cx.manager.rename(),
 			"shell" => cx.manager.shell(
+				exec.args.get(0).map(|e| e.as_str()).unwrap_or(""),
 				exec.named.contains_key("block"),
 				exec.named.contains_key("confirm"),
-				exec.args.get(0).map(|s| s.as_str()).unwrap_or(""),
 			),
 			"hidden" => cx.manager.current_mut().hidden(match exec.args.get(0).map(|s| s.as_str()) {
 				Some("show") => Some(true),

--- a/app/src/executor.rs
+++ b/app/src/executor.rs
@@ -108,6 +108,7 @@ impl Executor {
 			"rename" => cx.manager.rename(),
 			"shell" => cx.manager.shell(
 				exec.named.contains_key("block"),
+				exec.named.contains_key("confirm"),
 				exec.args.get(0).map(|s| s.as_str()).unwrap_or(""),
 			),
 			"hidden" => cx.manager.current_mut().hidden(match exec.args.get(0).map(|s| s.as_str()) {

--- a/config/docs/keymap.md
+++ b/config/docs/keymap.md
@@ -62,7 +62,9 @@
 - rename: Rename a file or directory.
 - shell: Run a shell command.
 
+  - `exec`: Optional, command template to be run.
   - `--block`: Block the UI until the command finishes.
+  - `--confirm`: When the template is provided, run it directly, no input UI was shown.
 
 - hidden: Set the visibility of hidden files.
 

--- a/core/src/manager/manager.rs
+++ b/core/src/manager/manager.rs
@@ -225,12 +225,14 @@ impl Manager {
 
 	pub fn bulk_rename(&self) -> bool { false }
 
-	pub fn shell(&self, block: bool, arg: &str) -> bool {
+	pub fn shell(&self, block: bool, confirm: bool, arg: &str) -> bool {
 		let mut command = arg.to_string();
 
 		tokio::spawn(async move {
-			if command.is_empty() {
-				let result = emit!(Input(InputOpt::top("Shell:").with_highlight()));
+			if confirm || command.is_empty() {
+				let opt = InputOpt::top("Shell:").with_value(command.as_str()).with_highlight();
+				let result = emit!(Input(opt));
+
 				if let Ok(exec) = result.await {
 					command = exec;
 				}

--- a/core/src/manager/manager.rs
+++ b/core/src/manager/manager.rs
@@ -225,16 +225,21 @@ impl Manager {
 
 	pub fn bulk_rename(&self) -> bool { false }
 
-	pub fn shell(&self, block: bool) -> bool {
-		tokio::spawn(async move {
-			let result = emit!(Input(InputOpt::top("Shell:").with_highlight()));
+	pub fn shell(&self, block: bool, arg: &str) -> bool {
+		let mut command = arg.to_string();
 
-			if let Ok(exec) = result.await {
-				emit!(Open(
-					Default::default(),
-					Some(Opener { exec, block, display_name: Default::default(), spread: true })
-				));
+		tokio::spawn(async move {
+			if command.is_empty() {
+				let result = emit!(Input(InputOpt::top("Shell:").with_highlight()));
+				if let Ok(exec) = result.await {
+					command = exec;
+				}
 			}
+
+			emit!(Open(
+				Default::default(),
+				Some(Opener { exec: command, block, display_name: Default::default(), spread: true })
+			));
 		});
 
 		false

--- a/core/src/tasks/scheduler.rs
+++ b/core/src/tasks/scheduler.rs
@@ -302,7 +302,7 @@ impl Scheduler {
 			})
 		});
 
-		let args = args.into_iter().map(|a| a.as_ref().to_os_string()).collect::<Vec<_>>();
+		let args = args.iter().map(|a| a.as_ref().to_os_string()).collect::<Vec<_>>();
 		tokio::spawn({
 			let process = self.process.clone();
 			let opener = opener.clone();


### PR DESCRIPTION
previous issues #37 

support style:

```
{ on = [ "l", "g" ], exec = "shell --block lazygit" },


{ on = [ "l", "g" ], exec = "shell --block 'lazygit -foo bar'" },
```