### PR TITLE
feat: choose-file mode

### DIFF
--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -1,5 +1,5 @@
 use core::{emit, files::FilesOp, input::InputMode, Event};
-use std::os::unix::prelude::OsStrExt;
+use std::{ffi::OsString, os::unix::prelude::OsStrExt};
 
 use anyhow::{Ok, Result};
 use config::{keymap::{Control, Key, KeymapLayer}, BOOT};
@@ -167,6 +167,17 @@ impl App {
 			}
 
 			Event::Open(targets, opener) => {
+				if let Some(p) = &BOOT.chooser_file {
+					let paths = targets.into_iter().fold(OsString::new(), |mut s, (p, _)| {
+						s.push(p);
+						s.push("\n");
+						s
+					});
+
+					std::fs::write(p, paths.as_bytes()).ok();
+					return emit!(Quit);
+				}
+
 				if let Some(opener) = opener {
 					tasks.file_open_with(&opener, &targets.into_iter().map(|(f, _)| f).collect::<Vec<_>>());
 				} else {

--- a/core/src/external/clipboard.rs
+++ b/core/src/external/clipboard.rs
@@ -28,4 +28,3 @@ pub async fn clipboard_set(s: &str) -> Result<()> {
 
 	bail!("failed to set clipboard")
 }
-

--- a/core/src/select/select.rs
+++ b/core/src/select/select.rs
@@ -1,8 +1,7 @@
 use anyhow::{anyhow, Result};
-use shared::tty_size;
 use tokio::sync::oneshot::Sender;
 
-use super::{SelectOpt, SELECT_PADDING};
+use super::SelectOpt;
 use crate::Position;
 
 #[derive(Default)]

--- a/core/src/which/mod.rs
+++ b/core/src/which/mod.rs
@@ -1,4 +1,3 @@
 mod which;
 
 pub use which::*;
-


### PR DESCRIPTION
This is a dummy pr to replicate the broken pull 68.

`yazi --file-chooser ./temp.txt ..`

You can now use my fork of [fm-nvim](https://github.com/Eric-Song-Nop/fm-nvim) with command Yazi.