### PR TITLE
feat: allow references to the selected files during shell execution

### DIFF
--- a/app/src/executor.rs
+++ b/app/src/executor.rs
@@ -106,7 +106,7 @@ impl Executor {
 			}
 			"create" => cx.manager.create(),
 			"rename" => cx.manager.rename(),
-			"copy" => cx.manager.copy(exec.args.get(0).map(|s| s.as_str()).unwrap_or("")),
+			"copy" => cx.manager.active().copy(exec.args.get(0).map(|s| s.as_str()).unwrap_or("")),
 			"shell" => cx.manager.active().shell(
 				exec.args.get(0).map(|e| e.as_str()).unwrap_or(""),
 				exec.named.contains_key("block"),


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/70

Now you can use variables like `$1`, `$@`, and `$*` just like the real shell does!

https://github.com/sxyazi/yazi/assets/17523360/52158059-d819-45c2-9851-5cf2098634e7
