### PR TITLE
feat: custom manager layout

### DIFF
--- a/app/src/manager/layout.rs
+++ b/app/src/manager/layout.rs
@@ -1,5 +1,4 @@
-use core::manager::{ALL_RATIO, CURRENT_RATIO, PARENT_RATIO, PREVIEW_RATIO};
-
+use config::MANAGER;
 use ratatui::{buffer::Buffer, layout::{self, Constraint, Direction, Rect}, widgets::{Block, Borders, Padding, Widget}};
 
 use super::{Folder, Preview};
@@ -15,15 +14,16 @@ impl<'a> Layout<'a> {
 
 impl<'a> Widget for Layout<'a> {
 	fn render(self, area: Rect, buf: &mut Buffer) {
+		let layout = &MANAGER.layout;
 		let manager = &self.cx.manager;
 
 		let chunks = layout::Layout::new()
 			.direction(Direction::Horizontal)
 			.constraints(
 				[
-					Constraint::Ratio(PARENT_RATIO, ALL_RATIO),
-					Constraint::Ratio(CURRENT_RATIO, ALL_RATIO),
-					Constraint::Ratio(PREVIEW_RATIO, ALL_RATIO),
+					Constraint::Ratio(layout.parent, layout.all),
+					Constraint::Ratio(layout.current, layout.all),
+					Constraint::Ratio(layout.preview, layout.all),
 				]
 				.as_ref(),
 			)

--- a/app/src/manager/preview.rs
+++ b/app/src/manager/preview.rs
@@ -1,7 +1,7 @@
-use core::manager::{PreviewData, PREVIEW_BORDER};
+use core::manager::PreviewData;
 
 use ansi_to_tui::IntoText;
-use ratatui::{buffer::Buffer, layout::Rect, widgets::{Clear, Paragraph, Widget}};
+use ratatui::{buffer::Buffer, layout::Rect, widgets::{Paragraph, Widget}};
 
 use super::Folder;
 use crate::Ctx;
@@ -16,16 +16,6 @@ impl<'a> Preview<'a> {
 
 impl<'a> Widget for Preview<'a> {
 	fn render(self, area: Rect, buf: &mut Buffer) {
-		Clear.render(
-			Rect {
-				x:      area.x,
-				y:      area.y,
-				width:  area.width + PREVIEW_BORDER / 2,
-				height: area.height,
-			},
-			buf,
-		);
-
 		let manager = &self.cx.manager;
 		let Some(hovered) = manager.hovered().map(|h| &h.path) else {
 			return;

--- a/config/docs/yazi.md
+++ b/config/docs/yazi.md
@@ -2,6 +2,10 @@
 
 ## manager
 
+- layout: Manager layout by ratio, 3-element array
+
+  - `[1, 4, 3]`: 1/8 width for parent, 4/8 width for current, 3/8 width for preview
+
 - sort_by: File sorting method
 
   - `"alphabetical"`: Sort alphabetically

--- a/config/preset/keymap.toml
+++ b/config/preset/keymap.toml
@@ -169,11 +169,11 @@ keymap = [
 	{ on = [ "x" ], exec = [ "delete --cut", "move 1 --in-operating" ] },
 
 	# Yank/Paste
-	{ on = [ "y" ], exec = [ "yank" ] },
-	{ on = [ "p" ], exec = [ "paste" ] },
-	{ on = [ "P" ], exec = [ "paste --before" ] },
+	{ on = [ "y" ], exec = "yank" },
+	{ on = [ "p" ], exec = "paste" },
+	{ on = [ "P" ], exec = "paste --before" },
 
 	# Undo/Redo
-	{ on = [ "u" ], exec = [ "undo" ] },
-	{ on = [ "<C-r>" ], exec = [ "redo" ] },
+	{ on = [ "u" ], exec = "undo" },
+	{ on = [ "<C-r>" ], exec = "redo" },
 ]

--- a/config/preset/yazi.toml
+++ b/config/preset/yazi.toml
@@ -1,4 +1,5 @@
 [manager]
+layout         = [ 1, 4, 3 ]
 sort_by        = "modified"
 sort_reverse   = true
 sort_dir_first = true

--- a/config/src/manager/layout.rs
+++ b/config/src/manager/layout.rs
@@ -1,0 +1,69 @@
+use anyhow::bail;
+use crossterm::terminal::WindowSize;
+use ratatui::prelude::Rect;
+use serde::Deserialize;
+use shared::Term;
+
+use super::{FOLDER_MARGIN, PREVIEW_BORDER, PREVIEW_MARGIN};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "Vec<u32>")]
+pub struct ManagerLayout {
+	pub parent:  u32,
+	pub current: u32,
+	pub preview: u32,
+	pub all:     u32,
+}
+
+impl TryFrom<Vec<u32>> for ManagerLayout {
+	type Error = anyhow::Error;
+
+	fn try_from(ratio: Vec<u32>) -> Result<Self, Self::Error> {
+		if ratio.len() != 3 {
+			bail!("invalid layout ratio: {:?}", ratio);
+		}
+		if ratio.iter().all(|&r| r == 0) {
+			bail!("at least one layout ratio must be non-zero: {:?}", ratio);
+		}
+
+		Ok(Self {
+			parent:  ratio[0],
+			current: ratio[1],
+			preview: ratio[2],
+			all:     ratio[0] + ratio[1] + ratio[2],
+		})
+	}
+}
+
+impl ManagerLayout {
+	pub fn preview_rect(&self) -> Rect {
+		let WindowSize { columns, rows, .. } = Term::size();
+
+		let x = (columns as u32 * (self.parent + self.current) / self.all) as u16;
+		let width = (columns as u32 * self.preview / self.all) as u16;
+
+		Rect {
+			x:      x.saturating_add(PREVIEW_BORDER / 2),
+			y:      PREVIEW_MARGIN / 2,
+			width:  width.saturating_sub(PREVIEW_BORDER),
+			height: rows.saturating_sub(PREVIEW_MARGIN),
+		}
+	}
+
+	#[inline]
+	pub fn preview_height(&self) -> usize { self.preview_rect().height as usize }
+
+	pub fn folder_rect(&self) -> Rect {
+		let WindowSize { columns, rows, .. } = Term::size();
+
+		Rect {
+			x:      (columns as u32 * self.parent / self.all) as u16,
+			y:      FOLDER_MARGIN / 2,
+			width:  (columns as u32 * self.current / self.all) as u16,
+			height: rows.saturating_sub(FOLDER_MARGIN),
+		}
+	}
+
+	#[inline]
+	pub fn folder_height(&self) -> usize { self.folder_rect().height as usize }
+}

--- a/config/src/manager/manager.rs
+++ b/config/src/manager/manager.rs
@@ -1,10 +1,12 @@
 use serde::Deserialize;
 
-use super::SortBy;
+use super::{ManagerLayout, SortBy};
 use crate::MERGED_YAZI;
 
 #[derive(Debug, Deserialize)]
 pub struct Manager {
+	pub layout: ManagerLayout,
+
 	// Sorting
 	pub sort_by:        SortBy,
 	pub sort_reverse:   bool,

--- a/config/src/manager/mod.rs
+++ b/config/src/manager/mod.rs
@@ -1,5 +1,12 @@
+mod layout;
 mod manager;
 mod sorting;
 
+pub use layout::*;
 pub use manager::*;
 pub use sorting::*;
+
+const FOLDER_MARGIN: u16 = 2;
+
+const PREVIEW_BORDER: u16 = 2;
+const PREVIEW_MARGIN: u16 = 2;

--- a/core/src/manager/mod.rs
+++ b/core/src/manager/mod.rs
@@ -13,13 +13,3 @@ pub use preview::*;
 pub use tab::*;
 pub use tabs::*;
 pub use watcher::*;
-
-pub const PARENT_RATIO: u32 = 1;
-pub const CURRENT_RATIO: u32 = 4;
-pub const PREVIEW_RATIO: u32 = 3;
-pub const ALL_RATIO: u32 = PARENT_RATIO + CURRENT_RATIO + PREVIEW_RATIO;
-
-pub const DIR_PADDING: u16 = 2;
-
-pub const PREVIEW_BORDER: u16 = 2;
-pub const PREVIEW_MARGIN: u16 = 2;


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/71

There are some special cases:


- `layout = [ 1, 4, 0 ]`, no preview

  <img width="1111" alt="image" src="https://github.com/sxyazi/yazi/assets/17523360/08d12188-a721-4712-8638-17a572489345">


- `layout = [ 0, 1, 0 ]`, single column

  <img width="1111" alt="image" src="https://github.com/sxyazi/yazi/assets/17523360/8302ea83-852d-4a17-9613-3e8230af4a63">
