### PR TITLE
Organize keys for logical behavior

### DIFF
--- a/config/preset/keymap.toml
+++ b/config/preset/keymap.toml
@@ -176,5 +176,5 @@ keymap = [
 
 	# Undo/Redo
 	{ on = [ "u" ], exec = "undo" },
-	{ on = [ "U" ], exec = "redo" },
+	{ on = [ "<C-r>" ], exec = "redo" },
 ]

--- a/config/preset/keymap.toml
+++ b/config/preset/keymap.toml
@@ -3,6 +3,7 @@
 keymap = [
 	{ on = [ "<Esc>" ], exec = "escape"  },
 	{ on = [ "q" ], exec = "quit" },
+	# close current tab and exit if it is last tab
 	{ on = [ "<C-q>" ], exec = "close" },
 
 	# Navigation
@@ -63,12 +64,12 @@ keymap = [
 	# Sorting
 	{ on = [ ",", "a" ], exec = "sort alphabetical" },
 	{ on = [ ",", "A" ], exec = "sort alphabetical --reverse" },
-	{ on = [ ",", "c" ], exec = "sort created --reverse" },
-	{ on = [ ",", "C" ], exec = "sort created" },
-	{ on = [ ",", "m" ], exec = "sort modified --reverse" },
-	{ on = [ ",", "M" ], exec = "sort modified" },
-	{ on = [ ",", "s" ], exec = "sort size --reverse" },
-	{ on = [ ",", "S" ], exec = "sort size" },
+	{ on = [ ",", "c" ], exec = "sort created" },
+	{ on = [ ",", "C" ], exec = "sort created --reverse" },
+	{ on = [ ",", "m" ], exec = "sort modified" },
+	{ on = [ ",", "M" ], exec = "sort modified --reverse" },
+	{ on = [ ",", "s" ], exec = "sort size" },
+	{ on = [ ",", "S" ], exec = "sort size --reverse" },
 
 	# Tabs
 	{ on = [ "t" ], exec = "tab_create --current" },
@@ -175,5 +176,5 @@ keymap = [
 
 	# Undo/Redo
 	{ on = [ "u" ], exec = "undo" },
-	{ on = [ "<C-r>" ], exec = "redo" },
+	{ on = [ "U" ], exec = "redo" },
 ]


### PR DESCRIPTION
- [x] Organize keys on sorting: 1) lower key always normal sort; 2) upper key always _reverse_ sort.
- [x] Add comment to improve clarity on _close_ command.
- [x] ~Change on _redo_ on more logical "U" instead of Ctrl+r (similar behavior with helix). Less keys to type.~