### PR TITLE
fix: set cursor block after closing input prompt from insert mode

### DIFF
--- a/core/src/input/input.rs
+++ b/core/src/input/input.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use anyhow::{anyhow, Result};
 use config::keymap::Key;
 use crossterm::event::KeyCode;
-use shared::CharKind;
+use shared::{CharKind, Term};
 use tokio::sync::oneshot::Sender;
 use unicode_width::UnicodeWidthStr;
 
@@ -43,6 +43,7 @@ impl Input {
 				cb.send(if submit { Ok(self.snap_mut().value.clone()) } else { Err(anyhow!("canceled")) });
 		}
 
+		let _ = Term::set_cursor_block();
 		self.visible = false;
 		true
 	}

--- a/core/src/input/input.rs
+++ b/core/src/input/input.rs
@@ -43,7 +43,6 @@ impl Input {
 				cb.send(if submit { Ok(self.snap_mut().value.clone()) } else { Err(anyhow!("canceled")) });
 		}
 
-		let _ = Term::set_cursor_default();
 		self.visible = false;
 		true
 	}

--- a/core/src/input/input.rs
+++ b/core/src/input/input.rs
@@ -43,7 +43,7 @@ impl Input {
 				cb.send(if submit { Ok(self.snap_mut().value.clone()) } else { Err(anyhow!("canceled")) });
 		}
 
-		let _ = Term::set_cursor_block();
+		let _ = Term::set_cursor_default();
 		self.visible = false;
 		true
 	}

--- a/core/src/input/input.rs
+++ b/core/src/input/input.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use anyhow::{anyhow, Result};
 use config::keymap::Key;
 use crossterm::event::KeyCode;
-use shared::{CharKind, Term};
+use shared::CharKind;
 use tokio::sync::oneshot::Sender;
 use unicode_width::UnicodeWidthStr;
 

--- a/shared/src/term/cursor.rs
+++ b/shared/src/term/cursor.rs
@@ -54,4 +54,7 @@ impl Term {
 
 	#[inline]
 	pub fn set_cursor_bar() -> Result<()> { Ok(execute!(stdout(), SetCursorStyle::BlinkingBar)?) }
+
+	#[inline]
+	pub fn set_cursor_default() -> Result<()> { Ok(execute!(stdout(), SetCursorStyle::DefaultUserShape)?) }
 }

--- a/shared/src/term/term.rs
+++ b/shared/src/term/term.rs
@@ -77,6 +77,7 @@ impl Drop for Term {
 
 			execute!(stdout(), DisableFocusChange, DisableBracketedPaste, LeaveAlternateScreen)?;
 
+			Self::set_cursor_default()?;
 			self.show_cursor()?;
 			Ok(disable_raw_mode()?)
 		};


### PR DESCRIPTION
I've noticed that after closing the input prompt from the insert mode, the cursor shape doesn't change back to block

How to reproduce:
1) open input prompt (e.g try to rename some file)
2) press enter to close it (from insert mode)
3) see that cursor shape is now bar (I guess it should be block as before opening `yazi`)

<details>
<summary>Before</summary>
<br>

https://github.com/sxyazi/yazi/assets/61150013/fb33b774-e1a9-4490-8ce8-be203a4c7b73

</details>


<details>
<summary>After</summary>
<br>

https://github.com/sxyazi/yazi/assets/61150013/22c7fa80-be8f-409d-93c0-b4164ec8ab51

</details>

(Not sure that I placed `Term::set_cursor_block()` to the right place)
