### PR TITLE
fix: doesn't redirect the stderr of the clipboard command to null

### DIFF
--- a/core/src/external/clipboard.rs
+++ b/core/src/external/clipboard.rs
@@ -56,6 +56,7 @@ pub async fn clipboard_set(s: impl AsRef<std::ffi::OsStr>) -> Result<()> {
 			.args(args)
 			.stdin(Stdio::piped())
 			.stdout(Stdio::null())
+			.stderr(Stdio::null())
 			.kill_on_drop(true)
 			.spawn()
 		else {


### PR DESCRIPTION
Close https://github.com/sxyazi/yazi/issues/118