### PR TITLE
Add fallback mime guessing in case file(1) is not available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "futures",
  "indexmap 2.0.0",
  "libc",
+ "mime_guess",
  "natord",
  "notify",
  "parking_lot",
@@ -1049,6 +1050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2003,6 +2020,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,7 @@ tracing       = "^0"
 trash         = "^3"
 unicode-width = "^0"
 yazi-prebuild = "^0"
+mime_guess = "2.0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 clipboard-win = "^4"

--- a/shared/src/mime.rs
+++ b/shared/src/mime.rs
@@ -18,7 +18,7 @@ pub enum MimeKind {
 
 impl MimeKind {
 	pub fn new(s: &str) -> Self {
-		if s.starts_with("text/") || s.ends_with("/xml") || s.ends_with("/javascript") {
+		if s.starts_with("text/") || s.ends_with("/xml") || s.ends_with("/javascript") || s.ends_with("/x-sh") {
 			Self::Text
 		} else if s.starts_with("image/") {
 			Self::Image


### PR DESCRIPTION
Relying on `file(1)` for mime guessing is quite ok for unix-like os. But on Windows, only few people add it to PATH. This pull request add a fallback mechanism in case `file(1)` is not in PATH.