### PR TITLE
feat: tab switch wraparound

### DIFF
--- a/core/src/manager/tabs.rs
+++ b/core/src/manager/tabs.rs
@@ -33,7 +33,11 @@ impl Tabs {
 	}
 
 	pub fn switch(&mut self, idx: isize, rel: bool) -> bool {
-		let idx = if rel { self.absolute(idx) } else { idx as usize };
+		let idx = if rel {
+			(self.idx as isize + idx).rem_euclid(self.items.len() as isize) as usize
+		} else {
+			idx as usize
+		};
 
 		if idx == self.idx || idx >= self.items.len() {
 			return false;


### PR DESCRIPTION
This allows tab switching to wrap back to the opposite extremity. E.g., if 5 tabs are open:
- `tab_switch 1` (<kbd>]</kbd> by default) from tab 5 will wrap to tab 1
- `tab_switch -1` (<kbd>[</kbd> by default) from tab 1 will wrap to tab 5