### PR TITLE
Fix image preview broken on zellij with wezterm

### DIFF
--- a/adaptor/src/adaptor.rs
+++ b/adaptor/src/adaptor.rs
@@ -29,6 +29,7 @@ pub enum Adaptor {
 impl Adaptor {
 	pub(super) fn detect() -> Self {
 		let vars = [
+			("ZELLIJ_SESSION_NAME", Self::Sixel),
 			("KITTY_WINDOW_ID", Self::Kitty),
 			("KONSOLE_VERSION", Self::Kitty),
 			("ITERM_SESSION_ID", Self::Iterm2),

--- a/shared/src/term/cursor.rs
+++ b/shared/src/term/cursor.rs
@@ -56,5 +56,7 @@ impl Term {
 	pub fn set_cursor_bar() -> Result<()> { Ok(execute!(stdout(), SetCursorStyle::BlinkingBar)?) }
 
 	#[inline]
-	pub fn set_cursor_default() -> Result<()> { Ok(execute!(stdout(), SetCursorStyle::DefaultUserShape)?) }
+	pub fn set_cursor_default() -> Result<()> {
+		Ok(execute!(stdout(), SetCursorStyle::DefaultUserShape)?)
+	}
 }


### PR DESCRIPTION
Zellij only supports sixel, and can detect zellij env with `ZELLIJ_SESSION_NAME`.

Also I ran `cargo fmt`