### PR TITLE
feat: include ignored files on search when hidden files are shown

### DIFF
--- a/core/src/external/fd.rs
+++ b/core/src/external/fd.rs
@@ -17,7 +17,7 @@ pub fn fd(opt: FdOpt) -> Result<UnboundedReceiver<File>> {
 	let mut child = Command::new("fd")
 		.arg("--base-directory")
 		.arg(&opt.cwd)
-		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
+		.args(if opt.hidden { ["--hidden", "--no-ignore"] } else { ["--no-hidden", "--ignore"] })
 		.arg(if opt.glob { "--glob" } else { "--regex" })
 		.arg(&opt.subject)
 		.kill_on_drop(true)

--- a/core/src/external/rg.rs
+++ b/core/src/external/rg.rs
@@ -16,7 +16,7 @@ pub fn rg(opt: RgOpt) -> Result<UnboundedReceiver<File>> {
 	let mut child = Command::new("rg")
 		.current_dir(&opt.cwd)
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
-		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
+		.args(if opt.hidden { ["--hidden", "--no-ignore"] } else { ["--no-hidden", "--ignore"] })
 		.arg(&opt.subject)
 		.kill_on_drop(true)
 		.stdout(Stdio::piped())


### PR DESCRIPTION
```
  -I, --no-ignore
          Show search results from files and directories that would otherwise be ignored by
          '.gitignore', '.ignore', '.fdignore', or the global ignore file. The flag can be
          overridden with --ignore.
```