### PR TITLE
feat: scroll half/full page with `arrow` percentage supported, and new Vi-like `<C-u>`, `<C-d>`, `<C-b>`, and `<C-f>` keybindings added

### DIFF
--- a/app/src/executor.rs
+++ b/app/src/executor.rs
@@ -61,7 +61,7 @@ impl Executor {
 
 			// Navigation
 			"arrow" => {
-				let step = exec.args.get(0).and_then(|s| s.parse().ok()).unwrap_or(0);
+				let step = exec.args.get(0).and_then(|s| s.parse().ok()).unwrap_or_default();
 				cx.manager.active_mut().arrow(step)
 			}
 			"peek" => {

--- a/config/preset/keymap.toml
+++ b/config/preset/keymap.toml
@@ -10,8 +10,10 @@ keymap = [
 	{ on = [ "k" ], exec = "arrow -1", desc = "Move cursor up" },
 	{ on = [ "j" ], exec = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "K" ], exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "J" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "<C-u>" ], exec = "arrow -50%", desc = "Move cursor up half page" },
+	{ on = [ "<C-d>" ], exec = "arrow 50%",  desc = "Move cursor down half page" },
+	{ on = [ "<C-b>" ], exec = "arrow -100%", desc = "Move cursor up one page" },
+	{ on = [ "<C-f>" ], exec = "arrow 100%",  desc = "Move cursor down one page" },
 
 	{ on = [ "h" ], exec = "leave", desc = "Go back to the parent directory" },
 	{ on = [ "l" ], exec = "enter", desc = "Enter the child directory" },

--- a/config/preset/keymap.toml
+++ b/config/preset/keymap.toml
@@ -10,6 +10,9 @@ keymap = [
 	{ on = [ "k" ], exec = "arrow -1", desc = "Move cursor up" },
 	{ on = [ "j" ], exec = "arrow 1",  desc = "Move cursor down" },
 
+	{ on = [ "K" ], exec = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "J" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+
 	{ on = [ "<C-u>" ], exec = "arrow -50%", desc = "Move cursor up half page" },
 	{ on = [ "<C-d>" ], exec = "arrow 50%",  desc = "Move cursor down half page" },
 	{ on = [ "<C-b>" ], exec = "arrow -100%", desc = "Move cursor up one page" },

--- a/config/preset/keymap.toml
+++ b/config/preset/keymap.toml
@@ -13,8 +13,8 @@ keymap = [
 	{ on = [ "K" ], exec = "arrow -5", desc = "Move cursor up 5 lines" },
 	{ on = [ "J" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
 
-	{ on = [ "<C-u>" ], exec = "arrow -50%", desc = "Move cursor up half page" },
-	{ on = [ "<C-d>" ], exec = "arrow 50%",  desc = "Move cursor down half page" },
+	{ on = [ "<C-u>" ], exec = "arrow -50%",  desc = "Move cursor up half page" },
+	{ on = [ "<C-d>" ], exec = "arrow 50%",   desc = "Move cursor down half page" },
 	{ on = [ "<C-b>" ], exec = "arrow -100%", desc = "Move cursor up one page" },
 	{ on = [ "<C-f>" ], exec = "arrow 100%",  desc = "Move cursor down one page" },
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,8 +14,9 @@ pub mod help;
 mod highlighter;
 pub mod input;
 pub mod manager;
-pub mod position;
+mod position;
 pub mod select;
+mod step;
 pub mod tasks;
 pub mod which;
 
@@ -23,5 +24,6 @@ pub use blocker::*;
 pub use event::*;
 pub use highlighter::*;
 pub use position::*;
+pub use step::*;
 
 pub fn init() { init_blocker(); }

--- a/core/src/manager/folder.rs
+++ b/core/src/manager/folder.rs
@@ -64,8 +64,8 @@ impl Folder {
 			return false;
 		}
 
-		let limit = MANAGER.layout.folder_height();
 		let old = self.cursor;
+		let limit = MANAGER.layout.folder_height();
 		self.cursor = step.add(self.cursor, || limit).min(len - 1);
 		self.hovered = self.files.duplicate(self.cursor);
 		self.set_page(false);
@@ -79,7 +79,7 @@ impl Folder {
 
 	pub fn prev(&mut self, step: Step) -> bool {
 		let old = self.cursor;
-		self.cursor = step.add(self.cursor, || 0);
+		self.cursor = step.add(self.cursor, || MANAGER.layout.folder_height());
 		self.hovered = self.files.duplicate(self.cursor);
 		self.set_page(false);
 

--- a/core/src/manager/folder.rs
+++ b/core/src/manager/folder.rs
@@ -1,3 +1,5 @@
+use std::{num::ParseIntError, str::FromStr};
+
 use config::MANAGER;
 use ratatui::layout::Rect;
 use shared::Url;
@@ -16,12 +18,31 @@ pub struct Folder {
 	pub hovered: Option<File>,
 }
 
+#[derive(Default)]
+pub struct Step {
+	pub(super) num:     isize,
+	pub(super) percent: bool,
+}
+
 impl From<Url> for Folder {
 	fn from(cwd: Url) -> Self { Self { cwd, ..Default::default() } }
 }
 
 impl From<&Url> for Folder {
 	fn from(cwd: &Url) -> Self { Self::from(cwd.clone()) }
+}
+
+impl FromStr for Step {
+	type Err = ParseIntError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(Self { num: s.trim_end_matches('%').parse()?, percent: s.ends_with('%') })
+	}
+}
+
+impl From<isize> for Step {
+	#[inline]
+	fn from(num: isize) -> Self { Self { num, percent: false } }
 }
 
 impl Folder {
@@ -58,18 +79,21 @@ impl Folder {
 		true
 	}
 
-	pub fn next(&mut self, step: usize) -> bool {
+	pub fn next(&mut self, mut step: usize, percent: bool) -> bool {
 		let len = self.files.len();
 		if len == 0 {
 			return false;
 		}
 
+		let limit = MANAGER.layout.folder_height();
+		if percent {
+			step = ((limit * step) as f64 * 0.01) as usize;
+		}
 		let old = self.cursor;
 		self.cursor = (self.cursor + step).min(len - 1);
 		self.hovered = self.files.duplicate(self.cursor);
 		self.set_page(false);
 
-		let limit = MANAGER.layout.folder_height();
 		if self.cursor >= (self.offset + limit).min(len).saturating_sub(5) {
 			self.offset = len.saturating_sub(limit).min(self.offset + self.cursor - old);
 		}
@@ -77,7 +101,11 @@ impl Folder {
 		old != self.cursor
 	}
 
-	pub fn prev(&mut self, step: usize) -> bool {
+	pub fn prev(&mut self, mut step: usize, percent: bool) -> bool {
+		if percent {
+			let limit = MANAGER.layout.folder_height();
+			step = ((limit * step) as f64 * 0.01) as usize;
+		}
 		let old = self.cursor;
 		self.cursor = self.cursor.saturating_sub(step);
 		self.hovered = self.files.duplicate(self.cursor);
@@ -105,7 +133,11 @@ impl Folder {
 
 	pub fn hover(&mut self, url: &Url) -> bool {
 		let new = self.files.position(url).unwrap_or(self.cursor);
-		if new > self.cursor { self.next(new - self.cursor) } else { self.prev(self.cursor - new) }
+		if new > self.cursor {
+			self.next(new - self.cursor, false)
+		} else {
+			self.prev(self.cursor - new, false)
+		}
 	}
 
 	#[inline]

--- a/core/src/manager/tab.rs
+++ b/core/src/manager/tab.rs
@@ -6,8 +6,8 @@ use shared::{Debounce, Defer, InputError, Url};
 use tokio::{pin, task::JoinHandle};
 use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
 
-use super::{Finder, Folder, Mode, Preview, PreviewLock, Step};
-use crate::{emit, external::{self, FzfOpt, ZoxideOpt}, files::{File, FilesOp, FilesSorter}, input::InputOpt, Event, BLOCKER};
+use super::{Finder, Folder, Mode, Preview, PreviewLock};
+use crate::{emit, external::{self, FzfOpt, ZoxideOpt}, files::{File, FilesOp, FilesSorter}, input::InputOpt, Event, Step, BLOCKER};
 
 pub struct Tab {
 	pub(super) mode:    Mode,
@@ -68,12 +68,7 @@ impl Tab {
 	}
 
 	pub fn arrow(&mut self, step: Step) -> bool {
-		let Step { num, percent } = step;
-		let ok = if step.num > 0 {
-			self.current.next(num as usize, percent)
-		} else {
-			self.current.prev(num.unsigned_abs(), percent)
-		};
+		let ok = if step.positive() { self.current.next(step) } else { self.current.prev(step) };
 		if !ok {
 			return false;
 		}

--- a/core/src/manager/tab.rs
+++ b/core/src/manager/tab.rs
@@ -68,7 +68,7 @@ impl Tab {
 	}
 
 	pub fn arrow(&mut self, step: Step) -> bool {
-		let ok = if step.positive() { self.current.next(step) } else { self.current.prev(step) };
+		let ok = if step.is_positive() { self.current.next(step) } else { self.current.prev(step) };
 		if !ok {
 			return false;
 		}

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -1,0 +1,56 @@
+use std::{num::ParseIntError, str::FromStr};
+
+pub enum Step {
+	Fixed(isize),
+	Percent(i8),
+}
+
+impl Default for Step {
+	fn default() -> Self { Self::Fixed(0) }
+}
+
+impl FromStr for Step {
+	type Err = ParseIntError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(if let Some(s) = s.strip_suffix('%') {
+			Self::Percent(s.parse()?)
+		} else {
+			Self::Fixed(s.parse()?)
+		})
+	}
+}
+
+impl From<isize> for Step {
+	fn from(n: isize) -> Self { Self::Fixed(n) }
+}
+
+impl From<usize> for Step {
+	fn from(n: usize) -> Self { Self::Fixed(n as isize) }
+}
+
+impl Step {
+	#[inline]
+	fn fixed<F: FnOnce() -> usize>(self, f: F) -> isize {
+		match self {
+			Self::Fixed(n) => n,
+			Self::Percent(0) => 0,
+			Self::Percent(n) => n as isize * f() as isize / 100,
+		}
+	}
+
+	#[inline]
+	pub fn add<F: FnOnce() -> usize>(self, pos: usize, f: F) -> usize {
+		let fixed = self.fixed(f);
+		if fixed > 0 { pos + fixed as usize } else { pos.saturating_sub(fixed.unsigned_abs()) }
+	}
+
+	#[inline]
+	pub fn positive(&self) -> bool {
+		match self {
+			Self::Fixed(n) if *n > 0 => true,
+			Self::Percent(n) if *n > 0 => true,
+			_ => false,
+		}
+	}
+}

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -6,7 +6,6 @@ pub enum Step {
 }
 
 impl Default for Step {
-	#[inline]
 	fn default() -> Self { Self::Fixed(0) }
 }
 
@@ -23,12 +22,10 @@ impl FromStr for Step {
 }
 
 impl From<isize> for Step {
-	#[inline]
 	fn from(n: isize) -> Self { Self::Fixed(n) }
 }
 
 impl From<usize> for Step {
-	#[inline]
 	fn from(n: usize) -> Self { Self::Fixed(n as isize) }
 }
 

--- a/core/src/step.rs
+++ b/core/src/step.rs
@@ -6,6 +6,7 @@ pub enum Step {
 }
 
 impl Default for Step {
+	#[inline]
 	fn default() -> Self { Self::Fixed(0) }
 }
 
@@ -22,10 +23,12 @@ impl FromStr for Step {
 }
 
 impl From<isize> for Step {
+	#[inline]
 	fn from(n: isize) -> Self { Self::Fixed(n) }
 }
 
 impl From<usize> for Step {
+	#[inline]
 	fn from(n: usize) -> Self { Self::Fixed(n as isize) }
 }
 
@@ -46,11 +49,10 @@ impl Step {
 	}
 
 	#[inline]
-	pub fn positive(&self) -> bool {
-		match self {
-			Self::Fixed(n) if *n > 0 => true,
-			Self::Percent(n) if *n > 0 => true,
-			_ => false,
+	pub fn is_positive(&self) -> bool {
+		match *self {
+			Self::Fixed(n) => n > 0,
+			Self::Percent(n) => n > 0,
 		}
 	}
 }


### PR DESCRIPTION
Now users can use command like `arrow 50%`, `arrow -50%` to move cursor in the distance calculated by percentage of page rows.

In a nutshell,
* `arrow -50%` to scroll up half page.
* `arrow 50%` to scroll down half page.
* `arrow 100%` to scroll down one page.
* `arrow 100%` to scroll up one page.

Users can customize the number, but I think the above is enough. See `config/preset/keymap.toml` in this PR.