### PR TITLE
feat: new `orphan` option for opener rules, to keep the process running even when Yazi exited

### DIFF
--- a/config/src/open/opener.rs
+++ b/config/src/open/opener.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Deserializer};
 pub struct Opener {
 	pub exec:         String,
 	pub block:        bool,
+	pub orphan:       bool,
 	pub display_name: String,
 	pub spread:       bool,
 }
@@ -18,6 +19,8 @@ impl<'de> Deserialize<'de> for Opener {
 			pub exec:         String,
 			#[serde(default)]
 			pub block:        bool,
+			#[serde(default)]
+			pub orphan:       bool,
 			pub display_name: Option<String>,
 		}
 
@@ -32,6 +35,6 @@ impl<'de> Deserialize<'de> for Opener {
 			.unwrap_or_else(|| shadow.exec.split_whitespace().next().unwrap().to_string());
 
 		let spread = shadow.exec.contains("$*") || shadow.exec.contains("$@");
-		Ok(Self { exec: shadow.exec, block: shadow.block, display_name, spread })
+		Ok(Self { exec: shadow.exec, block: shadow.block, orphan: shadow.orphan, display_name, spread })
 	}
 }

--- a/core/src/external/shell.rs
+++ b/core/src/external/shell.rs
@@ -10,6 +10,13 @@ pub struct ShellOpt {
 	pub orphan: bool,
 }
 
+impl ShellOpt {
+	pub fn with_piped(mut self) -> Self {
+		self.piped = true;
+		self
+	}
+}
+
 pub fn shell(opt: ShellOpt) -> Result<Child> {
 	#[cfg(not(target_os = "windows"))]
 	{

--- a/core/src/external/shell.rs
+++ b/core/src/external/shell.rs
@@ -4,9 +4,10 @@ use anyhow::Result;
 use tokio::process::{Child, Command};
 
 pub struct ShellOpt {
-	pub cmd:   OsString,
-	pub args:  Vec<OsString>,
-	pub piped: bool,
+	pub cmd:    OsString,
+	pub args:   Vec<OsString>,
+	pub piped:  bool,
+	pub orphan: bool,
 }
 
 pub fn shell(opt: ShellOpt) -> Result<Child> {
@@ -21,7 +22,7 @@ pub fn shell(opt: ShellOpt) -> Result<Child> {
 				.stdin(if opt.piped { Stdio::piped() } else { Stdio::inherit() })
 				.stdout(if opt.piped { Stdio::piped() } else { Stdio::inherit() })
 				.stderr(if opt.piped { Stdio::piped() } else { Stdio::inherit() })
-				.kill_on_drop(true)
+				.kill_on_drop(!opt.orphan)
 				.spawn()?,
 		)
 	}

--- a/core/src/manager/manager.rs
+++ b/core/src/manager/manager.rs
@@ -259,9 +259,10 @@ impl Manager {
 			emit!(Stop(true)).await;
 
 			let mut child = external::shell(ShellOpt {
-				cmd:   (*opener.exec).into(),
-				args:  vec![tmp.to_owned().into()],
-				piped: false,
+				cmd:    (*opener.exec).into(),
+				args:   vec![tmp.to_owned().into()],
+				piped:  false,
+				orphan: false,
 			})?;
 			child.wait().await?;
 

--- a/core/src/manager/tab.rs
+++ b/core/src/manager/tab.rs
@@ -379,7 +379,7 @@ impl Tab {
 
 			emit!(Open(
 				selected,
-				Some(Opener { exec, block, display_name: Default::default(), spread: true })
+				Some(Opener { exec, block, orphan: false, display_name: Default::default(), spread: true })
 			));
 		});
 

--- a/core/src/tasks/scheduler.rs
+++ b/core/src/tasks/scheduler.rs
@@ -310,6 +310,7 @@ impl Scheduler {
 						cmd: opener.exec.into(),
 						args,
 						block: opener.block,
+						orphan: opener.orphan,
 						cancel: cancel_tx,
 					})
 					.await


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/194

Close https://github.com/sxyazi/yazi/issues/194


https://github.com/sxyazi/yazi/assets/17523360/bd18b74f-0c82-4fd2-bbe1-307d53837ee6

