### PR TITLE
bugfix: cannot cd if there is whitespace prefix in path

### DIFF
--- a/core/src/manager/tab.rs
+++ b/core/src/manager/tab.rs
@@ -146,7 +146,7 @@ impl Tab {
 				emit!(Input(InputOpt::top("Change directory:").with_value(target.to_string_lossy())));
 
 			if let Some(Ok(s)) = result.recv().await {
-				emit!(Cd(Url::from(s)));
+				emit!(Cd(Url::from(s.trim())));
 			}
 		});
 		false

--- a/shared/src/url.rs
+++ b/shared/src/url.rs
@@ -42,15 +42,15 @@ impl From<&Path> for Url {
 }
 
 impl From<String> for Url {
-	fn from(path: String) -> Self { Self::from(PathBuf::from(path)) }
+	fn from(path: String) -> Self { Self::from(PathBuf::from(path.trim())) }
 }
 
 impl From<&String> for Url {
-	fn from(path: &String) -> Self { Self::from(PathBuf::from(path)) }
+	fn from(path: &String) -> Self { Self::from(PathBuf::from(path.trim())) }
 }
 
 impl From<&str> for Url {
-	fn from(path: &str) -> Self { Self::from(PathBuf::from(path)) }
+	fn from(path: &str) -> Self { Self::from(PathBuf::from(path.trim())) }
 }
 
 impl AsRef<Url> for Url {

--- a/shared/src/url.rs
+++ b/shared/src/url.rs
@@ -42,15 +42,15 @@ impl From<&Path> for Url {
 }
 
 impl From<String> for Url {
-	fn from(path: String) -> Self { Self::from(PathBuf::from(path.trim())) }
+	fn from(path: String) -> Self { Self::from(PathBuf::from(path)) }
 }
 
 impl From<&String> for Url {
-	fn from(path: &String) -> Self { Self::from(PathBuf::from(path.trim())) }
+	fn from(path: &String) -> Self { Self::from(PathBuf::from(path)) }
 }
 
 impl From<&str> for Url {
-	fn from(path: &str) -> Self { Self::from(PathBuf::from(path.trim())) }
+	fn from(path: &str) -> Self { Self::from(PathBuf::from(path)) }
 }
 
 impl AsRef<Url> for Url {


### PR DESCRIPTION
How to reproduce:
1. `g <space>`
2. enter ` C:\<some path>` (notice the prefix whitespace)
3. cannot cd
