### PR TITLE
Add x-wine-extension-ini to text mime

### DIFF
--- a/shared/src/mime.rs
+++ b/shared/src/mime.rs
@@ -18,7 +18,7 @@ pub enum MimeKind {
 
 impl MimeKind {
 	pub fn new(s: &str) -> Self {
-		if s.starts_with("text/") || s.ends_with("/xml") || s.ends_with("/javascript") {
+		if s.starts_with("text/") || s.ends_with("/xml") || s.ends_with("/javascript") || s.ends_with("/x-wine-extension-ini") {
 			Self::Text
 		} else if s.starts_with("image/") {
 			Self::Image


### PR DESCRIPTION
Some how `file -b --mime-type app/Cargo.toml` returns `application/x-wine-extension-ini` so I cannot preview as well as open `Cargo.toml` properly