### PR TITLE
feat: cross-system opener rule support

### DIFF
--- a/app/src/executor.rs
+++ b/app/src/executor.rs
@@ -64,7 +64,7 @@ impl Executor {
 			}
 			"peek" => {
 				let step = exec.args.get(0).and_then(|s| s.parse().ok()).unwrap_or(0);
-				cx.manager.active_mut().preview_arrow(step);
+				cx.manager.active_mut().preview.arrow(step);
 				cx.manager.peek(true, cx.image_layer())
 			}
 			"leave" => cx.manager.active_mut().leave(),

--- a/config/preset/yazi.toml
+++ b/config/preset/yazi.toml
@@ -14,55 +14,52 @@ max_height = 900
 cache_dir  = ""
 
 [opener]
-folder = [
-	{ exec = 'open -R "$@"', display_name = "Reveal in Finder" },
-	{ exec = '$EDITOR "$@"' },
+edit = [
+	{ exec = '$EDITOR "$@"', block = true, for = "unix" },
+	{ exec = 'code "%*"',                  for = "windows" },
 ]
-archive = [
-	{ exec = 'unar "$1"', display_name = "Extract here" },
+open = [
+	{ exec = 'xdg-open "$@"', desc = "Open", for = "linux" },
+	{ exec = 'open "$@"',     desc = "Open", for = "macos" },
+	{ exec = '%1',            desc = "Open", for = "windows" }
 ]
-text = [
-	{ exec = '$EDITOR "$@"', block = true },
+reveal = [
+	{ exec = 'open -R "$@"',  desc = "Reveal", for = "macos" },
+	{ exec = 'explorer "%*"', desc = "Reveal", for = "windows" },
+	{ exec = '''exiftool "$1"; echo "Press enter to exit"; read''', block = true, desc = "Show EXIF", for = "unix" },
 ]
-image = [
-	{ exec = 'open "$@"', display_name = "Open" },
-	{ exec = '''exiftool "$1"; echo "Press enter to exit"; read''', block = true, display_name = "Show EXIF" },
+extract = [
+	{ exec = 'unar "$1"', desc = "Extract here", for = "unix" },
+	{ exec = 'unar "%1"', desc = "Extract here", for = "windows" },
 ]
-video = [
-	{ exec = 'mpv "$@"' },
-	{ exec = '''mediainfo "$1"; echo "Press enter to exit"; read''', block = true, display_name = "Show media info" },
-]
-audio = [
-	{ exec = 'mpv "$@"' },
-	{ exec = '''mediainfo "$1"; echo "Press enter to exit"; read''', block = true, display_name = "Show media info" },
-]
-fallback = [
-	{ exec = 'open "$@"', display_name = "Open" },
-	{ exec = 'open -R "$@"', display_name = "Reveal in Finder" },
+play = [
+	{ exec = 'mpv "$@"', orphan = true, for = "unix" },
+	{ exec = 'mpv "%1"',                for = "windows" },
+	{ exec = '''mediainfo "$1"; echo "Press enter to exit"; read''', block = true, desc = "Show media info", for = "unix" },
 ]
 
 [open]
 rules = [
-	{ name = "*/", use = "folder" },
+	{ name = "*/", use = [ "edit", "open", "reveal" ] },
 
-	{ mime = "text/*", use = "text" },
-	{ mime = "image/*", use = "image" },
-	{ mime = "video/*", use = "video" },
-	{ mime = "audio/*", use = "audio" },
-	{ mime = "inode/x-empty", use = "text" },
+	{ mime = "text/*",  use = [ "edit", "reveal" ] },
+	{ mime = "image/*", use = [ "open", "reveal" ] },
+	{ mime = "video/*", use = [ "play", "reveal" ] },
+	{ mime = "audio/*", use = [ "play", "reveal" ] },
+	{ mime = "inode/x-empty", use = [ "edit", "reveal" ] },
 
-	{ mime = "application/json", use = "text" },
-	{ mime = "*/javascript", use = "text" },
+	{ mime = "application/json", use = [ "edit", "reveal" ] },
+	{ mime = "*/javascript",     use = [ "edit", "reveal" ] },
 
-	{ mime = "application/zip", use = "archive" },
-	{ mime = "application/gzip", use = "archive" },
-	{ mime = "application/x-tar", use = "archive" },
-	{ mime = "application/x-bzip", use = "archive" },
-	{ mime = "application/x-bzip2", use = "archive" },
-	{ mime = "application/x-7z-compressed", use = "archive" },
-	{ mime = "application/x-rar", use = "archive" },
+	{ mime = "application/zip",             use = [ "extract", "reveal" ] },
+	{ mime = "application/gzip",            use = [ "extract", "reveal" ] },
+	{ mime = "application/x-tar",           use = [ "extract", "reveal" ] },
+	{ mime = "application/x-bzip",          use = [ "extract", "reveal" ] },
+	{ mime = "application/x-bzip2",         use = [ "extract", "reveal" ] },
+	{ mime = "application/x-7z-compressed", use = [ "extract", "reveal" ] },
+	{ mime = "application/x-rar",           use = [ "extract", "reveal" ] },
 
-	{ mime = "*", use = "fallback" },
+	{ mime = "*", use = [ "open", "reveal" ] },
 ]
 
 [tasks]

--- a/config/src/open/opener.rs
+++ b/config/src/open/opener.rs
@@ -2,11 +2,27 @@ use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Opener {
-	pub exec:         String,
-	pub block:        bool,
-	pub orphan:       bool,
-	pub display_name: String,
-	pub spread:       bool,
+	pub exec:   String,
+	pub block:  bool,
+	pub orphan: bool,
+	pub desc:   String,
+	pub for_:   Option<String>,
+	pub spread: bool,
+}
+
+impl Opener {
+	pub fn take(mut self) -> Option<Self> {
+		if let Some(for_) = self.for_.take() {
+			match for_.as_bytes() {
+				b"unix" if cfg!(unix) => {}
+				b"windows" if cfg!(windows) => {}
+				b"linux" if cfg!(target_os = "linux") => {}
+				b"macos" if cfg!(target_os = "macos") => {}
+				_ => return None,
+			}
+		}
+		Some(self)
+	}
 }
 
 impl<'de> Deserialize<'de> for Opener {
@@ -16,25 +32,49 @@ impl<'de> Deserialize<'de> for Opener {
 	{
 		#[derive(Deserialize)]
 		pub struct Shadow {
-			pub exec:         String,
+			exec:   String,
 			#[serde(default)]
-			pub block:        bool,
+			block:  bool,
 			#[serde(default)]
-			pub orphan:       bool,
-			pub display_name: Option<String>,
+			orphan: bool,
+			desc:   Option<String>,
+			#[serde(rename = "for")]
+			for_:   Option<String>,
+
+			// TODO: remove this when v1.0.5 is released --
+			display_name: Option<String>,
+			// TODO: -- remove this when v1.0.5 is released
 		}
 
-		let shadow = Shadow::deserialize(deserializer)?;
-
+		let mut shadow = Shadow::deserialize(deserializer)?;
 		if shadow.exec.is_empty() {
 			return Err(serde::de::Error::custom("`exec` cannot be empty"));
 		}
 
-		let display_name = shadow
-			.display_name
-			.unwrap_or_else(|| shadow.exec.split_whitespace().next().unwrap().to_string());
+		// TODO: remove this when v1.0.5 is released --
+		if shadow.display_name.is_some() {
+			println!(
+				"WARNING: `display_name` is deprecated and will be removed in Yazi v1.0.6. Use `desc` instead.\ne.g. {}\n\n",
+				r#"{ exec = 'nvim "$@"', display_name = "Edit" }  ==>  { exec = 'nvim "$@"', desc = "Edit" }"#
+			);
+		}
+		if shadow.display_name.is_some() && shadow.desc.is_none() {
+			shadow.desc = shadow.display_name.clone();
+		}
+		// TODO: -- remove this when v1.0.5 is released
 
-		let spread = shadow.exec.contains("$*") || shadow.exec.contains("$@");
-		Ok(Self { exec: shadow.exec, block: shadow.block, orphan: shadow.orphan, display_name, spread })
+		let desc =
+			shadow.desc.unwrap_or_else(|| shadow.exec.split_whitespace().next().unwrap().to_string());
+
+		let spread =
+			shadow.exec.contains("$@") || shadow.exec.contains("%*") || shadow.exec.contains("$*");
+		Ok(Self {
+			exec: shadow.exec,
+			block: shadow.block,
+			orphan: shadow.orphan,
+			desc,
+			for_: shadow.for_,
+			spread,
+		})
 	}
 }

--- a/config/src/preview/preview.rs
+++ b/config/src/preview/preview.rs
@@ -23,11 +23,11 @@ impl Default for Preview {
 		}
 		#[derive(Deserialize)]
 		struct Shadow {
-			pub tab_size:   u32,
-			pub max_width:  u32,
-			pub max_height: u32,
+			tab_size:   u32,
+			max_width:  u32,
+			max_height: u32,
 
-			pub cache_dir: Option<String>,
+			cache_dir: Option<String>,
 		}
 
 		let preview = toml::from_str::<Outer>(&MERGED_YAZI).unwrap().preview;

--- a/core/src/manager/commands/open.rs
+++ b/core/src/manager/commands/open.rs
@@ -47,7 +47,7 @@ impl Manager {
 
 			let result = emit!(Select(SelectOpt::hovered(
 				"Open with:",
-				openers.iter().map(|o| o.display_name.clone()).collect()
+				openers.iter().map(|o| o.desc.clone()).collect()
 			)));
 			if let Ok(choice) = result.await {
 				emit!(Open(files, Some(openers[choice].clone())));

--- a/core/src/tab/commands/shell.rs
+++ b/core/src/tab/commands/shell.rs
@@ -26,7 +26,14 @@ impl Tab {
 
 			emit!(Open(
 				selected,
-				Some(Opener { exec, block, orphan: false, display_name: Default::default(), spread: true })
+				Some(Opener {
+					exec,
+					block,
+					orphan: false,
+					desc: Default::default(),
+					for_: None,
+					spread: true
+				})
 			));
 		});
 

--- a/core/src/tab/tab.rs
+++ b/core/src/tab/tab.rs
@@ -108,9 +108,6 @@ impl Tab {
 	#[inline]
 	pub fn preview_reset_image(&mut self) -> bool { self.preview.reset(|l| l.is_image()) }
 
-	#[inline]
-	pub fn preview_arrow(&mut self, step: isize) -> bool { self.preview.arrow(step) }
-
 	// --- Sorter
 	pub fn set_sorter(&mut self, sorter: FilesSorter) -> bool {
 		if sorter == self.sorter {


### PR DESCRIPTION
Yazi now supports dividing opener rules by system type, this solves https://github.com/sxyazi/yazi/issues/110#issuecomment-1706538851

<img width="1057" alt="image" src="https://github.com/sxyazi/yazi/assets/17523360/f9572cf2-2a4d-413e-93fe-267e84bf8ce7">

This PR also makes `display_name` as deprecated (to be fully removed in Yazi v1.0.6), using `desc` to maintain consistency with keymap.

