### PR TITLE
Add config support for coordinate and size adjustment for ueberzugpp image preview

### DIFF
--- a/yazi-adaptor/Cargo.toml
+++ b/yazi-adaptor/Cargo.toml
@@ -21,4 +21,4 @@ ratatui     = "^0"
 tokio       = { version = "^1", features = [ "parking_lot", "io-util", "process" ] }
 
 # Logging
-tracing = {version = "^0", features = ["max_level_debug", "release_max_level_warn"]}
+tracing = { version = "^0", features = [ "max_level_debug", "release_max_level_warn" ] }

--- a/yazi-adaptor/Cargo.toml
+++ b/yazi-adaptor/Cargo.toml
@@ -21,4 +21,4 @@ ratatui     = "^0"
 tokio       = { version = "^1", features = [ "parking_lot", "io-util", "process" ] }
 
 # Logging
-tracing = "^0"
+tracing = {version = "^0", features = ["max_level_debug", "release_max_level_warn"]}

--- a/yazi-adaptor/src/ueberzug.rs
+++ b/yazi-adaptor/src/ueberzug.rs
@@ -1,14 +1,9 @@
-use std::cmp::max;
-use std::{path::PathBuf, process::Stdio};
-use tracing::debug;
+use std::{cmp::max, path::PathBuf, process::Stdio};
 
 use anyhow::Result;
 use ratatui::prelude::Rect;
-use tokio::{
-	io::AsyncWriteExt,
-	process::{Child, Command},
-	sync::mpsc::{self, UnboundedSender},
-};
+use tokio::{io::AsyncWriteExt, process::{Child, Command}, sync::mpsc::{self, UnboundedSender}};
+use tracing::debug;
 use yazi_config::PREVIEW;
 
 use crate::Adaptor;
@@ -40,10 +35,8 @@ impl Ueberzug {
 
 	fn adjust_rect(mut rect: Rect) -> Rect {
 		let cfg = &PREVIEW.ueberzug;
-		rect.x =
-			max((rect.x as f64 / cfg.scale_down_factor + cfg.x_offset) as i32, 0) as u16;
-		rect.y =
-			max((rect.y as f64 / cfg.scale_down_factor + cfg.y_offset) as i32, 0) as u16;
+		rect.x = max((rect.x as f64 / cfg.scale_down_factor + cfg.x_offset) as i32, 0) as u16;
+		rect.y = max((rect.y as f64 / cfg.scale_down_factor + cfg.y_offset) as i32, 0) as u16;
 		rect.width =
 			max((rect.width as f64 / cfg.scale_down_factor + cfg.width_offset) as i32, 0) as u16;
 		rect.height =

--- a/yazi-adaptor/src/ueberzug.rs
+++ b/yazi-adaptor/src/ueberzug.rs
@@ -60,7 +60,7 @@ impl Ueberzug {
 		if let Some((path, tmp_rect)) = cmd {
 			debug!("ueberzug rect before adjustment: {:?}", tmp_rect);
 			let rect = Self::adjust_rect(tmp_rect);
-			debug!("ueberzug rect after adjust adjustment: {:?}", rect);
+			debug!("ueberzug rect after adjustment: {:?}", rect);
 			let s = format!(
 				r#"{{"action":"add","identifier":"yazi","x":{},"y":{},"max_width":{},"max_height":{},"path":"{}"}}{}"#,
 				rect.x,

--- a/yazi-adaptor/src/ueberzug.rs
+++ b/yazi-adaptor/src/ueberzug.rs
@@ -57,9 +57,9 @@ impl Ueberzug {
 
 	async fn send_command(child: &mut Child, cmd: Option<(PathBuf, Rect)>) -> Result<()> {
 		let stdin = child.stdin.as_mut().unwrap();
-		if let Some((path, tmp_rect)) = cmd {
-			debug!("ueberzug rect before adjustment: {:?}", tmp_rect);
-			let rect = Self::adjust_rect(tmp_rect);
+		if let Some((path, rect)) = cmd {
+			debug!("ueberzug rect before adjustment: {:?}", rect);
+			let rect = Self::adjust_rect(rect);
 			debug!("ueberzug rect after adjustment: {:?}", rect);
 
 			let s = format!(

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -14,15 +14,15 @@ max_width  = 600
 max_height = 900
 cache_dir  = ""
 
-[preview.ueberzug]
-# Scale down the coordinate and size of image preview that is incorrectly scaled
-# up by ueberzugpp in Wayland (tested under Hyprland). Example usage: if your
-# monitor has a 2.0 scale factor, you should pass 2.0 here.
-scale_down_factor = 1.0
-x_offset = 0.0
-y_offset = 0.0
-width_offset = 0.0
-height_offset = 0.0
+	[preview.ueberzug]
+	# Scale down the coordinate and size of image preview that is incorrectly scaled
+	# up by ueberzugpp in Wayland (tested under Hyprland). Example usage: if your
+	# monitor has a 2.0 scale factor, you should pass 2.0 here.
+	scale_down_factor = 1.0
+	x_offset          = 0.0
+	y_offset          = 0.0
+	width_offset      = 0.0
+	height_offset     = 0.0
 
 [opener]
 edit = [

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -14,6 +14,16 @@ max_width  = 600
 max_height = 900
 cache_dir  = ""
 
+[preview.ueberzug]
+# Scale down the coordinate and size of image preview that is incorrectly scaled
+# up by ueberzugpp in Wayland (tested under Hyprland). Example usage: if your
+# monitor has a 2.0 scale factor, you should pass 2.0 here.
+scale_down_factor = 1.0
+x_offset = 0.0
+y_offset = 0.0
+width_offset = 0.0
+height_offset = 0.0
+
 [opener]
 edit = [
 	{ exec = '$EDITOR "$@"', block = true,  for = "unix" },

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -9,20 +9,12 @@ show_hidden    = false
 show_symlink   = true
 
 [preview]
-tab_size   = 2
-max_width  = 600
-max_height = 900
-cache_dir  = ""
-
-	[preview.ueberzug]
-	# Scale down the coordinate and size of image preview that is incorrectly scaled
-	# up by ueberzugpp in Wayland (tested under Hyprland). Example usage: if your
-	# monitor has a 2.0 scale factor, you should pass 2.0 here.
-	scale_down_factor = 1.0
-	x_offset          = 0.0
-	y_offset          = 0.0
-	width_offset      = 0.0
-	height_offset     = 0.0
+tab_size        = 2
+max_width       = 600
+max_height      = 900
+cache_dir       = ""
+ueberzug_scale  = 1
+ueberzug_offset = [ 0, 0, 0, 0 ]
 
 [opener]
 edit = [

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -6,15 +6,6 @@ use yazi_shared::expand_path;
 
 use crate::{xdg::Xdg, MERGED_YAZI};
 
-#[derive(Debug, Deserialize)]
-pub struct UeberzugPreview {
-	pub scale_down_factor: f64,
-	pub x_offset:          f64,
-	pub y_offset:          f64,
-	pub width_offset:      f64,
-	pub height_offset:     f64,
-}
-
 #[derive(Debug)]
 pub struct Preview {
 	pub tab_size:   u32,

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -1,4 +1,7 @@
-use std::{path::{Path, PathBuf}, time::{self, SystemTime}};
+use std::{
+	path::{Path, PathBuf},
+	time::{self, SystemTime},
+};
 
 use md5::{Digest, Md5};
 use serde::Deserialize;
@@ -6,13 +9,24 @@ use yazi_shared::expand_path;
 
 use crate::{xdg::Xdg, MERGED_YAZI};
 
+#[derive(Debug, Deserialize)]
+pub struct UeberzugPreview {
+	pub scale_down_factor: f64,
+	pub x_offset: f64,
+	pub y_offset: f64,
+	pub width_offset: f64,
+	pub height_offset: f64,
+}
+
 #[derive(Debug)]
 pub struct Preview {
-	pub tab_size:   u32,
-	pub max_width:  u32,
+	pub tab_size: u32,
+	pub max_width: u32,
 	pub max_height: u32,
 
 	pub cache_dir: PathBuf,
+
+	pub ueberzug: UeberzugPreview,
 }
 
 impl Default for Preview {
@@ -23,11 +37,13 @@ impl Default for Preview {
 		}
 		#[derive(Deserialize)]
 		struct Shadow {
-			tab_size:   u32,
-			max_width:  u32,
+			tab_size: u32,
+			max_width: u32,
 			max_height: u32,
 
 			cache_dir: Option<String>,
+
+			ueberzug: UeberzugPreview,
 		}
 
 		let preview = toml::from_str::<Outer>(&MERGED_YAZI).unwrap().preview;
@@ -41,6 +57,8 @@ impl Default for Preview {
 			max_height: preview.max_height,
 
 			cache_dir,
+
+			ueberzug: preview.ueberzug,
 		}
 	}
 }

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -23,7 +23,8 @@ pub struct Preview {
 
 	pub cache_dir: PathBuf,
 
-	pub ueberzug: UeberzugPreview,
+	pub ueberzug_scale:  f64,
+	pub ueberzug_offset: (f64, f64, f64, f64),
 }
 
 impl Default for Preview {
@@ -40,7 +41,8 @@ impl Default for Preview {
 
 			cache_dir: Option<String>,
 
-			ueberzug: UeberzugPreview,
+			ueberzug_scale:  f64,
+			ueberzug_offset: (f64, f64, f64, f64),
 		}
 
 		let preview = toml::from_str::<Outer>(&MERGED_YAZI).unwrap().preview;
@@ -55,7 +57,8 @@ impl Default for Preview {
 
 			cache_dir,
 
-			ueberzug: preview.ueberzug,
+			ueberzug_scale: preview.ueberzug_scale,
+			ueberzug_offset: preview.ueberzug_offset,
 		}
 	}
 }

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -1,7 +1,4 @@
-use std::{
-	path::{Path, PathBuf},
-	time::{self, SystemTime},
-};
+use std::{path::{Path, PathBuf}, time::{self, SystemTime}};
 
 use md5::{Digest, Md5};
 use serde::Deserialize;
@@ -12,16 +9,16 @@ use crate::{xdg::Xdg, MERGED_YAZI};
 #[derive(Debug, Deserialize)]
 pub struct UeberzugPreview {
 	pub scale_down_factor: f64,
-	pub x_offset: f64,
-	pub y_offset: f64,
-	pub width_offset: f64,
-	pub height_offset: f64,
+	pub x_offset:          f64,
+	pub y_offset:          f64,
+	pub width_offset:      f64,
+	pub height_offset:     f64,
 }
 
 #[derive(Debug)]
 pub struct Preview {
-	pub tab_size: u32,
-	pub max_width: u32,
+	pub tab_size:   u32,
+	pub max_width:  u32,
 	pub max_height: u32,
 
 	pub cache_dir: PathBuf,
@@ -37,8 +34,8 @@ impl Default for Preview {
 		}
 		#[derive(Deserialize)]
 		struct Shadow {
-			tab_size: u32,
-			max_width: u32,
+			tab_size:   u32,
+			max_width:  u32,
 			max_height: u32,
 
 			cache_dir: Option<String>,


### PR DESCRIPTION
Fix https://github.com/sxyazi/yazi/issues/302

Example usage in yazi.toml for a 2.0 scale monitor on Hyprland:
```
[preview.ueberzug]
scale_down_factor = 2.0
x_offset = 0.5
y_offset = 0.5
width_offset = -0.5
height_offset = -0.5
```