### PR TITLE
fix: clear sixel image with empty characters directly

### DIFF
--- a/yazi-adaptor/src/sixel.rs
+++ b/yazi-adaptor/src/sixel.rs
@@ -21,10 +21,11 @@ impl Sixel {
 
 	pub(super) fn image_hide(rect: Rect) -> Result<()> {
 		let stdout = BufWriter::new(stdout().lock());
+		let s = " ".repeat(rect.width as usize);
 		Term::move_lock(stdout, (0, 0), |stdout| {
 			for y in rect.top()..rect.bottom() {
 				Term::move_to(stdout, rect.x, y)?;
-				Term::kill_to_end(stdout)?;
+				stdout.write_all(s.as_bytes())?;
 			}
 			Ok(())
 		})


### PR DESCRIPTION
On BlackBox `\x2B[K` doesn't work for sixel characters. I thought this is a bug of gnome vte.