### PR TITLE
fix: use `WAYLAND_DISPLAY` and `DISPLAY` to detect Wayland/X11 when `XDG_SESSION_TYPE` is not set

### DIFF
--- a/yazi-adaptor/src/adaptor.rs
+++ b/yazi-adaptor/src/adaptor.rs
@@ -61,6 +61,11 @@ impl Adaptor {
 			"wayland" => return Self::Wayland,
 			_ => {}
 		}
+		if env::var_os("WAYLAND_DISPLAY").filter(|s| !s.is_empty()).is_some() {
+			return Self::Wayland;
+		}
+		if env::var_os("DISPLAY").filter(|s| !s.is_empty()).is_some() {
+			return Self::X11;
 		if std::fs::symlink_metadata("/proc/sys/fs/binfmt_misc/WSLInterop").is_ok() {
 			return Self::Kitty;
 		}

--- a/yazi-adaptor/src/adaptor.rs
+++ b/yazi-adaptor/src/adaptor.rs
@@ -58,6 +58,7 @@ impl Adaptor {
 			"foot-extra" => return Self::Sixel,
 			_ => warn!("[Adaptor] Unknown TERM: {term}"),
 		}
+
 		match env::var("XDG_SESSION_TYPE").unwrap_or_default().as_str() {
 			"x11" => return Self::X11,
 			"wayland" => return Self::Wayland,
@@ -68,11 +69,12 @@ impl Adaptor {
 		}
 		if env::var_os("DISPLAY").is_some_and(|s| !s.is_empty()) {
 			return Self::X11;
+		}
 		if std::fs::symlink_metadata("/proc/sys/fs/binfmt_misc/WSLInterop").is_ok() {
 			return Self::Kitty;
 		}
 
-		warn!("[Adaptor] WAYLAND_DISPLAY and DISPLAY are both empty");
+		warn!("[Adaptor] Falling back to chafa");
 		Self::Chafa
 	}
 


### PR DESCRIPTION
Fix #311 