### PR TITLE
fix: change the rust tool chain in `shell.nix` from stable to nightly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... } @ inputs:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }@inputs:
     let
       # Nixpkgs overlays
       overlays = [
@@ -22,15 +22,18 @@
           };
         })
       ];
-    in
-    flake-utils.lib.eachDefaultSystem (system:
+    in flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system overlays; };
-        versionSuffix = "pre${builtins.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}_${self.shortRev or "dirty"}";
-        version = (builtins.fromTOML (builtins.readFile ./yazi-fm/Cargo.toml)).package.version + versionSuffix;
+        versionSuffix = "pre${
+            builtins.substring 0 8
+            (self.lastModifiedDate or self.lastModified or "19700101")
+          }_${self.shortRev or "dirty"}";
+        version = (builtins.fromTOML
+          (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
+          + versionSuffix;
         yazi = pkgs.callPackage ./nix/yazi.nix { inherit version; };
-      in
-      {
+      in {
         packages.default = yazi;
         packages.yazi = yazi;
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,7 +2,6 @@
 
 pkgs.mkShell {
   packages = with pkgs; [
-    rustToolchain
     rust-analyzer
 
     nodePackages.cspell
@@ -16,13 +15,13 @@ pkgs.mkShell {
     ripgrep
     fzf
     zoxide
+
+    (rust-bin.nightly.latest.rust.override { extensions = [ "rust-src" ]; })
   ];
 
-  buildInputs = with pkgs; lib.optionals stdenv.isDarwin (
-    with darwin.apple_sdk.frameworks; [ Foundation ]
-  );
+  buildInputs = with pkgs;
+    lib.optionals stdenv.isDarwin
+    (with darwin.apple_sdk.frameworks; [ Foundation ]);
 
-  env = {
-    RUST_BACKTRACE = "1";
-  };
+  env = { RUST_BACKTRACE = "1"; };
 }


### PR DESCRIPTION
The rustfmt.toml rules are only supported by rust nightly. With the current stable rust tool chain in flake.nix, `cargo fmt` gives me warnings like
```
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `format_code_in_doc_comments = false`, unstable features are only available in n
```

The format result with those warnings is different from the current code base for almost all files. I guess the main contributors of the repo use nightly rust. If so, we should make it consistent in shell.nix to help other contributors onboard with the same env.