### PR TITLE
fix: `jq` previews empty when the user sets `tab_size=8`

### DIFF
--- a/yazi-core/src/external/jq.rs
+++ b/yazi-core/src/external/jq.rs
@@ -1,16 +1,16 @@
 use std::{path::Path, process::Stdio};
 
 use anyhow::Result;
-use tokio::{io::{AsyncBufReadExt, BufReader}, process::Command};
+use tokio::{io::{AsyncBufReadExt, AsyncReadExt, BufReader}, process::Command, select};
 use yazi_config::PREVIEW;
 use yazi_shared::PeekError;
 
 pub async fn jq(path: &Path, skip: usize, limit: usize) -> Result<String, PeekError> {
 	let mut child = Command::new("jq")
-		.args(["-C", "--indent", &PREVIEW.tab_size.to_string(), "."])
+		.args(["-C", "--indent", "-1", "."])
 		.arg(path)
 		.stdout(Stdio::piped())
-		.stderr(Stdio::null())
+		.stderr(Stdio::piped())
 		.kill_on_drop(true)
 		.spawn()?;
 
@@ -21,18 +21,26 @@ pub async fn jq(path: &Path, skip: usize, limit: usize) -> Result<String, PeekEr
 		i += 1;
 		if i > skip + limit {
 			break;
-		} else if i <= skip {
-			continue;
 		}
-
-		lines.push_str(&line);
-		lines.push('\n');
+		if i > skip {
+			lines.push_str(&line);
+			lines.push('\n');
+		}
 	}
 
 	child.start_kill().ok();
+	if lines.is_empty() {
+		let mut stderr = child.stderr.take().unwrap();
+		select! {
+			Ok(_) = stderr.read_u8() => {
+				return Err("parse error".into());
+			}
+		}
+	}
+
 	if skip > 0 && i < skip + limit {
 		Err(PeekError::Exceed(i.saturating_sub(limit)))
 	} else {
-		Ok(lines)
+		Ok(lines.replace('\t', &" ".repeat(PREVIEW.tab_size as usize)))
 	}
 }

--- a/yazi-core/src/external/jq.rs
+++ b/yazi-core/src/external/jq.rs
@@ -7,7 +7,7 @@ use yazi_shared::PeekError;
 
 pub async fn jq(path: &Path, skip: usize, limit: usize) -> Result<String, PeekError> {
 	let mut child = Command::new("jq")
-		.args(["-C", "--indent", "-1", "."])
+		.args(["-C", "--tab", "."])
 		.arg(path)
 		.stdout(Stdio::piped())
 		.stderr(Stdio::piped())
@@ -32,9 +32,8 @@ pub async fn jq(path: &Path, skip: usize, limit: usize) -> Result<String, PeekEr
 	if lines.is_empty() {
 		let mut stderr = child.stderr.take().unwrap();
 		select! {
-			Ok(_) = stderr.read_u8() => {
-				return Err("parse error".into());
-			}
+			Ok(_) = stderr.read_u8() => return Err("parse error".into()),
+			else => {}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/318

This PR also adds the functionality of fallbacking to the built-in highlighter when the user provides an invalid JSON file to `jq`.