### PR TITLE
chore: add `.vscode` and `.idea` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ yazi-config/completions
 result
 result-*
 .direnv
+
+.idea/
+.vscode/


### PR DESCRIPTION
Ignore `.vscode` and `.idea` to prevent contributor's personal configuration from polluting the project.