### PR TITLE
feat(yazi-plugin): retrieve HOME also on windows

### DIFF
--- a/yazi-plugin/preset/utils.lua
+++ b/yazi-plugin/preset/utils.lua
@@ -30,6 +30,7 @@ end
 
 function utils.readable_path(path)
 	local home = os.getenv("HOME")
+  home = home and home or os.getenv("USERPROFILE")
 	if home == nil then
 		return path
 	elseif string.sub(path, 1, #home) == home then

--- a/yazi-plugin/preset/utils.lua
+++ b/yazi-plugin/preset/utils.lua
@@ -29,8 +29,7 @@ function utils.readable_size(size)
 end
 
 function utils.readable_path(path)
-	local home = os.getenv("HOME")
-  home = home and home or os.getenv("USERPROFILE")
+	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
 	if home == nil then
 		return path
 	elseif string.sub(path, 1, #home) == home then


### PR DESCRIPTION
Right now Yazi only searches for the `$HOME` variable that is not present on windows. Either the user has to set `$env:HOME = "$env:USERPROFILE"` in his profile file or Yazi could also check for the `$USERPROFILE` variable.

My implementation of this functionality is pretty basic