### PR TITLE
perf: reduce peak memory footprint during decoding large images

### DIFF
--- a/yazi-core/src/external/pdftoppm.rs
+++ b/yazi-core/src/external/pdftoppm.rs
@@ -1,11 +1,11 @@
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use regex::Regex;
 use tokio::process::Command;
 use yazi_adaptor::Image;
 use yazi_shared::PeekError;
 
-pub async fn pdftoppm(src: &Path, dest: impl AsRef<Path>, skip: usize) -> Result<(), PeekError> {
+pub async fn pdftoppm(src: &Path, dest: &Path, skip: usize) -> Result<(), PeekError> {
 	let output = Command::new("pdftoppm")
 		.args(["-singlefile", "-jpeg", "-jpegopt", "quality=75", "-f"])
 		.arg((skip + 1).to_string())
@@ -25,5 +25,5 @@ pub async fn pdftoppm(src: &Path, dest: impl AsRef<Path>, skip: usize) -> Result
 		return if pages > 0 { Err(PeekError::Exceed(pages - 1)) } else { Err(s.to_string().into()) };
 	}
 
-	Ok(Image::precache(Arc::new(output.stdout), dest).await?)
+	Ok(Image::precache_bin(output.stdout, dest.to_owned()).await?)
 }

--- a/yazi-core/src/tasks/workers/precache.rs
+++ b/yazi-core/src/tasks/workers/precache.rs
@@ -78,9 +78,7 @@ impl Precache {
 				if fs::symlink_metadata(&cache).await.is_ok() {
 					return Ok(self.sch.send(TaskOp::Adv(task.id, 1, 0))?);
 				}
-				if let Ok(img) = fs::read(&task.target).await {
-					Image::precache(Arc::new(img), cache).await.ok();
-				}
+				Image::precache(&task.target, cache).await.ok();
 				self.sch.send(TaskOp::Adv(task.id, 1, 0))?;
 			}
 			PrecacheOp::Video(task) => {


### PR DESCRIPTION
Before this patch:

```bash
❯ yazi --clear-cache

❯ /usr/bin/time -l ./old
       22.66 real        88.54 user         8.89 sys
          2953068544  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              729991  page reclaims
                 544  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                  27  messages sent
                  26  messages received
                  27  signals received
               45566  voluntary context switches
              355342  involuntary context switches
        859110694754  instructions retired
        249027752894  cycles elapsed
          2104009664  peak memory footprint
```

After this patch:

```bash
❯ yazi --clear-cache

❯ /usr/bin/time -l ./new
       20.98 real        89.38 user         8.32 sys
          2618294272  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              687985  page reclaims
                 578  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                  27  messages sent
                  27  messages received
                  27  signals received
               39077  voluntary context switches
              330604  involuntary context switches
        844330267015  instructions retired
        249565769264  cycles elapsed
          1593614592  peak memory footprint
```

A part of https://github.com/sxyazi/yazi/issues/373