### PR TITLE
feat: expose image max alloc and bound to allow for more control

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -69,6 +69,8 @@ rules = [
 micro_workers = 5
 macro_workers = 10
 bizarre_retry = 5
+image_alloc   = 536870912  # 512MB
+image_bound   = [ 0, 0 ]
 
 [plugins]
 preload = []

--- a/yazi-config/src/tasks/tasks.rs
+++ b/yazi-config/src/tasks/tasks.rs
@@ -11,6 +11,9 @@ pub struct Tasks {
 	pub macro_workers: u8,
 	#[validate(range(min = 1, message = "Cannot be less than 1"))]
 	pub bizarre_retry: u8,
+
+	pub image_alloc: u32,
+	pub image_bound: [u16; 2],
 }
 
 impl Default for Tasks {

--- a/yazi-core/src/external/pdftoppm.rs
+++ b/yazi-core/src/external/pdftoppm.rs
@@ -25,5 +25,5 @@ pub async fn pdftoppm(src: &Path, dest: &Path, skip: usize) -> Result<(), PeekEr
 		return if pages > 0 { Err(PeekError::Exceed(pages - 1)) } else { Err(s.to_string().into()) };
 	}
 
-	Ok(Image::precache_bin(output.stdout, dest.to_owned()).await?)
+	Ok(Image::precache_vec(output.stdout, dest.to_owned()).await?)
 }


### PR DESCRIPTION
Image decoding:

- image_alloc: Maximum memory allocation limit (in bytes) for decoding a single image, `0` for unlimited.
- image_bound(`[width, height]`): Maximum image size (in pixels) for decoding a single image, `0` for unlimited.


Close https://github.com/sxyazi/yazi/issues/373