### PR TITLE
feat: support sorting by file extension

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -106,6 +106,8 @@ keymap = [
 	{ on = [ ",", "N" ], exec = "sort natural --reverse --dir_first",      desc = "Sort naturally (reverse)" },
 	{ on = [ ",", "s" ], exec = "sort size --dir_first",                   desc = "Sort by size" },
 	{ on = [ ",", "S" ], exec = "sort size --reverse --dir_first",         desc = "Sort by size (reverse)" },
+	{ on = [ ",", "e" ], exec = "sort extension --dir_first",         	   desc = "Sort by extension" },
+	{ on = [ ",", "E" ], exec = "sort extension --reverse --dir_first",    desc = "Sort by extension (reverse)" },
 
 	# Tabs
 	{ on = [ "t" ], exec = "tab_create --current", desc = "Create a new tab using the current path" },

--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -96,18 +96,18 @@ keymap = [
 	{ on = [ "N" ], exec = "find_arrow --previous" },
 
 	# Sorting
-	{ on = [ ",", "a" ], exec = "sort alphabetical --dir_first",           desc = "Sort alphabetically" },
-	{ on = [ ",", "A" ], exec = "sort alphabetical --reverse --dir_first", desc = "Sort alphabetically (reverse)" },
-	{ on = [ ",", "c" ], exec = "sort created --dir_first",                desc = "Sort by creation time" },
-	{ on = [ ",", "C" ], exec = "sort created --reverse --dir_first",      desc = "Sort by creation time (reverse)" },
 	{ on = [ ",", "m" ], exec = "sort modified --dir_first",               desc = "Sort by modified time" },
 	{ on = [ ",", "M" ], exec = "sort modified --reverse --dir_first",     desc = "Sort by modified time (reverse)" },
+	{ on = [ ",", "c" ], exec = "sort created --dir_first",                desc = "Sort by created time" },
+	{ on = [ ",", "C" ], exec = "sort created --reverse --dir_first",      desc = "Sort by created time (reverse)" },
+	{ on = [ ",", "e" ], exec = "sort extension --dir_first",         	   desc = "Sort by extension" },
+	{ on = [ ",", "E" ], exec = "sort extension --reverse --dir_first",    desc = "Sort by extension (reverse)" },
+	{ on = [ ",", "a" ], exec = "sort alphabetical --dir_first",           desc = "Sort alphabetically" },
+	{ on = [ ",", "A" ], exec = "sort alphabetical --reverse --dir_first", desc = "Sort alphabetically (reverse)" },
 	{ on = [ ",", "n" ], exec = "sort natural --dir_first",                desc = "Sort naturally" },
 	{ on = [ ",", "N" ], exec = "sort natural --reverse --dir_first",      desc = "Sort naturally (reverse)" },
 	{ on = [ ",", "s" ], exec = "sort size --dir_first",                   desc = "Sort by size" },
 	{ on = [ ",", "S" ], exec = "sort size --reverse --dir_first",         desc = "Sort by size (reverse)" },
-	{ on = [ ",", "e" ], exec = "sort extension --dir_first",         	   desc = "Sort by extension" },
-	{ on = [ ",", "E" ], exec = "sort extension --reverse --dir_first",    desc = "Sort by extension (reverse)" },
 
 	# Tabs
 	{ on = [ "t" ], exec = "tab_create --current", desc = "Create a new tab using the current path" },

--- a/yazi-config/src/manager/sorting.rs
+++ b/yazi-config/src/manager/sorting.rs
@@ -8,12 +8,12 @@ use serde::{Deserialize, Serialize};
 pub enum SortBy {
 	#[default]
 	None,
-	Alphabetical,
-	Created,
 	Modified,
+	Created,
+	Extension,
+	Alphabetical,
 	Natural,
 	Size,
-	Extension,
 }
 
 impl FromStr for SortBy {
@@ -22,12 +22,12 @@ impl FromStr for SortBy {
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		Ok(match s {
 			"none" => Self::None,
-			"alphabetical" => Self::Alphabetical,
-			"created" => Self::Created,
 			"modified" => Self::Modified,
+			"created" => Self::Created,
+			"extension" => Self::Extension,
+			"alphabetical" => Self::Alphabetical,
 			"natural" => Self::Natural,
 			"size" => Self::Size,
-			"extension" => Self::Extension,
 			_ => bail!("invalid sort_by value: {s}"),
 		})
 	}
@@ -43,12 +43,12 @@ impl ToString for SortBy {
 	fn to_string(&self) -> String {
 		match self {
 			Self::None => "none",
-			Self::Alphabetical => "alphabetical",
-			Self::Created => "created",
 			Self::Modified => "modified",
+			Self::Created => "created",
+			Self::Extension => "extension",
+			Self::Alphabetical => "alphabetical",
 			Self::Natural => "natural",
 			Self::Size => "size",
-			Self::Extension => "extension",
 		}
 		.to_string()
 	}

--- a/yazi-config/src/manager/sorting.rs
+++ b/yazi-config/src/manager/sorting.rs
@@ -13,6 +13,7 @@ pub enum SortBy {
 	Modified,
 	Natural,
 	Size,
+	Extension,
 }
 
 impl FromStr for SortBy {
@@ -26,6 +27,7 @@ impl FromStr for SortBy {
 			"modified" => Self::Modified,
 			"natural" => Self::Natural,
 			"size" => Self::Size,
+			"extension" => Self::Extension,
 			_ => bail!("invalid sort_by value: {s}"),
 		})
 	}
@@ -46,6 +48,7 @@ impl ToString for SortBy {
 			Self::Modified => "modified",
 			Self::Natural => "natural",
 			Self::Size => "size",
+			Self::Extension => "extension",
 		}
 		.to_string()
 	}

--- a/yazi-core/src/files/sorter.rs
+++ b/yazi-core/src/files/sorter.rs
@@ -31,26 +31,32 @@ impl FilesSorter {
 
 		match self.by {
 			SortBy::None => return false,
-			SortBy::Alphabetical => items.sort_unstable_by(by_alphabetical),
-			SortBy::Created => items.sort_unstable_by(|a, b| {
-				let ord = self.cmp(a.created, b.created, self.promote(a, b));
-				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
-			}),
 			SortBy::Modified => items.sort_unstable_by(|a, b| {
 				let ord = self.cmp(a.modified, b.modified, self.promote(a, b));
 				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
 			}),
+			SortBy::Created => items.sort_unstable_by(|a, b| {
+				let ord = self.cmp(a.created, b.created, self.promote(a, b));
+				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
+			}),
+			SortBy::Extension => items.sort_unstable_by(|a, b| {
+				let ord = if self.sensitive {
+					self.cmp(a.url.extension(), b.url.extension(), self.promote(a, b))
+				} else {
+					self.cmp(
+						a.url.extension().map(|s| s.to_ascii_lowercase()),
+						b.url.extension().map(|s| s.to_ascii_lowercase()),
+						self.promote(a, b),
+					)
+				};
+				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
+			}),
+			SortBy::Alphabetical => items.sort_unstable_by(by_alphabetical),
 			SortBy::Natural => self.sort_naturally(items),
 			SortBy::Size => items.sort_unstable_by(|a, b| {
 				let aa = if a.is_dir() { sizes.get(&a.url).copied() } else { None };
 				let bb = if b.is_dir() { sizes.get(&b.url).copied() } else { None };
 				let ord = self.cmp(aa.unwrap_or(a.len), bb.unwrap_or(b.len), self.promote(a, b));
-				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
-			}),
-			SortBy::Extension => items.sort_unstable_by(|a,b| {
-				let a_ext = a.url.extension().unwrap_or_default().to_ascii_lowercase();
-				let b_ext = b.url.extension().unwrap_or_default().to_ascii_lowercase();
-				let ord = self.cmp(a_ext, b_ext, self.promote(a, b));
 				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
 			}),
 		}

--- a/yazi-core/src/files/sorter.rs
+++ b/yazi-core/src/files/sorter.rs
@@ -47,6 +47,12 @@ impl FilesSorter {
 				let ord = self.cmp(aa.unwrap_or(a.len), bb.unwrap_or(b.len), self.promote(a, b));
 				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
 			}),
+			SortBy::Extension => items.sort_unstable_by(|a,b| {
+				let a_ext = a.url.extension().unwrap_or_default().to_ascii_lowercase();
+				let b_ext = b.url.extension().unwrap_or_default().to_ascii_lowercase();
+				let ord = self.cmp(a_ext, b_ext, self.promote(a, b));
+				if ord == Ordering::Equal { by_alphabetical(a, b) } else { ord }
+			}),
 		}
 		true
 	}


### PR DESCRIPTION
Now yazi can sort by file extension.

Keymap: ,+e and ,+E

<img width="1148" alt="image" src="https://github.com/sxyazi/yazi/assets/64495949/54154871-5466-4127-b87d-7143b68b5e92">

<img width="1144" alt="image" src="https://github.com/sxyazi/yazi/assets/64495949/f54167a0-021a-4cc6-93ea-e411173f2092">
