### PR TITLE
fix: add `--follow` option to `paste` command

### DIFF
--- a/yazi-core/src/manager/commands/paste.rs
+++ b/yazi-core/src/manager/commands/paste.rs
@@ -3,11 +3,14 @@ use yazi_shared::event::Exec;
 use crate::{manager::Manager, tasks::Tasks};
 
 pub struct Opt {
-	force: bool,
+	force:  bool,
+	follow: bool,
 }
 
 impl From<&Exec> for Opt {
-	fn from(e: &Exec) -> Self { Self { force: e.named.contains_key("force") } }
+	fn from(e: &Exec) -> Self {
+		Self { force: e.named.contains_key("force"), follow: e.named.contains_key("follow") }
+	}
 }
 
 impl Manager {
@@ -16,6 +19,10 @@ impl Manager {
 		let (cut, ref src) = self.yanked;
 
 		let opt = opt.into() as Opt;
-		if cut { tasks.file_cut(src, dest, opt.force) } else { tasks.file_copy(src, dest, opt.force) }
+		if cut {
+			tasks.file_cut(src, dest, opt.force)
+		} else {
+			tasks.file_copy(src, dest, opt.force, opt.follow)
+		}
 	}
 }

--- a/yazi-core/src/tasks/tasks.rs
+++ b/yazi-core/src/tasks/tasks.rs
@@ -89,13 +89,13 @@ impl Tasks {
 		false
 	}
 
-	pub fn file_copy(&self, src: &HashSet<Url>, dest: &Url, force: bool) -> bool {
+	pub fn file_copy(&self, src: &HashSet<Url>, dest: &Url, force: bool, follow: bool) -> bool {
 		for u in src {
 			let to = dest.join(u.file_name().unwrap());
 			if force && u == &to {
 				debug!("file_copy: same file, skipping {:?}", to);
 			} else {
-				self.scheduler.file_copy(u.clone(), to, force);
+				self.scheduler.file_copy(u.clone(), to, force, follow);
 			}
 		}
 		false

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -207,7 +207,7 @@ impl Scheduler {
 		);
 	}
 
-	pub fn file_copy(&self, from: Url, mut to: Url, force: bool) {
+	pub fn file_copy(&self, from: Url, mut to: Url, force: bool, follow: bool) {
 		let name = format!("Copy {:?} to {:?}", from, to);
 		let id = self.running.write().add(TaskKind::User, name);
 
@@ -217,7 +217,7 @@ impl Scheduler {
 				if !force {
 					to = unique_path(to).await;
 				}
-				file.paste(FileOpPaste { id, from, to, cut: false, follow: true, retry: 0 }).await.ok();
+				file.paste(FileOpPaste { id, from, to, cut: false, follow, retry: 0 }).await.ok();
 			}
 			.boxed(),
 			LOW,

--- a/yazi-shared/src/fs/fns.rs
+++ b/yazi-shared/src/fs/fns.rs
@@ -1,14 +1,7 @@
-use std::{
-	collections::VecDeque,
-	path::{Path, PathBuf},
-};
+use std::{collections::VecDeque, path::{Path, PathBuf}};
 
 use anyhow::Result;
-use tokio::{
-	fs, io, select,
-	sync::{mpsc, oneshot},
-	time,
-};
+use tokio::{fs, io, select, sync::{mpsc, oneshot}, time};
 
 pub async fn calculate_size(path: &Path) -> u64 {
 	let mut total = 0;
@@ -132,10 +125,7 @@ pub fn copy_with_progress(from: &Path, to: &Path) -> mpsc::Receiver<Result<u64, 
 #[cfg(unix)]
 #[allow(clippy::collapsible_else_if)]
 pub fn permissions(mode: u32) -> String {
-	use libc::{
-		mode_t, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFSOCK, S_IRGRP, S_IROTH,
-		S_IRUSR, S_ISGID, S_ISUID, S_ISVTX, S_IWGRP, S_IWOTH, S_IWUSR, S_IXGRP, S_IXOTH, S_IXUSR,
-	};
+	use libc::{mode_t, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFSOCK, S_IRGRP, S_IROTH, S_IRUSR, S_ISGID, S_ISUID, S_ISVTX, S_IWGRP, S_IWOTH, S_IWUSR, S_IXGRP, S_IXOTH, S_IXUSR};
 
 	let mut s = String::with_capacity(10);
 	let m = mode as mode_t;
@@ -155,51 +145,27 @@ pub fn permissions(mode: u32) -> String {
 	s.push(if m & S_IRUSR != 0 { 'r' } else { '-' });
 	s.push(if m & S_IWUSR != 0 { 'w' } else { '-' });
 	s.push(if m & S_IXUSR != 0 {
-		if m & S_ISUID != 0 {
-			's'
-		} else {
-			'x'
-		}
+		if m & S_ISUID != 0 { 's' } else { 'x' }
 	} else {
-		if m & S_ISUID != 0 {
-			'S'
-		} else {
-			'-'
-		}
+		if m & S_ISUID != 0 { 'S' } else { '-' }
 	});
 
 	// Group
 	s.push(if m & S_IRGRP != 0 { 'r' } else { '-' });
 	s.push(if m & S_IWGRP != 0 { 'w' } else { '-' });
 	s.push(if m & S_IXGRP != 0 {
-		if m & S_ISGID != 0 {
-			's'
-		} else {
-			'x'
-		}
+		if m & S_ISGID != 0 { 's' } else { 'x' }
 	} else {
-		if m & S_ISGID != 0 {
-			'S'
-		} else {
-			'-'
-		}
+		if m & S_ISGID != 0 { 'S' } else { '-' }
 	});
 
 	// Other
 	s.push(if m & S_IROTH != 0 { 'r' } else { '-' });
 	s.push(if m & S_IWOTH != 0 { 'w' } else { '-' });
 	s.push(if m & S_IXOTH != 0 {
-		if m & S_ISVTX != 0 {
-			't'
-		} else {
-			'x'
-		}
+		if m & S_ISVTX != 0 { 't' } else { 'x' }
 	} else {
-		if m & S_ISVTX != 0 {
-			'T'
-		} else {
-			'-'
-		}
+		if m & S_ISVTX != 0 { 'T' } else { '-' }
 	});
 
 	s


### PR DESCRIPTION
 Instead of copying the file pointed to by the symlink , create a soft link to the original path under the pasted path

See #433