### PR TITLE
chore: make `yazi-plugins` as default feature

### DIFF
--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -12,7 +12,7 @@ repository  = "https://github.com/sxyazi/yazi"
 yazi-adaptor = { path = "../yazi-adaptor", version = "0.1.5" }
 yazi-config  = { path = "../yazi-config", version = "0.1.5" }
 yazi-core    = { path = "../yazi-core", version = "0.1.5" }
-yazi-plugin  = { path = "../yazi-plugin", version = "0.1.5" }
+yazi-plugin  = { path = "../yazi-plugin", version = "0.1.5", optional = true }
 yazi-shared  = { path = "../yazi-shared", version = "0.1.5" }
 
 # External dependencies
@@ -38,3 +38,7 @@ signal-hook-tokio = { version = "^0", features = [ "futures-v0_3" ] }
 [[bin]]
 name = "yazi"
 path = "src/main.rs"
+
+[features]
+plugin  = ["dep:yazi-plugin"]
+default = ["plugin"]

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -7,7 +7,7 @@ use yazi_config::{keymap::Key, BOOT};
 use yazi_core::{input::InputMode, preview::COLLISION, Ctx};
 use yazi_shared::{emit, event::{Event, Exec}, fs::FilesOp, term::Term, Layer};
 
-use crate::{Executor, Logs, Panic, Root, Signals};
+use crate::{Executor, Logs, Panic, Signals};
 
 pub(crate) struct App {
 	pub(crate) cx:      Ctx,
@@ -72,9 +72,13 @@ impl App {
 
 		let collision = COLLISION.swap(false, Ordering::Relaxed);
 		let frame = term.draw(|f| {
-			yazi_plugin::scope(&self.cx, |_| {
-				f.render_widget(Root::new(&self.cx), f.size());
-			});
+			#[cfg(feature = "plugin")]
+			{
+				use crate::Root;
+				yazi_plugin::scope(&self.cx, |_| {
+					f.render_widget(Root::new(&self.cx), f.size());
+				});
+			}
 
 			if let Some((x, y)) = self.cx.cursor() {
 				f.set_cursor(x, y);

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -17,6 +17,7 @@ mod widgets;
 use executor::*;
 use logs::*;
 use panic::*;
+#[cfg(feature = "plugin")]
 use root::*;
 use signals::*;
 
@@ -29,6 +30,7 @@ async fn main() -> anyhow::Result<()> {
 
 	yazi_core::init();
 
+	#[cfg(feature = "plugin")]
 	yazi_plugin::init();
 
 	yazi_adaptor::init();

--- a/yazi-fm/src/root.rs
+++ b/yazi-fm/src/root.rs
@@ -1,5 +1,6 @@
-use ratatui::{buffer::Buffer, layout::{Constraint, Direction, Layout, Rect}, widgets::Widget};
+use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
 use yazi_core::Ctx;
+#[cfg(feature = "plugin")]
 use yazi_plugin::components;
 
 use super::{completion, input, select, tasks, which};
@@ -9,20 +10,25 @@ pub(super) struct Root<'a> {
 	cx: &'a Ctx,
 }
 
+#[cfg(feature = "plugin")]
 impl<'a> Root<'a> {
 	pub(super) fn new(cx: &'a Ctx) -> Self { Self { cx } }
 }
 
 impl<'a> Widget for Root<'a> {
 	fn render(self, area: Rect, buf: &mut Buffer) {
-		let chunks = Layout::new()
-			.direction(Direction::Vertical)
-			.constraints([Constraint::Length(1), Constraint::Min(0), Constraint::Length(1)])
-			.split(area);
+		#[cfg(feature = "plugin")]
+		{
+			use ratatui::layout::{Constraint, Direction, Layout};
+			let chunks = Layout::new()
+				.direction(Direction::Vertical)
+				.constraints([Constraint::Length(1), Constraint::Min(0), Constraint::Length(1)])
+				.split(area);
 
-		components::Header::new(self.cx).render(chunks[0], buf);
-		components::Manager::new(self.cx).render(chunks[1], buf);
-		components::Status::new(self.cx).render(chunks[2], buf);
+			components::Header::new(self.cx).render(chunks[0], buf);
+			components::Manager::new(self.cx).render(chunks[1], buf);
+			components::Status::new(self.cx).render(chunks[2], buf);
+		}
 
 		if self.cx.tasks.visible {
 			tasks::Layout::new(self.cx).render(area, buf);


### PR DESCRIPTION
 `LuaJIT` does not support `riscv64`, this commit to allow riscv64 compile without `plugin` feature