### PR TITLE
feat: add `--empty` and `--cursor` options to the `rename` command

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -71,7 +71,7 @@ keymap = [
 	{ on = [ "d" ],         exec = [ "remove", "escape --visual --select" ],               desc = "Move the files to the trash" },
 	{ on = [ "D" ],         exec = [ "remove --permanently", "escape --visual --select" ], desc = "Permanently delete the files" },
 	{ on = [ "a" ],         exec = "create",                                               desc = "Create a file or directory (ends with / for directories)" },
-	{ on = [ "r" ],         exec = "rename",                                               desc = "Rename a file or directory" },
+	{ on = [ "r" ],         exec = "rename --cursor=before_ext",                           desc = "Rename a file or directory" },
 	{ on = [ ";" ],         exec = "shell",                                                desc = "Run a shell command" },
 	{ on = [ ":" ],         exec = "shell --block",                                        desc = "Run a shell command (block the UI until the command finishes)" },
 	{ on = [ "." ],         exec = "hidden toggle",                                        desc = "Toggle the visibility of hidden files" },

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -133,8 +133,8 @@ impl InputCfg {
 	}
 
 	#[inline]
-	pub fn with_cursor(mut self, cursor: usize) -> Self {
-		self.cursor = Some(cursor);
+	pub fn with_cursor(mut self, cursor: Option<usize>) -> Self {
+		self.cursor = cursor;
 		self
 	}
 }

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -9,6 +9,7 @@ pub struct InputCfg {
 	pub realtime:   bool,
 	pub completion: bool,
 	pub highlight:  bool,
+	pub cursor_at:  Option<usize>,
 }
 
 #[derive(Default)]
@@ -128,6 +129,12 @@ impl InputCfg {
 	#[inline]
 	pub fn with_value(mut self, value: impl Into<String>) -> Self {
 		self.value = value.into();
+		self
+	}
+
+	#[inline]
+	pub fn with_cursor_at(mut self, cursor_at: Option<usize>) -> Self {
+		self.cursor_at = cursor_at;
 		self
 	}
 }

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -5,11 +5,11 @@ use crate::{INPUT, SELECT};
 pub struct InputCfg {
 	pub title:      String,
 	pub value:      String,
+	pub cursor:     Option<usize>,
 	pub position:   Position,
 	pub realtime:   bool,
 	pub completion: bool,
 	pub highlight:  bool,
-	pub cursor_at:  Option<usize>,
 }
 
 #[derive(Default)]
@@ -133,8 +133,8 @@ impl InputCfg {
 	}
 
 	#[inline]
-	pub fn with_cursor_at(mut self, cursor_at: Option<usize>) -> Self {
-		self.cursor_at = cursor_at;
+	pub fn with_cursor(mut self, cursor: usize) -> Self {
+		self.cursor = Some(cursor);
 		self
 	}
 }

--- a/yazi-core/src/input/commands/show.rs
+++ b/yazi-core/src/input/commands/show.rs
@@ -41,7 +41,13 @@ impl Input {
 		self.highlight = opt.cfg.highlight;
 
 		// Reset snaps
-		self.snaps.reset(opt.cfg.value, self.limit(), opt.cfg.cursor_at);
+		self.snaps.reset(opt.cfg.value, self.limit());
+
+		// Set cursor after reset
+		if let Some(cursor) = opt.cfg.cursor {
+			self.snaps.current_mut().cursor = cursor;
+		}
+
 		render!();
 	}
 }

--- a/yazi-core/src/input/commands/show.rs
+++ b/yazi-core/src/input/commands/show.rs
@@ -41,7 +41,7 @@ impl Input {
 		self.highlight = opt.cfg.highlight;
 
 		// Reset snaps
-		self.snaps.reset(opt.cfg.value, self.limit());
+		self.snaps.reset(opt.cfg.value, self.limit(), opt.cfg.cursor_at);
 		render!();
 	}
 }

--- a/yazi-core/src/input/snaps.rs
+++ b/yazi-core/src/input/snaps.rs
@@ -11,15 +11,11 @@ pub(super) struct InputSnaps {
 
 impl InputSnaps {
 	#[inline]
-	pub(super) fn reset(&mut self, value: String, limit: usize, cursor_at: Option<usize>) {
+	pub(super) fn reset(&mut self, value: String, limit: usize) {
 		self.idx = 0;
 		self.versions.clear();
 		self.versions.push(InputSnap::new(value, limit));
 		self.current = self.versions[0].clone();
-
-		if let Some(cursor) = cursor_at {
-			self.current.cursor = cursor;
-		}
 	}
 
 	pub(super) fn tag(&mut self, limit: usize) -> bool {

--- a/yazi-core/src/input/snaps.rs
+++ b/yazi-core/src/input/snaps.rs
@@ -11,11 +11,15 @@ pub(super) struct InputSnaps {
 
 impl InputSnaps {
 	#[inline]
-	pub(super) fn reset(&mut self, value: String, limit: usize) {
+	pub(super) fn reset(&mut self, value: String, limit: usize, cursor_at: Option<usize>) {
 		self.idx = 0;
 		self.versions.clear();
 		self.versions.push(InputSnap::new(value, limit));
 		self.current = self.versions[0].clone();
+
+		if let Some(cursor) = cursor_at {
+			self.current.cursor = cursor;
+		}
 	}
 
 	pub(super) fn tag(&mut self, limit: usize) -> bool {

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -33,18 +33,11 @@ impl Manager {
 
 		let ext = url.extension();
 		match by {
-			"name" => {
-				return ext.map_or_else(String::new, |s| s.to_string_lossy().to_string());
-			}
-			"ext" if ext.is_some() => {
-				return format!("{}.", url.file_stem().unwrap().to_string_lossy());
-			}
-			"dot_ext" if ext.is_some() => {
-				return url.file_stem().unwrap().to_string_lossy().to_string();
-			}
-			_ => {}
+			"name" => ext.map_or_else(String::new, |s| s.to_string_lossy().to_string()),
+			"ext" if ext.is_some() => format!("{}.", url.file_stem().unwrap().to_string_lossy()),
+			"dot_ext" if ext.is_some() => url.file_stem().unwrap().to_string_lossy().to_string(),
+			_ => url.file_name().map_or_else(String::new, |s| s.to_string_lossy().to_string()),
 		}
-		url.file_name().map_or_else(String::new, |s| s.to_string_lossy().to_string())
 	}
 
 	async fn rename_and_hover(old: Url, new: Url) -> Result<()> {

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -33,7 +33,7 @@ impl Manager {
 
 		let ext = url.extension();
 		match by {
-			"name" => ext.map_or_else(String::new, |s| s.to_string_lossy().to_string()),
+			"name" => ext.map_or_else(String::new, |s| format!(".{}", s.to_string_lossy().to_string())),
 			"ext" if ext.is_some() => format!("{}.", url.file_stem().unwrap().to_string_lossy()),
 			"dot_ext" if ext.is_some() => url.file_stem().unwrap().to_string_lossy().to_string(),
 			_ => url.file_name().map_or_else(String::new, |s| s.to_string_lossy().to_string()),

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -10,16 +10,16 @@ use yazi_shared::{event::Exec, fs::{max_common_root, File, FilesOp, Url}, term::
 use crate::{input::Input, manager::Manager};
 
 pub struct Opt {
-	force: bool,
-	replace: bool,
+	force:    bool,
+	replace:  bool,
 	keep_ext: bool,
 }
 
 impl From<&Exec> for Opt {
 	fn from(e: &Exec) -> Self {
 		Self {
-			force: e.named.contains_key("force"),
-			replace: e.named.contains_key("replace"),
+			force:    e.named.contains_key("force"),
+			replace:  e.named.contains_key("replace"),
 			keep_ext: e.named.contains_key("keep-ext"),
 		}
 	}
@@ -60,9 +60,7 @@ impl Manager {
 				(opt.replace.then(|| "").unwrap_or(&full_name).into(), None)
 			};
 
-			let mut result =
-				Input::_show(InputCfg::rename().with_value(initial_value).with_cursor_at(cursor_start));
-
+			let mut result = Input::_show(InputCfg::rename().with_value(initial_value));
 			let Some(Ok(name)) = result.recv().await else {
 				return;
 			};


### PR DESCRIPTION
Closes #354

This is in my opinion a very important feature to have, and I'd have a further proposal:
use `--replace` as default behavior and add three different flags:
- `--append`: puts cursor between name and extension (e.g. `name|.ext`)
- `--append-ext`: puts cursor at the very end of the extension (current default behavior, e.g. `name.ext|`)
- `--prepend`: puts cursor at the very beginning of the file name (e.g. `|name.ext`)

This would be a little breaking, but I think it's worth it since we are moving to v0.2, and it would also be more consistent with ranger's behavior.
Please do let me know your thoughts on this :smiley: 