### PR TITLE
feat: add `YAZI_LEVEL` env variable for shells

### DIFF
--- a/yazi-plugin/src/external/shell.rs
+++ b/yazi-plugin/src/external/shell.rs
@@ -29,18 +29,12 @@ impl ShellOpt {
 }
 
 pub fn shell(opt: ShellOpt) -> Result<Child> {
+	let level = env::var("YAZI_LEVEL").ok().and_then(|s| s.parse::<u32>().ok()).unwrap_or(0);
+
 	#[cfg(unix)]
 	return Ok(unsafe {
 		Command::new("sh")
-			.env(
-				"YAZI_LEVEL",
-				(env::var("YAZI_LEVEL")
-					.ok()
-					.and_then(|lvl_str| lvl_str.parse::<u32>().ok())
-					.unwrap_or(0)
-					+ 1)
-				.to_string(),
-			)
+			.env("YAZI_LEVEL", (level + 1).to_string())
 			.arg("-c")
 			.stdin(opt.stdio())
 			.stdout(opt.stdio())
@@ -65,6 +59,7 @@ pub fn shell(opt: ShellOpt) -> Result<Child> {
 		let expanded = parser::parse(opt.cmd.to_string_lossy().as_ref(), &args_);
 		Ok(
 			Command::new("cmd")
+				.env("YAZI_LEVEL", (level + 1).to_string())
 				.arg("/C")
 				.args(&expanded)
 				.stdin(opt.stdio())

--- a/yazi-plugin/src/external/shell.rs
+++ b/yazi-plugin/src/external/shell.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, process::Stdio};
+use std::{env, ffi::OsString, process::Stdio};
 
 use anyhow::Result;
 use tokio::process::{Child, Command};
@@ -32,6 +32,15 @@ pub fn shell(opt: ShellOpt) -> Result<Child> {
 	#[cfg(unix)]
 	return Ok(unsafe {
 		Command::new("sh")
+			.env(
+				"YAZI_LEVEL",
+				(env::var("YAZI_LEVEL")
+					.ok()
+					.and_then(|lvl_str| lvl_str.parse::<i32>().ok())
+					.unwrap_or(0)
+					+ 1)
+				.to_string(),
+			)
 			.arg("-c")
 			.stdin(opt.stdio())
 			.stdout(opt.stdio())

--- a/yazi-plugin/src/external/shell.rs
+++ b/yazi-plugin/src/external/shell.rs
@@ -36,7 +36,7 @@ pub fn shell(opt: ShellOpt) -> Result<Child> {
 				"YAZI_LEVEL",
 				(env::var("YAZI_LEVEL")
 					.ok()
-					.and_then(|lvl_str| lvl_str.parse::<i32>().ok())
+					.and_then(|lvl_str| lvl_str.parse::<u32>().ok())
 					.unwrap_or(0)
 					+ 1)
 				.to_string(),


### PR DESCRIPTION
It can be useful for several purposes, such as detecting nested instances.
For example, I like to have an indicator on my shell prompt line when using a shell that has been launched from my terminal file manager.

For reference, other terminal file managers implementing the same feature:
- https://github.com/ranger/ranger/commit/23b7f16961a7b679dec16f6ee91401a6b8f6ca82
- https://github.com/gokcehan/lf/commit/e82cbb820f5c50e551ca8ac54f3ec87683859dfd

Sorry for anything that's unusual about the way I implemented it, I haven't yet contributed much to Rust projects, so I'm not that familiar with the conventions around the language. I'm happy to receive any reviews and make adjustments as required!

---

ps. As a bonus, here's an example configuration for `starship`, it might be worth adding this to the "Tips" section of the docs, if you agree:
```
[env_var.YAZI]
variable = 'YAZI_LEVEL'
format = 'yz [ $env_value]($style) '
style = 'bold green'
```