### PR TITLE
feat: add support for snap packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
         run: cargo build --release --locked --target ${{ matrix.target }}
 
-      - name: Build-snap
+      - name: Build snap
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: snapcore/action-build@v1
 
@@ -82,7 +82,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
-          files:  |
+          files: |
             yazi-${{ matrix.target }}.zip
             yazi*.snap
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
         run: cargo build --release --locked --target ${{ matrix.target }}
 
+      - name: Build-snap
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: snapcore/action-build@v1
+
       - name: Pack artifacts [Linux & macOS]
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         env:
@@ -78,5 +82,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
-          files: yazi-${{ matrix.target }}.zip
+          files:  |
+            yazi-${{ matrix.target }}.zip
+            yazi*.snap
           generate_release_notes: true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: yazi
+base: core22
+adopt-info: yazi
+summary: Blazing fast terminal file manager
+description: |
+    Yazi, which means "duck", is a terminal file manager written in Rust, based on non-blocking async I/O.
+    It aims to provide an efficient, user-friendly, and customizable file management experience.
+license: MIT
+
+grade: stable
+confinement: classic
+
+architectures:
+  - build-on: amd64
+    build-for: amd64
+#  - build-on: amd64
+#    build-for: arm64
+
+
+apps:
+  yazi:
+    command: yazi
+    environment:
+      PATH: $SNAP/bin:$PATH
+
+parts:
+  yazi:
+    plugin: rust
+    source: https://github.com/sxyazi/yazi.git
+    override-build: |
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=0)
+      cargo install fd-find --root $CRAFT_PART_INSTALL
+      cargo install ripgrep --root $CRAFT_PART_INSTALL
+      cargo install zoxide --root $CRAFT_PART_INSTALL
+      git clone --depth 1 https://github.com/junegunn/fzf.git fzf
+      fzf/install --bin && mv fzf/bin/fzf $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,21 +1,17 @@
 name: yazi
 base: core22
 adopt-info: yazi
-summary: Blazing fast terminal file manager
+summary: Blazing fast terminal file manager written in Rust, based on async I/O.
 description: |
-    Yazi, which means "duck", is a terminal file manager written in Rust, based on non-blocking async I/O.
-    It aims to provide an efficient, user-friendly, and customizable file management experience.
+  Yazi is a terminal file manager written in Rust, based on non-blocking async I/O.
+  It aims to provide an efficient, user-friendly, and customizable file management experience.
 license: MIT
-
 grade: stable
 confinement: classic
 
 architectures:
-  - build-on: amd64
-    build-for: amd64
-#  - build-on: amd64
-#    build-for: arm64
-
+  - amd64
+  # - arm64
 
 apps:
   yazi:


### PR DESCRIPTION
The `snapcraft.yaml` is quite straightforward. I'll explain a little bit, in case you may want to change it in the future.

On the top is various meta information, only things to be care are `grade` and `confinement`: 
 - grade can be `devel` or `stable`, defines the quality grade of the snap. 
 - confinement can be `strict` or `classic`, the latter means the snap have full system access just like traditionally applications.

The packing process is defined in `parts` section. 
- Building is take care by `rust` plugin, and carry out with `craftctl default`. You may replace it with any custom build commands. 
- `craftctl set version=...` is used to set the version info. 
- The rest is all for dependencies.
  current only `fd-find`, `ripgrep`, `zoxide`, `fzf` are boundle with yazi, these may need to be change with requirements.
- - - -
As for the release workflow,  I did not add new matrix, current build is take place on `x86_64-unknown-linux-gnu` with  `snapcore/action-build@v1`. The release file would be `yazi*.snap`. 
The snap package can be install with `sudo snap install <package.snap> --dangerous --classic`

Finally, to make it easier for users to get future updates, the snap can be publish to snap store. Snapcraft also provide its own [build service](https://snapcraft.io/build) to automatic build and release snaps. 
