### PR TITLE
fix: input offset is not reset when renaming with `--cursor=start` and the filename is too long

### DIFF
--- a/yazi-core/src/input/commands/show.rs
+++ b/yazi-core/src/input/commands/show.rs
@@ -46,6 +46,7 @@ impl Input {
 		// Set cursor after reset
 		if let Some(cursor) = opt.cfg.cursor {
 			self.snaps.current_mut().cursor = cursor;
+			self.move_(0);
 		}
 
 		render!();


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/573