### PR TITLE
feat: new `image_quality` and `sixel_fraction` options to allow users to configure the image preview quality

### DIFF
--- a/yazi-adaptor/src/sixel.rs
+++ b/yazi-adaptor/src/sixel.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Result};
 use color_quant::NeuQuant;
 use image::DynamicImage;
 use ratatui::layout::Rect;
+use yazi_config::PREVIEW;
 use yazi_shared::term::Term;
 
 use crate::{adaptor::Adaptor, Image, CLOSE, ESCAPE, START};
@@ -44,7 +45,7 @@ impl Sixel {
 
 		tokio::task::spawn_blocking(move || {
 			let img = img.into_rgba8();
-			let nq = NeuQuant::new(10, 256 - alpha as usize, &img);
+			let nq = NeuQuant::new(PREVIEW.sixel_fraction as i32, 256 - alpha as usize, &img);
 
 			let mut buf: Vec<u8> = Vec::with_capacity(1 << 16);
 			write!(buf, "{}P0;1;8q\"1;1;{};{}", START, img.width(), img.height())?;

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -17,6 +17,8 @@ tab_size        = 2
 max_width       = 600
 max_height      = 900
 cache_dir       = ""
+image_quality   = 75
+sixel_fraction  = 15
 ueberzug_scale  = 1
 ueberzug_offset = [ 0, 0, 0, 0 ]
 


### PR DESCRIPTION
Closes https://github.com/sxyazi/yazi/issues/446 - @baitian752
Closes https://github.com/sxyazi/yazi/issues/562 - @AlexKurisu

> - image_quality: Quality on pre-caching images, range 50-90. The larger value, the better image quality, but slower with more CPU consumption, and generates larger cache files that occupy more storage space.
> - sixel_fraction: Sixel is a very old image format that only supports 256 colors. For better image preview, Yazi trains a neural network for each image to find the most representative colors. This value determines the number of samples used during the training, range 10-20. A smaller value produces better results but is also slower.

See the docs here: http://localhost:3000/docs/configuration/yazi#preview