### PR TITLE
fix: attach plugin `args` to the `entry` method for better future optimization possibilities

### DIFF
--- a/yazi-plugin/preset/state.lua
+++ b/yazi-plugin/preset/state.lua
@@ -1,16 +1,25 @@
 local cache = {}
+local sub_mt = {
+	__index = function(target, k)
+		local bucket = rawget(target, "__yazi_bucket")
+		return cache[bucket] and cache[bucket][k]
+	end,
+	__newindex = function(target, k, v)
+		local bucket = rawget(target, "__yazi_bucket")
+		cache[bucket] = cache[bucket] or {}
+		cache[bucket][k] = v
+	end,
+}
 
-state = setmetatable({
-	clear = function() cache[YAZI_PLUGIN_NAME] = nil end,
-}, {
+state = setmetatable({}, {
 	__index = function(_, k)
 		local bucket = YAZI_PLUGIN_NAME
 		return cache[bucket] and cache[bucket][k]
 	end,
-
 	__newindex = function(_, k, v)
 		local bucket = YAZI_PLUGIN_NAME
 		cache[bucket] = cache[bucket] or {}
 		cache[bucket][k] = v
 	end,
+	__call = function() return setmetatable({ __yazi_bucket = YAZI_PLUGIN_NAME }, sub_mt) end,
 })


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/pull/587

As no new version has been released yet, this is not considered a breaking change.

Now please use:

```
return {
  entry = function(self, args)
    ya.err(args[1]) -- "foo"
    ya.err(args[2]) -- "bar"
  end,
}
```

to access the arguments of the plugin.