### PR TITLE
feat: if prompt is empty, close it on `backspace` command

### DIFF
--- a/yazi-core/src/input/commands/backspace.rs
+++ b/yazi-core/src/input/commands/backspace.rs
@@ -18,6 +18,13 @@ impl Input {
 		let opt = opt.into() as Opt;
 		let snap = self.snaps.current_mut();
 
+		if snap.value.is_empty() {
+			self.ticket = self.ticket.wrapping_add(1);
+			self.visible = false;
+			render!();
+			return;
+		}
+
 		if !opt.under && snap.cursor < 1 {
 			return;
 		} else if opt.under && snap.cursor >= snap.value.len() {

--- a/yazi-core/src/tab/commands/search.rs
+++ b/yazi-core/src/tab/commands/search.rs
@@ -63,6 +63,10 @@ impl Tab {
 			let mut input = Input::_show(InputCfg::search(&opt.type_.to_string()));
 			let Some(Ok(subject)) = input.recv().await else { bail!("") };
 
+			if subject.is_empty() {
+				return Ok(());
+			}
+
 			cwd = cwd.into_search(subject.clone());
 			let rx = if opt.type_ == OptType::Rg {
 				external::rg(external::RgOpt { cwd: cwd.clone(), hidden, subject })


### PR DESCRIPTION
In relation to #551 

Also fixed issue of search` being run with `nil` mentioned in [this comment](https://github.com/sxyazi/yazi/issues/551#issuecomment-1902705562).