### PR TITLE
feat: add a way to use zoxide as an input field

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -80,7 +80,8 @@ keymap = [
 	{ on = [ "S" ],         exec = "search rg",                                            desc = "Search files by content using ripgrep" },
 	{ on = [ "<C-s>" ],     exec = "search none",                                          desc = "Cancel the ongoing search" },
 	{ on = [ "z" ],         exec = "jump zoxide",                                          desc = "Jump to a directory using zoxide" },
-	{ on = [ "Z" ],         exec = "jump fzf",                                             desc = "Jump to a directory, or reveal a file using fzf" },
+	{ on = [ "Z" ],         exec = "jump zoxide_interactive",                              desc = "Jump to a directory using zoxide interactively"},
+	# { on = [ " " ],         exec = "jump fzf",                                             desc = "Jump to a directory, or reveal a file using fzf" },
 
 	# Linemode
 	{ on = [ "m", "s" ], exec = "linemode size",        desc = "Set linemode to size" },

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -178,6 +178,11 @@ quit_title  = "{n} task{s} running, sure to quit? (y/N)"
 quit_origin = "top-center"
 quit_offset = [ 0, 2, 50, 3 ]
 
+# zoxide
+zoxide_title =  "Zoxide query"
+zoxide_origin = "top-center"
+zoxide_offset = [ 0, 2, 50, 3 ]
+
 [select]
 open_title  = "Open with:"
 open_origin = "hovered"

--- a/yazi-config/src/popup/input.rs
+++ b/yazi-config/src/popup/input.rs
@@ -59,6 +59,11 @@ pub struct Input {
 	pub quit_title:  String,
 	pub quit_origin: Origin,
 	pub quit_offset: Offset,
+
+    // zoxide
+    pub zoxide_title:  String,
+    pub zoxide_origin: Origin,
+    pub zoxide_offset: Offset,
 }
 
 impl Default for Input {

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -126,6 +126,15 @@ impl InputCfg {
 		}
 	}
 
+    #[inline]
+    pub fn zoxide() -> Self {
+        Self {
+            title: INPUT.zoxide_title.to_owned(),
+            position: Position::new(INPUT.zoxide_origin, INPUT.zoxide_offset),
+            ..Default::default()
+        }
+    }
+
 	#[inline]
 	pub fn with_value(mut self, value: impl Into<String>) -> Self {
 		self.value = value.into();

--- a/yazi-plugin/src/external/zoxide.rs
+++ b/yazi-plugin/src/external/zoxide.rs
@@ -6,12 +6,14 @@ use yazi_shared::fs::Url;
 
 pub struct ZoxideOpt {
 	pub cwd: Url,
+	pub query: Option<String>,
 }
 
 pub async fn zoxide(opt: ZoxideOpt) -> Result<Url> {
 	let child = Command::new("zoxide")
-		.args(["query", "-i", "--exclude"])
+		.args(["query", "--exclude"])
 		.arg(&opt.cwd)
+		.arg(if let Some(query) = &opt.query { query } else { "--interactive" })
 		.kill_on_drop(true)
 		.stdout(Stdio::piped())
 		.spawn()?;


### PR DESCRIPTION
I'd appreciate it if we discussed this, before you make any changes.

Missing:
- [ ] New default keybind for `jump fzf`
- [ ] Fix the hang on line 55
- [ ] Replace `Err(anyhow!(""))` with the correct way to create an empty error

Breaking changes:
- `jump zoxide` now uses an input field, and the old functionality is moved to `jump zoxide_interactive`
- Default `jump fzf` keybind is changed