### PR TITLE
feat: add [icon] prepend_rules and append_rules in theme.toml

### DIFF
--- a/yazi-config/src/keymap/keymap.rs
+++ b/yazi-config/src/keymap/keymap.rs
@@ -52,24 +52,6 @@ impl<'de> Deserialize<'de> for Keymap {
 		#[rustfmt::skip]
 		Preset::mix(&mut shadow.completion.keymap, shadow.completion.prepend_keymap, shadow.completion.append_keymap);
 
-		// TODO: remove this when v0.2.3 is released --
-		if !shadow.input.keymap.iter().any(|c| c.on() == "<Backspace>") {
-			println!(
-				"WARNING: Default keybinding for `<Backspace>` is missing, please add a `{}` to the `[input]` section of `keymap.toml`.
-In Yazi v0.2.0, `<Backspace>` previously hardcoded within the input component has been moved to `keymap.toml` to allow users to customize it.",
-				r#"{ on = [ "<Backspace>" ], exec = "backspace" }"#
-			);
-		}
-		// TODO: -- remove this when v0.2.3 is released
-
-		// TODO: remove this when v0.2.3 is released --
-		if shadow.manager.keymap.iter().any(|c| c.exec().contains("--empty=name")) {
-			println!(
-				"WARNING: `rename --empty=name` is deprecated in Yazi v0.2.2, please use `rename --empty=stem` instead.",
-			);
-		}
-		// TODO: -- remove this when v0.2.3 is released
-
 		Ok(Self {
 			manager:    shadow.manager.keymap,
 			tasks:      shadow.tasks.keymap,

--- a/yazi-config/src/theme/icon.rs
+++ b/yazi-config/src/theme/icon.rs
@@ -1,15 +1,11 @@
 use serde::{Deserialize, Deserializer};
 
 use super::Style;
-use crate::{
-	preset::Preset,
-	theme::{Color, StyleShadow},
-	Pattern,
-};
+use crate::{preset::Preset, theme::{Color, StyleShadow}, Pattern};
 
 pub struct Icon {
-	pub name: Pattern,
-	pub text: String,
+	pub name:  Pattern,
+	pub text:  String,
 	pub style: Style,
 }
 
@@ -20,11 +16,11 @@ impl Icon {
 	{
 		#[derive(Deserialize)]
 		struct IconOuter {
-			rules: Vec<IconRule>,
+			rules:         Vec<IconRule>,
 			#[serde(default)]
 			prepend_rules: Vec<IconRule>,
 			#[serde(default)]
-			append_rules: Vec<IconRule>,
+			append_rules:  Vec<IconRule>,
 		}
 		#[derive(Deserialize)]
 		struct IconRule {
@@ -44,8 +40,8 @@ impl Icon {
 				.rules
 				.into_iter()
 				.map(|r| Icon {
-					name: r.name,
-					text: r.text,
+					name:  r.name,
+					text:  r.text,
 					style: StyleShadow { fg: r.fg, ..Default::default() }.into(),
 				})
 				.collect(),

--- a/yazi-config/src/theme/icon.rs
+++ b/yazi-config/src/theme/icon.rs
@@ -31,8 +31,6 @@ impl Icon {
 		}
 
 		let mut outer = IconOuter::deserialize(deserializer)?;
-
-		#[rustfmt::skip]
 		Preset::mix(&mut outer.rules, outer.prepend_rules, outer.append_rules);
 
 		Ok(

--- a/yazi-config/src/theme/icon.rs
+++ b/yazi-config/src/theme/icon.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer};
 
 use super::Style;
-use crate::{theme::{Color, StyleShadow}, Pattern};
+use crate::{theme::{Color, StyleShadow}, Pattern, preset::Preset};
 
 pub struct Icon {
 	pub name:  Pattern,
@@ -17,6 +17,10 @@ impl Icon {
 		#[derive(Deserialize)]
 		struct IconOuter {
 			rules: Vec<IconRule>,
+			#[serde(default)]
+            prepend_rules: Vec<IconRule>,
+			#[serde(default)]
+            append_rules: Vec<IconRule>,
 		}
 		#[derive(Deserialize)]
 		struct IconRule {
@@ -26,8 +30,13 @@ impl Icon {
 			fg: Option<Color>,
 		}
 
+		let mut outer = IconOuter::deserialize(deserializer)?;
+
+		#[rustfmt::skip]
+		Preset::mix(&mut outer.rules, outer.prepend_rules, outer.append_rules);
+
 		Ok(
-			IconOuter::deserialize(deserializer)?
+			outer
 				.rules
 				.into_iter()
 				.map(|r| Icon {

--- a/yazi-config/src/theme/icon.rs
+++ b/yazi-config/src/theme/icon.rs
@@ -1,11 +1,15 @@
 use serde::{Deserialize, Deserializer};
 
 use super::Style;
-use crate::{theme::{Color, StyleShadow}, Pattern, preset::Preset};
+use crate::{
+	preset::Preset,
+	theme::{Color, StyleShadow},
+	Pattern,
+};
 
 pub struct Icon {
-	pub name:  Pattern,
-	pub text:  String,
+	pub name: Pattern,
+	pub text: String,
 	pub style: Style,
 }
 
@@ -18,9 +22,9 @@ impl Icon {
 		struct IconOuter {
 			rules: Vec<IconRule>,
 			#[serde(default)]
-            prepend_rules: Vec<IconRule>,
+			prepend_rules: Vec<IconRule>,
 			#[serde(default)]
-            append_rules: Vec<IconRule>,
+			append_rules: Vec<IconRule>,
 		}
 		#[derive(Deserialize)]
 		struct IconRule {
@@ -40,8 +44,8 @@ impl Icon {
 				.rules
 				.into_iter()
 				.map(|r| Icon {
-					name:  r.name,
-					text:  r.text,
+					name: r.name,
+					text: r.text,
 					style: StyleShadow { fg: r.fg, ..Default::default() }.into(),
 				})
 				.collect(),


### PR DESCRIPTION
Add `prepend_rules` and `append_rules` for merging custom icon rules with default rules. But didn't wrote about this feature in docs, can do it tomorrow.

Also removed TODO warnings in `keymap.rs`.

Is it okay that I use rustfmt in separate commit, should i squash it somehow?

