### PR TITLE
fix: update version output when commit SHA is not present

### DIFF
--- a/yazi-config/src/boot/boot.rs
+++ b/yazi-config/src/boot/boot.rs
@@ -58,10 +58,12 @@ impl Default for Args {
 		let args = Self::parse();
 
 		if args.version {
+			let commit_sha =
+				(env!("VERGEN_GIT_SHA") != "VERGEN_IDEMPOTENT_OUTPUT").then_some(env!("VERGEN_GIT_SHA"));
 			println!(
-				"yazi {} ({} {})",
+				"yazi {} ({}{})",
 				env!("CARGO_PKG_VERSION"),
-				env!("VERGEN_GIT_SHA"),
+				commit_sha.map(|v| format!("{v} ")).unwrap_or_default(),
 				env!("VERGEN_BUILD_DATE")
 			);
 			process::exit(0);


### PR DESCRIPTION
Hey!

Arch maintainer of yazi here :wave:

I realized version flag (`-V`) shows the following for me:

```sh
yazi 0.2.3 (VERGEN_IDEMPOTENT_OUTPUT 2024-02-11)
```

This is due to git commits not being available at build time.

This PR updates the version output like following when commit SHA is not available:

```sh
yazi 0.2.3 (2024-02-11)
```
