### PR TITLE
feat: nested selection conflict detection

### DIFF
--- a/yazi-core/src/tab/commands/escape.rs
+++ b/yazi-core/src/tab/commands/escape.rs
@@ -40,7 +40,7 @@ impl Tab {
 		let state = self.mode.is_select();
 		for f in indices.iter().filter_map(|i| self.current.files.get(*i)) {
 			if state {
-				self.selected.insert(f.url());
+				self.selected.add(&f.url);
 			} else {
 				self.selected.remove(&f.url);
 			}

--- a/yazi-core/src/tab/commands/select.rs
+++ b/yazi-core/src/tab/commands/select.rs
@@ -31,9 +31,9 @@ impl<'a> Tab {
 		};
 
 		render!(match opt.state {
-			Some(true) => self.selected.insert(url.into_owned()),
+			Some(true) => self.selected.add(&url),
 			Some(false) => self.selected.remove(&url),
-			None => self.selected.remove(&url) || self.selected.insert(url.into_owned()),
+			None => self.selected.remove(&url) || self.selected.add(&url),
 		});
 	}
 }

--- a/yazi-core/src/tab/commands/select_all.rs
+++ b/yazi-core/src/tab/commands/select_all.rs
@@ -27,7 +27,7 @@ impl Tab {
 		match opt.into().state {
 			Some(true) => {
 				for f in self.current.files.iter() {
-					b |= self.selected.insert(f.url());
+					b |= self.selected.add(&f.url);
 				}
 			}
 			Some(false) => {
@@ -37,7 +37,7 @@ impl Tab {
 			}
 			None => {
 				for f in self.current.files.iter() {
-					b |= self.selected.remove(&f.url) || self.selected.insert(f.url());
+					b |= self.selected.remove(&f.url) || self.selected.add(&f.url);
 				}
 			}
 		}

--- a/yazi-core/src/tab/mod.rs
+++ b/yazi-core/src/tab/mod.rs
@@ -4,6 +4,7 @@ mod config;
 mod finder;
 mod mode;
 mod preview;
+mod selected;
 mod tab;
 
 pub use backstack::*;

--- a/yazi-core/src/tab/mod.rs
+++ b/yazi-core/src/tab/mod.rs
@@ -12,4 +12,5 @@ pub use config::*;
 pub use finder::*;
 pub use mode::*;
 pub use preview::*;
+pub use selected::*;
 pub use tab::*;

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -91,9 +91,9 @@ mod tests {
 		let url1 = Url::from(Path::new("/a/b"));
 		let url2 = Url::from(Path::new("/c/d"));
 
-		assert!(selected.insert(url1), "Should successfully insert url1");
-		assert!(selected.insert(url2), "Should successfully insert url2");
-		assert_eq!(selected.inner.len(), 2, "There should be two URLs");
+		assert!(selected.insert(url1));
+		assert!(selected.insert(url2));
+		assert_eq!(selected.inner.len(), 2);
 	}
 
 	#[test]
@@ -102,8 +102,8 @@ mod tests {
 		let parent_url = Url::from(Path::new("/a"));
 		let child_url = Url::from(Path::new("/a/b"));
 
-		assert!(selected.insert(parent_url), "Should successfully insert parent_url");
-		assert!(!selected.insert(child_url), "Should fail to insert child_url due to conflict");
+		assert!(selected.insert(parent_url));
+		assert!(!selected.insert(child_url));
 	}
 
 	#[test]
@@ -113,9 +113,9 @@ mod tests {
 		let parent_url = Url::from(Path::new("/a/b"));
 		let sibling_url = Url::from(Path::new("/a/b/d"));
 
-		assert!(selected.insert(child_url), "Should successfully insert child_url");
-		assert!(!selected.insert(parent_url), "Should fail to insert parent_url due to conflict");
-		assert!(selected.insert(sibling_url), "Should successfully insert sibling_url");
+		assert!(selected.insert(child_url));
+		assert!(!selected.insert(parent_url));
+		assert!(selected.insert(sibling_url));
 	}
 
 	#[test]
@@ -123,10 +123,10 @@ mod tests {
 		let mut selected = Selected::default();
 		let url = Url::from(Path::new("/a/b"));
 
-		assert!(selected.insert(url.clone()), "Should successfully insert url");
-		assert!(selected.remove(&url), "Should successfully remove url");
-		assert!(selected.inner.is_empty(), "Inner set should be empty after removal");
-		assert!(selected.parents.is_empty(), "Parents map should be empty after removal");
+		assert!(selected.insert(url.clone()));
+		assert!(selected.remove(&url));
+		assert!(selected.inner.is_empty());
+		assert!(selected.parents.is_empty());
 	}
 
 	#[test]
@@ -136,7 +136,7 @@ mod tests {
 		let child2 = Url::from(Path::new("/parent/child2"));
 		let child3 = Url::from(Path::new("/parent/child3"));
 		let urls = vec![&child1, &child2, &child3];
-		assert!(selected.insert_many(&urls), "Should successfully insert urls with the same parent");
+		assert!(selected.insert_many(&urls));
 	}
 
 	#[test]
@@ -147,7 +147,7 @@ mod tests {
 		let child1 = Url::from(Path::new("/parent/child1"));
 		let child2 = Url::from(Path::new("/parent/child2"));
 		let urls = vec![&child1, &child2];
-		assert!(!selected.insert_many(&urls), "Should fail to insert since parent already exists");
+		assert!(!selected.insert_many(&urls));
 	}
 
 	#[test]
@@ -159,16 +159,13 @@ mod tests {
 		let child1 = Url::from(Path::new("/parent/child1"));
 		let child2 = Url::from(Path::new("/parent/child2"));
 		let urls = vec![&child1, &child2];
-		assert!(
-			selected.insert_many(&urls),
-			"Should success to insert since one of the children already exists"
-		);
+		assert!(selected.insert_many(&urls));
 	}
 
 	#[test]
 	fn insert_many_empty_urls_list() {
 		let mut selected = Selected::default();
-		assert!(selected.insert_many(&[]), "Inserting an empty list of urls should false");
+		assert!(selected.insert_many(&[]));
 	}
 
 	#[test]
@@ -178,10 +175,7 @@ mod tests {
 		let child1 = Url::from(Path::new("/parent/child/child1"));
 		let child2 = Url::from(Path::new("/parent/child/child2"));
 		let urls = vec![&child1, &child2];
-		assert!(
-			!selected.insert_many(&urls),
-			"Should successfully insert urls when parent is a child of another url in the set"
-		);
+		assert!(!selected.insert_many(&urls));
 	}
 	#[test]
 	fn insert_many_with_direct_parent_fails() {
@@ -189,10 +183,7 @@ mod tests {
 		selected.insert(Url::from(Path::new("/a")));
 		let binding = Url::from(Path::new("/a/b"));
 		let urls = vec![&binding];
-		assert!(
-			!selected.insert_many(&urls),
-			"Should not allow insert when parent is already selected"
-		);
+		assert!(!selected.insert_many(&urls));
 	}
 
 	#[test]
@@ -201,10 +192,7 @@ mod tests {
 		selected.insert(Url::from(Path::new("/a/b")));
 		let binding = Url::from(Path::new("/a"));
 		let urls = vec![&binding];
-		assert!(
-			!selected.insert_many(&urls),
-			"Should not allow insert of a parent when a child is already selected"
-		);
+		assert!(!selected.insert_many(&urls));
 	}
 
 	#[test]
@@ -213,7 +201,7 @@ mod tests {
 		let child1 = Url::from(Path::new("/a/b"));
 		let child2 = Url::from(Path::new("/a/c"));
 		let urls = vec![&child1, &child2];
-		assert!(selected.insert_many(&urls), "Should allow inserts of sibling directories");
+		assert!(selected.insert_many(&urls));
 	}
 
 	#[test]
@@ -222,11 +210,9 @@ mod tests {
 		selected.insert(Url::from(Path::new("/a/b")));
 		let binding = Url::from(Path::new("/a/b/c"));
 		let urls = vec![&binding];
-		assert!(
-			!selected.insert_many(&urls),
-			"Should not allow insert of a grandchild when the child is already selected"
-		);
+		assert!(!selected.insert_many(&urls));
 	}
+
 	#[test]
 	fn test_insert_many_with_remove() {
 		let mut selected = Selected::default();
@@ -234,15 +220,15 @@ mod tests {
 		let child2 = Url::from(Path::new("/parent/child2"));
 		let child3 = Url::from(Path::new("/parent/child3"));
 		let urls = vec![&child1, &child2, &child3];
-		assert!(selected.insert_many(&urls), "Should successfully insert urls with the same parent");
-		assert!(selected.remove(&child1), "Should successfully remove url");
+		assert!(selected.insert_many(&urls));
+		assert!(selected.remove(&child1));
 		assert_eq!(selected.inner.len(), 2);
-		assert!(!selected.parents.is_empty(), "parent map should not be empty");
-		assert!(selected.remove(&child2), "Should successfully remove url");
-		assert!(!selected.parents.is_empty(), "parent map should not be empty");
-		assert!(selected.remove(&child3), "Should successfully remove url");
+		assert!(!selected.parents.is_empty());
+		assert!(selected.remove(&child2));
+		assert!(!selected.parents.is_empty());
+		assert!(selected.remove(&child3));
 
-		assert!(selected.inner.is_empty(), "Inner set should be empty after removal");
-		assert!(selected.parents.is_empty(), "Parents map should be empty after removal");
+		assert!(selected.inner.is_empty());
+		assert!(selected.parents.is_empty());
 	}
 }

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -48,11 +48,13 @@ impl Selected {
 	/// # Examples
 	///
 	/// ```
+	/// # use yazi_core::tab::Selected;
+	/// # use yazi_shared::fs::Url;
 	/// let mut s = Selected::default();
 	///
 	/// let url1 = Url::from("/a/b/c");
 	/// let url2 = Url::from("/a/b/d");
-	/// assert!(selected.add_many(&[&url1, &url2]));
+	/// assert!(s.add_many(&[&url1, &url2]));
 	/// ```
 	pub fn add_many(&mut self, urls: &[&Url]) -> bool {
 		if urls.is_empty() {

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -117,4 +117,69 @@ mod tests {
 		assert!(selected.inner.is_empty(), "Inner set should be empty after removal");
 		assert!(selected.parents.is_empty(), "Parents map should be empty after removal");
 	}
+
+
+	#[test]
+	fn insert_many_success() {
+		let mut selected = Selected::new();
+		let parent = Url::from(Path::new("/parent"));
+		let child1= Url::from(Path::new("/parent/child1"));
+		let child2= Url::from(Path::new("/parent/child2"));
+		let urls = vec![
+			&child1,
+			&child2,
+		];
+		assert!(selected.insert_many(&urls, parent), "Should successfully insert urls with the same parent");
+	}
+
+	#[test]
+	fn insert_many_with_existing_parent_fails() {
+		let mut selected = Selected::new();
+		let parent = Url::from(Path::new("/parent"));
+		selected.insert(Url::from(Path::new("/parent")));
+		let childs1= Url::from(Path::new("/parent/child1"));
+		let childs2=Url::from(Path::new("/parent/child2"));
+		let urls = vec![
+			&childs1,
+			&childs2
+		];
+		assert!(!selected.insert_many(&urls, parent), "Should fail to insert since parent already exists");
+	}
+
+	#[test]
+	fn insert_many_with_existing_child_fails() {
+		let mut selected = Selected::new();
+		let parent = Url::from(Path::new("/parent"));
+		let child = Url::from(Path::new("/parent/child1"));
+		selected.insert(child);
+		let child1= Url::from(Path::new("/parent/child1"));
+		let child2= Url::from(Path::new("/parent/child2"));
+		let urls = vec![
+			&child1,
+			&child2
+		];
+		assert!(!selected.insert_many(&urls, parent), "Should fail to insert since one of the children already exists");
+	}
+
+	#[test]
+	fn insert_many_empty_urls_list() {
+		let mut selected = Selected::new();
+		let parent = Url::from(Path::new("/parent"));
+		let urls = vec![];
+		assert!(selected.insert_many(&urls, parent), "Inserting an empty list of urls should succeed");
+	}
+
+	#[test]
+	fn insert_many_with_parent_as_child_of_another_url() {
+		let mut selected = Selected::new();
+		let parent = Url::from(Path::new("/parent/child"));
+		selected.insert(Url::from(Path::new("/parent")));
+		let child1= Url::from(Path::new("/parent/child/child1"));
+		let child2= Url::from(Path::new("/parent/child/child2"));
+		let urls = vec![
+			&child1,
+			&child2,
+		];
+		assert!(selected.insert_many(&urls, parent), "Should successfully insert urls when parent is a child of another url in the set");
+	}
 }

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -11,8 +11,13 @@ pub struct Selected {
 impl Selected {
 	pub fn new() -> Self { Selected { inner: BTreeSet::new(), parents: HashMap::new() } }
 
-	pub fn insert(&mut self, url: Url) -> bool {
-		let url_buf = url.to_path_buf();
+	pub fn insert(&mut self, url: Url) -> bool { self.insert_many(&[&url]) }
+
+	pub fn insert_many(&mut self, urls: &[&Url]) -> bool {
+		if urls.is_empty() {
+			return false;
+		}
+		let url_buf = urls[0].to_path_buf();
 
 		let mut current_path = url_buf.clone();
 		while let Some(parent) = current_path.parent() {
@@ -27,15 +32,17 @@ impl Selected {
 		}
 
 		let mut current_path = url_buf.clone();
+		let len_of_urls = urls.len();
 		loop {
 			current_path = match current_path.parent() {
 				Some(parent) => parent.to_path_buf(),
 				None => break,
 			};
 			let counter = self.parents.entry(current_path.clone()).or_insert(0);
-			*counter += 1;
+			*counter += len_of_urls;
 		}
-		self.inner.insert(url.clone());
+
+		self.inner.extend(urls.iter().cloned().cloned());
 		true
 	}
 
@@ -118,68 +125,121 @@ mod tests {
 		assert!(selected.parents.is_empty(), "Parents map should be empty after removal");
 	}
 
-
 	#[test]
 	fn insert_many_success() {
 		let mut selected = Selected::new();
-		let parent = Url::from(Path::new("/parent"));
-		let child1= Url::from(Path::new("/parent/child1"));
-		let child2= Url::from(Path::new("/parent/child2"));
-		let urls = vec![
-			&child1,
-			&child2,
-		];
-		assert!(selected.insert_many(&urls, parent), "Should successfully insert urls with the same parent");
+		let child1 = Url::from(Path::new("/parent/child1"));
+		let child2 = Url::from(Path::new("/parent/child2"));
+		let child3 = Url::from(Path::new("/parent/child3"));
+		let urls = vec![&child1, &child2, &child3];
+		assert!(selected.insert_many(&urls), "Should successfully insert urls with the same parent");
 	}
 
 	#[test]
 	fn insert_many_with_existing_parent_fails() {
 		let mut selected = Selected::new();
-		let parent = Url::from(Path::new("/parent"));
 		selected.insert(Url::from(Path::new("/parent")));
-		let childs1= Url::from(Path::new("/parent/child1"));
-		let childs2=Url::from(Path::new("/parent/child2"));
-		let urls = vec![
-			&childs1,
-			&childs2
-		];
-		assert!(!selected.insert_many(&urls, parent), "Should fail to insert since parent already exists");
+
+		let childs1 = Url::from(Path::new("/parent/child1"));
+		let childs2 = Url::from(Path::new("/parent/child2"));
+		let urls = vec![&childs1, &childs2];
+		assert!(!selected.insert_many(&urls), "Should fail to insert since parent already exists");
 	}
 
 	#[test]
 	fn insert_many_with_existing_child_fails() {
 		let mut selected = Selected::new();
-		let parent = Url::from(Path::new("/parent"));
 		let child = Url::from(Path::new("/parent/child1"));
 		selected.insert(child);
-		let child1= Url::from(Path::new("/parent/child1"));
-		let child2= Url::from(Path::new("/parent/child2"));
-		let urls = vec![
-			&child1,
-			&child2
-		];
-		assert!(!selected.insert_many(&urls, parent), "Should fail to insert since one of the children already exists");
+
+		let child1 = Url::from(Path::new("/parent/child1"));
+		let child2 = Url::from(Path::new("/parent/child2"));
+		let urls = vec![&child1, &child2];
+		assert!(
+			selected.insert_many(&urls),
+			"Should success to insert since one of the children already exists"
+		);
 	}
 
 	#[test]
 	fn insert_many_empty_urls_list() {
 		let mut selected = Selected::new();
-		let parent = Url::from(Path::new("/parent"));
 		let urls = vec![];
-		assert!(selected.insert_many(&urls, parent), "Inserting an empty list of urls should succeed");
+		assert!(!selected.insert_many(&urls), "Inserting an empty list of urls should false");
 	}
 
 	#[test]
 	fn insert_many_with_parent_as_child_of_another_url() {
 		let mut selected = Selected::new();
-		let parent = Url::from(Path::new("/parent/child"));
-		selected.insert(Url::from(Path::new("/parent")));
-		let child1= Url::from(Path::new("/parent/child/child1"));
-		let child2= Url::from(Path::new("/parent/child/child2"));
-		let urls = vec![
-			&child1,
-			&child2,
-		];
-		assert!(selected.insert_many(&urls, parent), "Should successfully insert urls when parent is a child of another url in the set");
+		selected.insert(Url::from(Path::new("/parent/child")));
+		let child1 = Url::from(Path::new("/parent/child/child1"));
+		let child2 = Url::from(Path::new("/parent/child/child2"));
+		let urls = vec![&child1, &child2];
+		assert!(
+			!selected.insert_many(&urls),
+			"Should successfully insert urls when parent is a child of another url in the set"
+		);
+	}
+	#[test]
+	fn insert_many_with_direct_parent_fails() {
+		let mut selected = Selected::new();
+		selected.insert(Url::from(Path::new("/a")));
+		let binding = Url::from(Path::new("/a/b"));
+		let urls = vec![&binding];
+		assert!(
+			!selected.insert_many(&urls),
+			"Should not allow insert when parent is already selected"
+		);
+	}
+
+	#[test]
+	fn insert_many_with_nested_child_fails() {
+		let mut selected = Selected::new();
+		selected.insert(Url::from(Path::new("/a/b")));
+		let binding = Url::from(Path::new("/a"));
+		let urls = vec![&binding];
+		assert!(
+			!selected.insert_many(&urls),
+			"Should not allow insert of a parent when a child is already selected"
+		);
+	}
+
+	#[test]
+	fn insert_many_sibling_directories_success() {
+		let mut selected = Selected::new();
+		let child1 = Url::from(Path::new("/a/b"));
+		let child2 = Url::from(Path::new("/a/c"));
+		let urls = vec![&child1, &child2];
+		assert!(selected.insert_many(&urls), "Should allow inserts of sibling directories");
+	}
+
+	#[test]
+	fn insert_many_with_grandchild_fails() {
+		let mut selected = Selected::new();
+		selected.insert(Url::from(Path::new("/a/b")));
+		let binding = Url::from(Path::new("/a/b/c"));
+		let urls = vec![&binding];
+		assert!(
+			!selected.insert_many(&urls),
+			"Should not allow insert of a grandchild when the child is already selected"
+		);
+	}
+	#[test]
+	fn test_insert_many_with_remove() {
+		let mut selected = Selected::new();
+		let child1 = Url::from(Path::new("/parent/child1"));
+		let child2 = Url::from(Path::new("/parent/child2"));
+		let child3 = Url::from(Path::new("/parent/child3"));
+		let urls = vec![&child1, &child2, &child3];
+		assert!(selected.insert_many(&urls), "Should successfully insert urls with the same parent");
+		assert!(selected.remove(&child1), "Should successfully remove url");
+		assert_eq!(selected.inner.len(),2);
+		assert!(!selected.parents.is_empty(),"parent map should not be empty");
+		assert!(selected.remove(&child2), "Should successfully remove url");
+		assert!(!selected.parents.is_empty(),"parent map should not be empty");
+		assert!(selected.remove(&child3), "Should successfully remove url");
+
+		assert!(selected.inner.is_empty(), "Inner set should be empty after removal");
+		assert!(selected.parents.is_empty(), "Parents map should be empty after removal");
 	}
 }

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -48,36 +48,31 @@ impl Selected {
 	/// # Examples
 	///
 	/// ```
-	/// #
-	/// # use yazi_core::select::Select;
-	/// # use yazi_shared::fs::Url;
-	/// let mut selected= Select::default();
+	/// let mut s = Selected::default();
+	///
 	/// let url1 = Url::from("/a/b/c");
 	/// let url2 = Url::from("/a/b/d");
-	/// let urls = vec![&url1, &url2];
-	///
-	/// assert!(selected.add_many(&urls));
+	/// assert!(selected.add_many(&[&url1, &url2]));
 	/// ```
 	pub fn add_many(&mut self, urls: &[&Url]) -> bool {
 		if urls.is_empty() {
 			return true;
-		}
-
-		let mut parent = urls[0].parent_url();
-		while let Some(u) = parent {
-			if self.inner.contains(&u) {
-				return false;
-			}
-			parent = u.parent_url();
-		}
-
-		if self.parents.contains_key(urls[0]) {
+		} else if self.parents.contains_key(urls[0]) {
 			return false;
 		}
 
 		let mut parent = urls[0].parent_url();
+		let mut parents = vec![];
 		while let Some(u) = parent {
+			if self.inner.contains(&u) {
+				return false;
+			}
+
 			parent = u.parent_url();
+			parents.push(u);
+		}
+
+		for u in parents {
 			*self.parents.entry(u).or_insert(0) += urls.len();
 		}
 

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -1,0 +1,120 @@
+use std::{collections::{BTreeSet, HashMap}, path::PathBuf};
+
+use yazi_shared::fs::Url;
+
+#[derive(Default)]
+pub struct Selected {
+	inner:   BTreeSet<Url>,
+	parents: HashMap<PathBuf, usize>,
+}
+
+impl Selected {
+	pub fn new() -> Self { Selected { inner: BTreeSet::new(), parents: HashMap::new() } }
+
+	pub fn insert(&mut self, url: Url) -> bool {
+		let url_buf = url.to_path_buf();
+
+		let mut current_path = url_buf.clone();
+		while let Some(parent) = current_path.parent() {
+			if self.inner.contains(&Url::from(parent)) {
+				return false;
+			}
+			current_path = parent.to_path_buf();
+		}
+
+		if self.parents.contains_key(&url_buf) {
+			return false;
+		}
+
+		let mut current_path = url_buf.clone();
+		loop {
+			current_path = match current_path.parent() {
+				Some(parent) => parent.to_path_buf(),
+				None => break,
+			};
+			let counter = self.parents.entry(current_path.clone()).or_insert(0);
+			*counter += 1;
+		}
+		self.inner.insert(url.clone());
+		true
+	}
+
+	pub fn remove(&mut self, url: &Url) -> bool {
+		if !self.inner.remove(&url) {
+			return false;
+		}
+
+		let mut current_path = url.to_path_buf();
+		loop {
+			current_path = match current_path.parent() {
+				Some(parent) => parent.to_path_buf(),
+				None => break,
+			};
+			let counter = self.parents.entry(current_path.clone()).or_insert(0);
+			*counter -= 1;
+			if *counter == 0 {
+				self.parents.remove(&current_path);
+			}
+		}
+		return true;
+	}
+
+	pub fn is_empty(&self) -> bool { self.inner.is_empty() }
+
+	pub fn clear(&mut self) {
+		self.parents.clear();
+		self.inner.clear();
+	}
+
+	pub fn iter(&self) -> std::collections::btree_set::Iter<Url> { self.inner.iter() }
+}
+#[cfg(test)]
+mod tests {
+	use std::path::Path;
+
+	use super::*;
+
+	#[test]
+	fn test_insert_non_conflicting() {
+		let mut selected = Selected::new();
+		let url1 = Url::from(Path::new("/a/b"));
+		let url2 = Url::from(Path::new("/c/d"));
+
+		assert!(selected.insert(url1), "Should successfully insert url1");
+		assert!(selected.insert(url2), "Should successfully insert url2");
+		assert_eq!(selected.inner.len(), 2, "There should be two URLs");
+	}
+
+	#[test]
+	fn test_insert_conflicting_parent() {
+		let mut selected = Selected::new();
+		let parent_url = Url::from(Path::new("/a"));
+		let child_url = Url::from(Path::new("/a/b"));
+
+		assert!(selected.insert(parent_url), "Should successfully insert parent_url");
+		assert!(!selected.insert(child_url), "Should fail to insert child_url due to conflict");
+	}
+
+	#[test]
+	fn test_insert_conflicting_child() {
+		let mut selected = Selected::new();
+		let child_url = Url::from(Path::new("/a/b/c"));
+		let parent_url = Url::from(Path::new("/a/b"));
+		let sibling_url = Url::from(Path::new("/a/b/d"));
+
+		assert!(selected.insert(child_url), "Should successfully insert child_url");
+		assert!(!selected.insert(parent_url), "Should fail to insert parent_url due to conflict");
+		assert!(selected.insert(sibling_url), "Should successfully insert sibling_url");
+	}
+
+	#[test]
+	fn test_remove() {
+		let mut selected = Selected::new();
+		let url = Url::from(Path::new("/a/b"));
+
+		assert!(selected.insert(url.clone()), "Should successfully insert url");
+		assert!(selected.remove(&url), "Should successfully remove url");
+		assert!(selected.inner.is_empty(), "Inner set should be empty after removal");
+		assert!(selected.parents.is_empty(), "Parents map should be empty after removal");
+	}
+}

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -81,15 +81,13 @@ impl Selected {
 
 #[cfg(test)]
 mod tests {
-	use std::path::Path;
-
 	use super::*;
 
 	#[test]
 	fn test_insert_non_conflicting() {
 		let mut selected = Selected::default();
-		let url1 = Url::from(Path::new("/a/b"));
-		let url2 = Url::from(Path::new("/c/d"));
+		let url1 = Url::from("/a/b");
+		let url2 = Url::from("/c/d");
 
 		assert!(selected.insert(url1));
 		assert!(selected.insert(url2));
@@ -99,8 +97,8 @@ mod tests {
 	#[test]
 	fn test_insert_conflicting_parent() {
 		let mut selected = Selected::default();
-		let parent_url = Url::from(Path::new("/a"));
-		let child_url = Url::from(Path::new("/a/b"));
+		let parent_url = Url::from("/a");
+		let child_url = Url::from("/a/b");
 
 		assert!(selected.insert(parent_url));
 		assert!(!selected.insert(child_url));
@@ -109,9 +107,9 @@ mod tests {
 	#[test]
 	fn test_insert_conflicting_child() {
 		let mut selected = Selected::default();
-		let child_url = Url::from(Path::new("/a/b/c"));
-		let parent_url = Url::from(Path::new("/a/b"));
-		let sibling_url = Url::from(Path::new("/a/b/d"));
+		let child_url = Url::from("/a/b/c");
+		let parent_url = Url::from("/a/b");
+		let sibling_url = Url::from("/a/b/d");
 
 		assert!(selected.insert(child_url));
 		assert!(!selected.insert(parent_url));
@@ -121,7 +119,7 @@ mod tests {
 	#[test]
 	fn test_remove() {
 		let mut selected = Selected::default();
-		let url = Url::from(Path::new("/a/b"));
+		let url = Url::from("/a/b");
 
 		assert!(selected.insert(url.clone()));
 		assert!(selected.remove(&url));
@@ -132,9 +130,9 @@ mod tests {
 	#[test]
 	fn insert_many_success() {
 		let mut selected = Selected::default();
-		let child1 = Url::from(Path::new("/parent/child1"));
-		let child2 = Url::from(Path::new("/parent/child2"));
-		let child3 = Url::from(Path::new("/parent/child3"));
+		let child1 = Url::from("/parent/child1");
+		let child2 = Url::from("/parent/child2");
+		let child3 = Url::from("/parent/child3");
 		let urls = vec![&child1, &child2, &child3];
 		assert!(selected.insert_many(&urls));
 	}
@@ -142,10 +140,10 @@ mod tests {
 	#[test]
 	fn insert_many_with_existing_parent_fails() {
 		let mut selected = Selected::default();
-		selected.insert(Url::from(Path::new("/parent")));
+		selected.insert(Url::from("/parent"));
 
-		let child1 = Url::from(Path::new("/parent/child1"));
-		let child2 = Url::from(Path::new("/parent/child2"));
+		let child1 = Url::from("/parent/child1");
+		let child2 = Url::from("/parent/child2");
 		let urls = vec![&child1, &child2];
 		assert!(!selected.insert_many(&urls));
 	}
@@ -153,11 +151,11 @@ mod tests {
 	#[test]
 	fn insert_many_with_existing_child_fails() {
 		let mut selected = Selected::default();
-		let child = Url::from(Path::new("/parent/child1"));
+		let child = Url::from("/parent/child1");
 		selected.insert(child);
 
-		let child1 = Url::from(Path::new("/parent/child1"));
-		let child2 = Url::from(Path::new("/parent/child2"));
+		let child1 = Url::from("/parent/child1");
+		let child2 = Url::from("/parent/child2");
 		let urls = vec![&child1, &child2];
 		assert!(selected.insert_many(&urls));
 	}
@@ -171,17 +169,17 @@ mod tests {
 	#[test]
 	fn insert_many_with_parent_as_child_of_another_url() {
 		let mut selected = Selected::default();
-		selected.insert(Url::from(Path::new("/parent/child")));
-		let child1 = Url::from(Path::new("/parent/child/child1"));
-		let child2 = Url::from(Path::new("/parent/child/child2"));
+		selected.insert(Url::from("/parent/child"));
+		let child1 = Url::from("/parent/child/child1");
+		let child2 = Url::from("/parent/child/child2");
 		let urls = vec![&child1, &child2];
 		assert!(!selected.insert_many(&urls));
 	}
 	#[test]
 	fn insert_many_with_direct_parent_fails() {
 		let mut selected = Selected::default();
-		selected.insert(Url::from(Path::new("/a")));
-		let binding = Url::from(Path::new("/a/b"));
+		selected.insert(Url::from("/a"));
+		let binding = Url::from("/a/b");
 		let urls = vec![&binding];
 		assert!(!selected.insert_many(&urls));
 	}
@@ -189,8 +187,8 @@ mod tests {
 	#[test]
 	fn insert_many_with_nested_child_fails() {
 		let mut selected = Selected::default();
-		selected.insert(Url::from(Path::new("/a/b")));
-		let binding = Url::from(Path::new("/a"));
+		selected.insert(Url::from("/a/b"));
+		let binding = Url::from("/a");
 		let urls = vec![&binding];
 		assert!(!selected.insert_many(&urls));
 	}
@@ -198,8 +196,8 @@ mod tests {
 	#[test]
 	fn insert_many_sibling_directories_success() {
 		let mut selected = Selected::default();
-		let child1 = Url::from(Path::new("/a/b"));
-		let child2 = Url::from(Path::new("/a/c"));
+		let child1 = Url::from("/a/b");
+		let child2 = Url::from("/a/c");
 		let urls = vec![&child1, &child2];
 		assert!(selected.insert_many(&urls));
 	}
@@ -207,8 +205,8 @@ mod tests {
 	#[test]
 	fn insert_many_with_grandchild_fails() {
 		let mut selected = Selected::default();
-		selected.insert(Url::from(Path::new("/a/b")));
-		let binding = Url::from(Path::new("/a/b/c"));
+		selected.insert(Url::from("/a/b"));
+		let binding = Url::from("/a/b/c");
 		let urls = vec![&binding];
 		assert!(!selected.insert_many(&urls));
 	}
@@ -216,9 +214,9 @@ mod tests {
 	#[test]
 	fn test_insert_many_with_remove() {
 		let mut selected = Selected::default();
-		let child1 = Url::from(Path::new("/parent/child1"));
-		let child2 = Url::from(Path::new("/parent/child2"));
-		let child3 = Url::from(Path::new("/parent/child3"));
+		let child1 = Url::from("/parent/child1");
+		let child2 = Url::from("/parent/child2");
+		let child3 = Url::from("/parent/child3");
 		let urls = vec![&child1, &child2, &child3];
 		assert!(selected.insert_many(&urls));
 		assert!(selected.remove(&child1));

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -9,6 +9,9 @@ pub struct Selected {
 }
 
 impl Selected {
+	pub fn get_inner(&self)->BTreeSet<Url>{
+		return self.inner.clone()
+	}
 	pub fn new() -> Self { Selected { inner: BTreeSet::new(), parents: HashMap::new() } }
 
 	pub fn insert(&mut self, url: Url) -> bool { self.insert_many(&[&url]) }
@@ -74,6 +77,9 @@ impl Selected {
 	}
 
 	pub fn iter(&self) -> std::collections::btree_set::Iter<Url> { self.inner.iter() }
+	pub fn contains(&self,url:&Url)->bool{
+		self.inner.contains(url)
+	}
 }
 #[cfg(test)]
 mod tests {

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -18,23 +18,22 @@ impl Selected {
 			return true;
 		}
 
-		let mut current_path = urls[0].clone();
-		while let Some(parent) = current_path.parent_url() {
-			if self.inner.contains(&parent) {
+		let mut parent = urls[0].parent_url();
+		while let Some(u) = parent {
+			if self.inner.contains(&u) {
 				return false;
 			}
-			current_path = parent;
+			parent = u.parent_url();
 		}
 
 		if self.parents.contains_key(urls[0]) {
 			return false;
 		}
 
-		let mut current_path = urls[0].clone();
-		let len_of_urls = urls.len();
-		while let Some(parent) = current_path.parent_url() {
-			current_path = parent;
-			*self.parents.entry(current_path.clone()).or_insert(0) += len_of_urls;
+		let mut parent = urls[0].parent_url();
+		while let Some(u) = parent {
+			parent = u.parent_url();
+			*self.parents.entry(u).or_insert(0) += urls.len();
 		}
 
 		self.inner.extend(urls.iter().cloned().cloned());

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -17,6 +17,47 @@ impl Deref for Selected {
 impl Selected {
 	pub fn add(&mut self, url: &Url) -> bool { self.add_many(&[url]) }
 
+	/// Adds a list of URLs to the user structure.
+	///
+	/// This method attempts to add a slice of `Url` references to the internal
+	/// structure, ensuring that all URLs have the same parent directory. For
+	/// example, URLs such as `/a/b/c`, `/a/b/d`, `/a/b/e`, and `/a/b/f` are
+	/// acceptable, while `/a/b/c` and `/a/e/f` would not be, due to differing
+	/// parent directories.
+	///
+	/// The addition will fail under the following conditions:
+	/// - Any of the URLs already exists within the `inner` collection.
+	/// - The parent directory of the URLs already exists as a key in the
+	///   `parents` map.
+	///
+	/// When the provided list of URLs is empty, the method will return `true` as
+	/// there are no URLs to process, which is considered a successful operation.
+	///
+	/// # Arguments
+	///
+	/// * `urls` - A slice of references to `Url` objects that are to be added.
+	/// All URLs should have the same parent path.
+	///
+	/// # Returns
+	///
+	/// Returns `true` if all URLs were successfully added, or if the input list
+	/// is empty. Returns `false` if any URL could not be added due to the
+	/// existence of its parent directory in the structure, or if the URL itself
+	/// is already present.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// #
+	/// # use yazi_core::select::Select;
+	/// # use yazi_shared::fs::Url;
+	/// let mut selected= Select::default();
+	/// let url1 = Url::from("/a/b/c");
+	/// let url2 = Url::from("/a/b/d");
+	/// let urls = vec![&url1, &url2];
+	///
+	/// assert!(selected.add_many(&urls));
+	/// ```
 	pub fn add_many(&mut self, urls: &[&Url]) -> bool {
 		if urls.is_empty() {
 			return true;

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -15,8 +15,9 @@ impl Selected {
 
 	pub fn insert_many(&mut self, urls: &[&Url]) -> bool {
 		if urls.is_empty() {
-			return false;
+			return true;
 		}
+
 		let url_buf = urls[0].to_path_buf();
 
 		let mut current_path = url_buf.clone();
@@ -143,9 +144,9 @@ mod tests {
 		let mut selected = Selected::default();
 		selected.insert(Url::from(Path::new("/parent")));
 
-		let childs1 = Url::from(Path::new("/parent/child1"));
-		let childs2 = Url::from(Path::new("/parent/child2"));
-		let urls = vec![&childs1, &childs2];
+		let child1 = Url::from(Path::new("/parent/child1"));
+		let child2 = Url::from(Path::new("/parent/child2"));
+		let urls = vec![&child1, &child2];
 		assert!(!selected.insert_many(&urls), "Should fail to insert since parent already exists");
 	}
 
@@ -167,8 +168,7 @@ mod tests {
 	#[test]
 	fn insert_many_empty_urls_list() {
 		let mut selected = Selected::default();
-		let urls = vec![];
-		assert!(!selected.insert_many(&urls), "Inserting an empty list of urls should false");
+		assert!(selected.insert_many(&[]), "Inserting an empty list of urls should false");
 	}
 
 	#[test]

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -9,10 +9,7 @@ pub struct Selected {
 }
 
 impl Selected {
-	pub fn get_inner(&self)->BTreeSet<Url>{
-		return self.inner.clone()
-	}
-	pub fn new() -> Self { Selected { inner: BTreeSet::new(), parents: HashMap::new() } }
+	pub fn get_inner(&self) -> BTreeSet<Url> { self.inner.clone() }
 
 	pub fn insert(&mut self, url: Url) -> bool { self.insert_many(&[&url]) }
 
@@ -50,7 +47,7 @@ impl Selected {
 	}
 
 	pub fn remove(&mut self, url: &Url) -> bool {
-		if !self.inner.remove(&url) {
+		if !self.inner.remove(url) {
 			return false;
 		}
 
@@ -66,7 +63,7 @@ impl Selected {
 				self.parents.remove(&current_path);
 			}
 		}
-		return true;
+		true
 	}
 
 	pub fn is_empty(&self) -> bool { self.inner.is_empty() }
@@ -77,10 +74,10 @@ impl Selected {
 	}
 
 	pub fn iter(&self) -> std::collections::btree_set::Iter<Url> { self.inner.iter() }
-	pub fn contains(&self,url:&Url)->bool{
-		self.inner.contains(url)
-	}
+
+	pub fn contains(&self, url: &Url) -> bool { self.inner.contains(url) }
 }
+
 #[cfg(test)]
 mod tests {
 	use std::path::Path;
@@ -89,7 +86,7 @@ mod tests {
 
 	#[test]
 	fn test_insert_non_conflicting() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let url1 = Url::from(Path::new("/a/b"));
 		let url2 = Url::from(Path::new("/c/d"));
 
@@ -100,7 +97,7 @@ mod tests {
 
 	#[test]
 	fn test_insert_conflicting_parent() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let parent_url = Url::from(Path::new("/a"));
 		let child_url = Url::from(Path::new("/a/b"));
 
@@ -110,7 +107,7 @@ mod tests {
 
 	#[test]
 	fn test_insert_conflicting_child() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let child_url = Url::from(Path::new("/a/b/c"));
 		let parent_url = Url::from(Path::new("/a/b"));
 		let sibling_url = Url::from(Path::new("/a/b/d"));
@@ -122,7 +119,7 @@ mod tests {
 
 	#[test]
 	fn test_remove() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let url = Url::from(Path::new("/a/b"));
 
 		assert!(selected.insert(url.clone()), "Should successfully insert url");
@@ -133,7 +130,7 @@ mod tests {
 
 	#[test]
 	fn insert_many_success() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let child1 = Url::from(Path::new("/parent/child1"));
 		let child2 = Url::from(Path::new("/parent/child2"));
 		let child3 = Url::from(Path::new("/parent/child3"));
@@ -143,7 +140,7 @@ mod tests {
 
 	#[test]
 	fn insert_many_with_existing_parent_fails() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		selected.insert(Url::from(Path::new("/parent")));
 
 		let childs1 = Url::from(Path::new("/parent/child1"));
@@ -154,7 +151,7 @@ mod tests {
 
 	#[test]
 	fn insert_many_with_existing_child_fails() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let child = Url::from(Path::new("/parent/child1"));
 		selected.insert(child);
 
@@ -169,14 +166,14 @@ mod tests {
 
 	#[test]
 	fn insert_many_empty_urls_list() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let urls = vec![];
 		assert!(!selected.insert_many(&urls), "Inserting an empty list of urls should false");
 	}
 
 	#[test]
 	fn insert_many_with_parent_as_child_of_another_url() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		selected.insert(Url::from(Path::new("/parent/child")));
 		let child1 = Url::from(Path::new("/parent/child/child1"));
 		let child2 = Url::from(Path::new("/parent/child/child2"));
@@ -188,7 +185,7 @@ mod tests {
 	}
 	#[test]
 	fn insert_many_with_direct_parent_fails() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		selected.insert(Url::from(Path::new("/a")));
 		let binding = Url::from(Path::new("/a/b"));
 		let urls = vec![&binding];
@@ -200,7 +197,7 @@ mod tests {
 
 	#[test]
 	fn insert_many_with_nested_child_fails() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		selected.insert(Url::from(Path::new("/a/b")));
 		let binding = Url::from(Path::new("/a"));
 		let urls = vec![&binding];
@@ -212,7 +209,7 @@ mod tests {
 
 	#[test]
 	fn insert_many_sibling_directories_success() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let child1 = Url::from(Path::new("/a/b"));
 		let child2 = Url::from(Path::new("/a/c"));
 		let urls = vec![&child1, &child2];
@@ -221,7 +218,7 @@ mod tests {
 
 	#[test]
 	fn insert_many_with_grandchild_fails() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		selected.insert(Url::from(Path::new("/a/b")));
 		let binding = Url::from(Path::new("/a/b/c"));
 		let urls = vec![&binding];
@@ -232,17 +229,17 @@ mod tests {
 	}
 	#[test]
 	fn test_insert_many_with_remove() {
-		let mut selected = Selected::new();
+		let mut selected = Selected::default();
 		let child1 = Url::from(Path::new("/parent/child1"));
 		let child2 = Url::from(Path::new("/parent/child2"));
 		let child3 = Url::from(Path::new("/parent/child3"));
 		let urls = vec![&child1, &child2, &child3];
 		assert!(selected.insert_many(&urls), "Should successfully insert urls with the same parent");
 		assert!(selected.remove(&child1), "Should successfully remove url");
-		assert_eq!(selected.inner.len(),2);
-		assert!(!selected.parents.is_empty(),"parent map should not be empty");
+		assert_eq!(selected.inner.len(), 2);
+		assert!(!selected.parents.is_empty(), "parent map should not be empty");
 		assert!(selected.remove(&child2), "Should successfully remove url");
-		assert!(!selected.parents.is_empty(),"parent map should not be empty");
+		assert!(!selected.parents.is_empty(), "parent map should not be empty");
 		assert!(selected.remove(&child3), "Should successfully remove url");
 
 		assert!(selected.inner.is_empty(), "Inner set should be empty after removal");

--- a/yazi-core/src/tab/tab.rs
+++ b/yazi-core/src/tab/tab.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use anyhow::Result;
 use tokio::task::JoinHandle;
 use yazi_shared::{fs::Url, render};
 
 use super::{Backstack, Config, Finder, Mode, Preview};
-use crate::folder::{Folder, FolderStage};
+use crate::{folder::{Folder, FolderStage}, tab::selected::Selected};
 
 pub struct Tab {
 	pub mode:    Mode,
@@ -15,7 +15,7 @@ pub struct Tab {
 
 	pub backstack: Backstack<Url>,
 	pub history:   BTreeMap<Url, Folder>,
-	pub selected:  BTreeSet<Url>,
+	pub selected:  Selected,
 
 	pub preview:       Preview,
 	pub finder:        Option<Finder>,

--- a/yazi-fm/src/lives/tab.rs
+++ b/yazi-fm/src/lives/tab.rs
@@ -41,7 +41,7 @@ impl Tab {
 				me.parent.as_ref().map(|f| Folder::make(None, f, me)).transpose()
 			});
 
-			reg.add_field_method_get("selected", |_, me| Selected::make(&me.selected.get_inner()));
+			reg.add_field_method_get("selected", |_, me| Selected::make(&me.selected));
 
 			reg.add_field_method_get("preview", |_, me| Preview::make(me));
 		})?;

--- a/yazi-fm/src/lives/tab.rs
+++ b/yazi-fm/src/lives/tab.rs
@@ -41,7 +41,7 @@ impl Tab {
 				me.parent.as_ref().map(|f| Folder::make(None, f, me)).transpose()
 			});
 
-			reg.add_field_method_get("selected", |_, me| Selected::make(&me.selected));
+			reg.add_field_method_get("selected", |_, me| Selected::make(&me.selected.get_inner()));
 
 			reg.add_field_method_get("preview", |_, me| Preview::make(me));
 		})?;


### PR DESCRIPTION
I implemented conflict path detection using HashMap. Using a prefix tree might also be a worthwhile option to consider.

Closes https://github.com/sxyazi/yazi/issues/688