### PR TITLE
fix: allow running `ya.sync` in a sync plugin call

### DIFF
--- a/yazi-plugin/preset/ya.lua
+++ b/yazi-plugin/preset/ya.lua
@@ -29,6 +29,10 @@ function ya.flat(t)
 end
 
 function ya.sync(f)
+	if ya.SYNC_ON then
+		return function(...) f(...) end
+	end
+
 	YAZI_SYNC_BLOCKS = YAZI_SYNC_BLOCKS + 1
 	if YAZI_SYNC_CALLS == YAZI_SYNC_BLOCKS then
 		YAZI_SYNC_ENTRY = f


### PR DESCRIPTION
This fixes a issue (yazi would panic) I encountered when calling an async plugin that uses `ya.sync` synchronously, which happened because I was creating a `setup` function for a plugin.