### PR TITLE
fix: initialize logs right after configurations

### DIFF
--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -6,7 +6,7 @@ use yazi_config::keymap::Key;
 use yazi_core::input::InputMode;
 use yazi_shared::{emit, event::{Cmd, Event, NEED_RENDER}, term::Term, Layer};
 
-use crate::{lives::Lives, Ctx, Executor, Panic, Router, Signals};
+use crate::{lives::Lives, Ctx, Executor, Router, Signals};
 
 pub(crate) struct App {
 	pub(crate) cx:      Ctx,
@@ -16,7 +16,6 @@ pub(crate) struct App {
 
 impl App {
 	pub(crate) async fn run() -> Result<()> {
-		Panic::install();
 		let term = Term::start()?;
 		let signals = Signals::start()?;
 

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -6,7 +6,7 @@ use yazi_config::keymap::Key;
 use yazi_core::input::InputMode;
 use yazi_shared::{emit, event::{Cmd, Event, NEED_RENDER}, term::Term, Layer};
 
-use crate::{lives::Lives, Ctx, Executor, Logs, Panic, Router, Signals};
+use crate::{lives::Lives, Ctx, Executor, Panic, Router, Signals};
 
 pub(crate) struct App {
 	pub(crate) cx:      Ctx,
@@ -17,7 +17,6 @@ pub(crate) struct App {
 impl App {
 	pub(crate) async fn run() -> Result<()> {
 		Panic::install();
-		let _log = Logs::init()?;
 		let term = Term::start()?;
 		let signals = Signals::start()?;
 

--- a/yazi-fm/src/logs.rs
+++ b/yazi-fm/src/logs.rs
@@ -1,21 +1,21 @@
-use anyhow::{Context, Result};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt, prelude::__tracing_subscriber_SubscriberExt, Registry};
-use yazi_boot::BOOT;
+use yazi_shared::{RoCell, Xdg};
+
+static _GUARD: RoCell<WorkerGuard> = RoCell::new();
 
 pub(super) struct Logs;
 
 impl Logs {
-	pub(super) fn init() -> Result<WorkerGuard> {
-		let appender = tracing_appender::rolling::never(&BOOT.state_dir, "yazi.log");
+	pub(super) fn start() {
+		let appender = tracing_appender::rolling::never(Xdg::state_dir().unwrap(), "yazi.log");
 		let (handle, guard) = tracing_appender::non_blocking(appender);
 
 		// let filter = EnvFilter::from_default_env();
 		let subscriber = Registry::default().with(fmt::layer().pretty().with_writer(handle));
 
-		tracing::subscriber::set_global_default(subscriber)
-			.context("setting default subscriber failed")?;
+		tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-		Ok(guard)
+		_GUARD.init(guard);
 	}
 }

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -35,8 +35,10 @@ use signals::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+	Panic::install();
+	Logs::start();
+
 	_ = fdlimit::raise_fd_limit();
-	// console_subscriber::init();
 
 	yazi_config::init();
 


### PR DESCRIPTION
As we talked in https://github.com/sxyazi/yazi/issues/703#issuecomment-1954797994 this PR makes it so that the logs are initialized in the beginning of the application.

I made it run right after the `yazi_config::init();` because I'm not sure if there's any log that might occur if any error ever happens when initializing `yazy_core` or the `yazi_scheduler`.