### PR TITLE
Change Defaults of Displaying Files/Dirs

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -4,12 +4,12 @@
 
 [manager]
 ratio          = [ 1, 4, 3 ]
-sort_by        = "alphabetical"
+sort_by        = "natural"
 sort_sensitive = false
 sort_reverse   = false
-sort_dir_first = false
+sort_dir_first = true
 linemode       = "none"
-show_hidden    = false
+show_hidden    = true
 show_symlink   = true
 scrolloff      = 5
 


### PR DESCRIPTION
Changing default way of display files/dirs to more commonly used. 

- sorting: alphabetical -> natural
- sort_dir_first: false -> true
- show_hidden: false -> true

I think it good to have some kind poll for users to vote. 
**Poll:** #741

**Option 1: after change**:
- sorting: alphabetical -> natural
- sort_dir_first: false -> true
- show_hidden: false -> true
After:
![20240227_13h41m26s_grim](https://github.com/sxyazi/yazi/assets/7127165/0092130c-80f0-4b50-bd9f-6c2063cc3179)

**Option 2: original**. :
Before, `show_hidden=false` (original):
![20240227_13h45m13s_grim](https://github.com/sxyazi/yazi/assets/7127165/ad6d7694-b6ea-4d1f-9609-e9551150df82)
I think most of the time we need to see hidden files.

**Option 3: original with show hidden**:
- show_hidden: false -> true
Before, with change `show_hidden=true`:
![20240227_13h44m55s_grim](https://github.com/sxyazi/yazi/assets/7127165/87a0e299-e5d4-4db2-83e6-f4b1c51611f0)
Files and dirs clashed together and not separated.