### PR TITLE
ci: add cachix workflow

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish Flake
-    runs-on: [ubuntu-latest, macos-latest-xlarge]
+    runs-on: [ubuntu-latest, macos-latest]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,26 @@
+# Publish the Nix flake outputs to Cachix
+name: Cachix
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish Flake
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v25
+
+    - name: Authenticate with Cachix
+      uses: cachix/cachix-action@v14
+      with:
+        name: yazi
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - name: Build nix flake
+      run: nix build -L

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish Flake
-    runs-on: [ubuntu-latest, macos-latest]
+    runs-on: [ubuntu-latest, macos-latest-xlarge]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish Flake
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4


### PR DESCRIPTION
First time setting cachix up, not sure if I'm doing anything wrong. I used the following resources for reference:
- https://github.com/helix-editor/helix/blob/master/.github/workflows/cachix.yml
- https://nix.dev/tutorials/nixos/continuous-integration-github-actions

You now need to set up the secrets, which can only be done by someone with the right privileges. Here are the steps from the official tutorial:

> ### 1. Creating your first binary cache
> 
> It's recommended to have different binary caches per team, depending who will have write/read access to it.
> 
> Fill out the form on the [create binary cache](https://app.cachix.org/cache) page.
> 
> On your freshly created binary cache, follow the **Push binaries** tab instructions.
> 
> ### 2. Setting up secrets
> 
> On your GitHub repository or organization (for use across all repositories):
> 
> 1. Click on `Settings`.
> 2. Click on `Secrets`.
> 3. Add your previously generated secrets (`CACHIX_SIGNING_KEY` and/or `CACHIX_AUTH_TOKEN`).

For this PR, I'm using the `CACHIX_AUTH_TOKEN` for the last step.

Fix: https://github.com/sxyazi/yazi/issues/495