### PR TITLE
ci: fix erroneous usage of runs-on in the cachix workflow

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   publish:
     name: Publish Flake
-    runs-on: [ubuntu-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4


### PR DESCRIPTION
Whoops, looks like I messed up the syntax. The job is currently stuck on `Waiting for a runner to pick up this job...`, because I'm not using the `runs-on` property correctly.

You need to use a matrix if you want the job to be run by multiple runners.