### PR TITLE
Allow both '\' and '/' character in folder creation

### DIFF
--- a/yazi-core/src/manager/commands/create.rs
+++ b/yazi-core/src/manager/commands/create.rs
@@ -32,7 +32,7 @@ impl Manager {
 				}
 			}
 
-			if name.ends_with(MAIN_SEPARATOR) {
+			if name.ends_with('/') || name.ends_with('\\') {
 				fs::create_dir_all(&path).await?;
 			} else {
 				fs::create_dir_all(&path.parent().unwrap()).await.ok();

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -75,13 +75,13 @@ impl Manager {
 			};
 
 			{
-				let s = old.iter().map(|o| o.as_os_str()).collect::<Vec<_>>().join(OsStr::new("\n"));
+				let s = old.iter().map(|o| o.display().to_string()).collect::<Vec<_>>().join("\n");
 				OpenOptions::new()
 					.write(true)
 					.create_new(true)
 					.open(&tmp)
 					.await?
-					.write_all(s.as_encoded_bytes())
+					.write_all(s.as_bytes())
 					.await?;
 			}
 

--- a/yazi-core/src/tab/commands/cd.rs
+++ b/yazi-core/src/tab/commands/cd.rs
@@ -72,7 +72,7 @@ impl Tab {
 		let opt = opt.into() as Opt;
 
 		tokio::spawn(async move {
-			let rx = Input::_show(InputCfg::cd().with_value(opt.target.to_string_lossy()));
+			let rx = Input::_show(InputCfg::cd().with_value(""));
 
 			let rx = Debounce::new(UnboundedReceiverStream::new(rx), Duration::from_millis(50));
 			pin!(rx);

--- a/yazi-core/src/tab/finder.rs
+++ b/yazi-core/src/tab/finder.rs
@@ -77,12 +77,12 @@ impl Finder {
 	}
 
 	#[inline]
-	fn matches(&self, name: &OsStr) -> bool { self.query.is_match(name.as_encoded_bytes()) }
+	fn matches(&self, name: &OsStr) -> bool { self.query.is_match(name.to_string_lossy().as_bytes()) }
 
 	/// Explode the name into three parts: head, body, tail.
 	#[inline]
 	pub fn highlighted(&self, name: &OsStr) -> Option<Vec<Range<usize>>> {
-		self.query.find(name.as_encoded_bytes()).map(|m| vec![m.range()])
+		self.query.find(name.to_string_lossy().as_bytes()).map(|m| vec![m.range()])
 	}
 }
 

--- a/yazi-core/src/tasks/commands/open.rs
+++ b/yazi-core/src/tasks/commands/open.rs
@@ -30,13 +30,9 @@ impl Tasks {
 		};
 
 		if let Some(p) = &BOOT.chooser_file {
-			let paths = opt.targets.into_iter().fold(OsString::new(), |mut s, (p, _)| {
-				s.push(p);
-				s.push("\n");
-				s
-			});
+			let paths = opt.targets.into_iter().map(|(p, _)| p.to_string_lossy().to_string()).collect::<Vec<_>>().join("\n");
 
-			std::fs::write(p, paths.as_encoded_bytes()).ok();
+			std::fs::write(p, paths.as_bytes()).ok();
 			emit!(Quit(false));
 			return false;
 		}

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -43,8 +43,8 @@ impl App {
 
 	fn dispatch_quit(&mut self, no_cwd_file: bool) {
 		if let Some(p) = BOOT.cwd_file.as_ref().filter(|_| !no_cwd_file) {
-			let cwd = self.cx.manager.cwd().as_os_str();
-			std::fs::write(p, cwd.as_encoded_bytes()).ok();
+			let cwd = self.cx.manager.cwd();
+			std::fs::write(p, cwd.display().to_string().as_bytes()).ok();
 		}
 		Term::goodbye(|| false);
 	}

--- a/yazi-shared/src/fs/path.rs
+++ b/yazi-shared/src/fs/path.rs
@@ -48,8 +48,7 @@ pub fn expand_path(p: impl AsRef<Path>) -> PathBuf { _expand_path(p.as_ref()) }
 
 #[inline]
 pub fn ends_with_slash(p: &Path) -> bool {
-	let b = p.as_os_str().as_encoded_bytes();
-	if let [.., last] = b { *last == MAIN_SEPARATOR as u8 } else { false }
+	p.display().to_string().ends_with(MAIN_SEPARATOR)
 }
 
 pub async fn unique_path(mut p: Url) -> Url {

--- a/yazi-shared/src/fs/url.rs
+++ b/yazi-shared/src/fs/url.rs
@@ -107,7 +107,8 @@ impl ToString for Url {
 			UrlScheme::Archive => "archive://",
 		};
 
-		let path = percent_encode(self.path.as_os_str().as_encoded_bytes(), ENCODE_SET);
+		let path_str = self.path.display().to_string();
+		let path = percent_encode(path_str.as_bytes(), ENCODE_SET);
 		let frag = self.frag.as_ref().map(|s| format!("#{s}")).unwrap_or_default();
 		format!("{scheme}{path}{frag}")
 	}


### PR DESCRIPTION
To create folder on Windows, currently I have to use `\`. But this character is hard to type. So, for convenient sake, let's allow both `/` and `\` just in folder creation operation.