### PR TITLE
feat: allow both `/` and `\` in folder creation

### DIFF
--- a/yazi-core/src/manager/commands/create.rs
+++ b/yazi-core/src/manager/commands/create.rs
@@ -32,7 +32,7 @@ impl Manager {
 				}
 			}
 
-			if name.ends_with(MAIN_SEPARATOR) {
+			if name.ends_with('/') || name.ends_with('\\') {
 				fs::create_dir_all(&path).await?;
 			} else {
 				fs::create_dir_all(&path.parent().unwrap()).await.ok();


### PR DESCRIPTION
On Windows, I have to use `\` for folder creation but this character is hard to type. So, for convenient sake, let's allow both `/` and `\` just in folder creation.