### PR TITLE
feat: support `YAZI_FILE_ONE` environment variable for `file(1)` path

### DIFF
--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -15,10 +15,10 @@ function M:preload()
 		urls[#urls + 1] = tostring(file.url)
 	end
 
-	local file_cmd_path = os.getenv("YAZI_FILE_CMD_PATH") or "file"
-	local child, code = Command(file_cmd_path):args({ "-bL", "--mime-type" }):args(urls):stdout(Command.PIPED):spawn()
+	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
+	local child, code = Command(cmd):args({ "-bL", "--mime-type" }):args(urls):stdout(Command.PIPED):spawn()
 	if not child then
-		ya.err(string.format("spawn `%s` command returns %s", file_cmd_path, tostring(code)))
+		ya.err(string.format("spawn `%s` command returns %s", cmd, code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -15,7 +15,8 @@ function M:preload()
 		urls[#urls + 1] = tostring(file.url)
 	end
 
-	local child, code = Command("file"):args({ "-bL", "--mime-type" }):args(urls):stdout(Command.PIPED):spawn()
+	local file_cmd_path = os.getenv("YAZI_FILE_CMD_PATH") or "file"
+	local child, code = Command(file_cmd_path):args({ "-bL", "--mime-type" }):args(urls):stdout(Command.PIPED):spawn()
 	if not child then
 		ya.err("spawn `file` command returns " .. tostring(code))
 		return 0

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -18,7 +18,7 @@ function M:preload()
 	local file_cmd_path = os.getenv("YAZI_FILE_CMD_PATH") or "file"
 	local child, code = Command(file_cmd_path):args({ "-bL", "--mime-type" }):args(urls):stdout(Command.PIPED):spawn()
 	if not child then
-		ya.err("spawn `file` command returns " .. tostring(code))
+		ya.err(string.format("spawn `%s` command returns %s", file_cmd_path, tostring(code)))
 		return 0
 	end
 


### PR DESCRIPTION
The `mime` plugin shall use `YAZI_FILE_CMD_PATH` to check mime type, if that environment variable does not exist, it call `file` directly.

This PR benefits mostly Windows users. Currently, Windows users have to add `Git\usr\bin` to PATH. But aside from the `file` command, this also add a lot more commands (`ls`, `less`, `cp`...). Those commands have conflicting names with Powershell or Nushell commands and can cause undesirable behavior.

The solution is to give yazi the path of `file` command via some form of configuration. Considering that `mime` is a lua plugin, an environment variable config is easier to implement.

**Note**: If this PR is accepted, we need to update the doc, but I can't find where it is.