### PR TITLE
feat: add `Ctrl-[` as an escape key

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -6,6 +6,7 @@
 
 keymap = [
 	{ on = [ "<Esc>" ], run = "escape",             desc = "Exit visual mode, clear selected, or cancel search" },
+	{ on = [ "<C-[>" ], run = "escape",             desc = "Exit visual mode, clear selected, or cancel search" },
 	{ on = [ "q" ],     run = "quit",               desc = "Exit the process" },
 	{ on = [ "Q" ],     run = "quit --no-cwd-file", desc = "Exit the process without writing cwd-file" },
 	{ on = [ "<C-q>" ], run = "close",              desc = "Close the current tab, or quit if it is last tab" },
@@ -154,6 +155,7 @@ keymap = [
 
 keymap = [
 	{ on = [ "<Esc>" ], run = "close", desc = "Hide the task manager" },
+	{ on = [ "<C-[>" ], run = "close", desc = "Hide the task manager" },
 	{ on = [ "<C-q>" ], run = "close", desc = "Hide the task manager" },
 	{ on = [ "w" ],     run = "close", desc = "Hide the task manager" },
 
@@ -172,8 +174,9 @@ keymap = [
 [select]
 
 keymap = [
-	{ on = [ "<C-q>" ],   run = "close",          desc = "Cancel selection" },
 	{ on = [ "<Esc>" ],   run = "close",          desc = "Cancel selection" },
+	{ on = [ "<C-[>" ],   run = "close",          desc = "Cancel selection" },
+	{ on = [ "<C-q>" ],   run = "close",          desc = "Cancel selection" },
 	{ on = [ "<Enter>" ], run = "close --submit", desc = "Submit the selection" },
 
 	{ on = [ "k" ], run = "arrow -1", desc = "Move cursor up" },
@@ -197,6 +200,7 @@ keymap = [
 	{ on = [ "<C-q>" ],   run = "close",          desc = "Cancel input" },
 	{ on = [ "<Enter>" ], run = "close --submit", desc = "Submit the input" },
 	{ on = [ "<Esc>" ],   run = "escape",         desc = "Go back the normal mode, or cancel input" },
+	{ on = [ "<C-[>" ],   run = "escape",         desc = "Go back the normal mode, or cancel input" },
 
 	# Mode
 	{ on = [ "i" ], run = "insert",                              desc = "Enter insert mode" },
@@ -279,6 +283,7 @@ keymap = [
 
 keymap = [
 	{ on = [ "<Esc>" ], run = "escape", desc = "Clear the filter, or hide the help" },
+	{ on = [ "<C-[>" ], run = "escape", desc = "Clear the filter, or hide the help" },
 	{ on = [ "q" ],     run = "close",  desc = "Exit the process" },
 	{ on = [ "<C-q>" ], run = "close",  desc = "Hide the help" },
 


### PR DESCRIPTION
In Vim, Ctrl + [ is an alternative to using the <Esc> key and behaves exactly the same way. This pull request adds that functionality to Yazi.

Also added ^ as a key to move to the beginning of the line, like in Vim. This is a little inaccurate as in Vim, the ^ key moves to the first non-whitespace character in a line, not to the beginning of the line, but I think for the use cases in Yazi, the ^ key being the same as the 0 key shouldn't be much of an issue.