### PR TITLE
refactor: add new `run` property

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -5,296 +5,296 @@
 [manager]
 
 keymap = [
-	{ on = [ "<Esc>" ], exec = "escape",             desc = "Exit visual mode, clear selected, or cancel search" },
-	{ on = [ "q" ],     exec = "quit",               desc = "Exit the process" },
-	{ on = [ "Q" ],     exec = "quit --no-cwd-file", desc = "Exit the process without writing cwd-file" },
-	{ on = [ "<C-q>" ], exec = "close",              desc = "Close the current tab, or quit if it is last tab" },
-	{ on = [ "<C-z>" ], exec = "suspend",            desc = "Suspend the process" },
+	{ on = [ "<Esc>" ], run = "escape",             desc = "Exit visual mode, clear selected, or cancel search" },
+	{ on = [ "q" ],     run = "quit",               desc = "Exit the process" },
+	{ on = [ "Q" ],     run = "quit --no-cwd-file", desc = "Exit the process without writing cwd-file" },
+	{ on = [ "<C-q>" ], run = "close",              desc = "Close the current tab, or quit if it is last tab" },
+	{ on = [ "<C-z>" ], run = "suspend",            desc = "Suspend the process" },
 
 	# Navigation
-	{ on = [ "k" ], exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "j" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "k" ], run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "j" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "K" ], exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "J" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "K" ], run = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "J" ], run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
-	{ on = [ "<S-Up>" ],   exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "<S-Down>" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "<S-Up>" ],   run = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "<S-Down>" ], run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
-	{ on = [ "<C-u>" ], exec = "arrow -50%",  desc = "Move cursor up half page" },
-	{ on = [ "<C-d>" ], exec = "arrow 50%",   desc = "Move cursor down half page" },
-	{ on = [ "<C-b>" ], exec = "arrow -100%", desc = "Move cursor up one page" },
-	{ on = [ "<C-f>" ], exec = "arrow 100%",  desc = "Move cursor down one page" },
+	{ on = [ "<C-u>" ], run = "arrow -50%",  desc = "Move cursor up half page" },
+	{ on = [ "<C-d>" ], run = "arrow 50%",   desc = "Move cursor down half page" },
+	{ on = [ "<C-b>" ], run = "arrow -100%", desc = "Move cursor up one page" },
+	{ on = [ "<C-f>" ], run = "arrow 100%",  desc = "Move cursor down one page" },
 
-	{ on = [ "<C-PageUp>" ],   exec = "arrow -50%",  desc = "Move cursor up half page" },
-	{ on = [ "<C-PageDown>" ], exec = "arrow 50%",   desc = "Move cursor down half page" },
-	{ on = [ "<PageUp>" ],     exec = "arrow -100%", desc = "Move cursor up one page" },
-	{ on = [ "<PageDown>" ],   exec = "arrow 100%",  desc = "Move cursor down one page" },
+	{ on = [ "<C-PageUp>" ],   run = "arrow -50%",  desc = "Move cursor up half page" },
+	{ on = [ "<C-PageDown>" ], run = "arrow 50%",   desc = "Move cursor down half page" },
+	{ on = [ "<PageUp>" ],     run = "arrow -100%", desc = "Move cursor up one page" },
+	{ on = [ "<PageDown>" ],   run = "arrow 100%",  desc = "Move cursor down one page" },
 
-	{ on = [ "h" ], exec = "leave", desc = "Go back to the parent directory" },
-	{ on = [ "l" ], exec = "enter", desc = "Enter the child directory" },
+	{ on = [ "h" ], run = "leave", desc = "Go back to the parent directory" },
+	{ on = [ "l" ], run = "enter", desc = "Enter the child directory" },
 
-	{ on = [ "H" ], exec = "back",    desc = "Go back to the previous directory" },
-	{ on = [ "L" ], exec = "forward", desc = "Go forward to the next directory" },
+	{ on = [ "H" ], run = "back",    desc = "Go back to the previous directory" },
+	{ on = [ "L" ], run = "forward", desc = "Go forward to the next directory" },
 
-	{ on = [ "<A-k>" ], exec = "seek -5", desc = "Seek up 5 units in the preview" },
-	{ on = [ "<A-j>" ], exec = "seek 5",  desc = "Seek down 5 units in the preview" },
-	{ on = [ "<A-PageUp>" ],   exec = "seek -5", desc = "Seek up 5 units in the preview" },
-	{ on = [ "<A-PageDown>" ], exec = "seek 5",  desc = "Seek down 5 units in the preview" },
+	{ on = [ "<A-k>" ], run = "seek -5", desc = "Seek up 5 units in the preview" },
+	{ on = [ "<A-j>" ], run = "seek 5",  desc = "Seek down 5 units in the preview" },
+	{ on = [ "<A-PageUp>" ],   run = "seek -5", desc = "Seek up 5 units in the preview" },
+	{ on = [ "<A-PageDown>" ], run = "seek 5",  desc = "Seek down 5 units in the preview" },
 
-	{ on = [ "<Up>" ],    exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "<Down>" ],  exec = "arrow 1",  desc = "Move cursor down" },
-	{ on = [ "<Left>" ],  exec = "leave",    desc = "Go back to the parent directory" },
-	{ on = [ "<Right>" ], exec = "enter",    desc = "Enter the child directory" },
+	{ on = [ "<Up>" ],    run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<Down>" ],  run = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "<Left>" ],  run = "leave",    desc = "Go back to the parent directory" },
+	{ on = [ "<Right>" ], run = "enter",    desc = "Enter the child directory" },
 
-	{ on = [ "g", "g" ], exec = "arrow -99999999", desc = "Move cursor to the top" },
-	{ on = [ "G" ],      exec = "arrow 99999999",  desc = "Move cursor to the bottom" },
+	{ on = [ "g", "g" ], run = "arrow -99999999", desc = "Move cursor to the top" },
+	{ on = [ "G" ],      run = "arrow 99999999",  desc = "Move cursor to the bottom" },
 
 	# Selection
-	{ on = [ "<Space>" ], exec = [ "select --state=none", "arrow 1" ], desc = "Toggle the current selection state" },
-	{ on = [ "v" ],       exec = "visual_mode",                        desc = "Enter visual mode (selection mode)" },
-	{ on = [ "V" ],       exec = "visual_mode --unset",                desc = "Enter visual mode (unset mode)" },
-	{ on = [ "<C-a>" ],   exec = "select_all --state=true",            desc = "Select all files" },
-	{ on = [ "<C-r>" ],   exec = "select_all --state=none",            desc = "Inverse selection of all files" },
+	{ on = [ "<Space>" ], run = [ "select --state=none", "arrow 1" ], desc = "Toggle the current selection state" },
+	{ on = [ "v" ],       run = "visual_mode",                        desc = "Enter visual mode (selection mode)" },
+	{ on = [ "V" ],       run = "visual_mode --unset",                desc = "Enter visual mode (unset mode)" },
+	{ on = [ "<C-a>" ],   run = "select_all --state=true",            desc = "Select all files" },
+	{ on = [ "<C-r>" ],   run = "select_all --state=none",            desc = "Inverse selection of all files" },
 
 	# Operation
-	{ on = [ "o" ],         exec = "open",                       desc = "Open the selected files" },
-	{ on = [ "O" ],         exec = "open --interactive",         desc = "Open the selected files interactively" },
-	{ on = [ "<Enter>" ],   exec = "open",                       desc = "Open the selected files" },
-	{ on = [ "<C-Enter>" ], exec = "open --interactive",         desc = "Open the selected files interactively" },
-	{ on = [ "y" ],         exec = "yank",                       desc = "Copy the selected files" },
-	{ on = [ "Y" ],         exec = "unyank",                     desc = "Cancel the yank status of files" },
-	{ on = [ "x" ],         exec = "yank --cut",                 desc = "Cut the selected files" },
-	{ on = [ "p" ],         exec = "paste",                      desc = "Paste the files" },
-	{ on = [ "P" ],         exec = "paste --force",              desc = "Paste the files (overwrite if the destination exists)" },
-	{ on = [ "-" ],         exec = "link",                       desc = "Symlink the absolute path of files" },
-	{ on = [ "_" ],         exec = "link --relative",            desc = "Symlink the relative path of files" },
-	{ on = [ "d" ],         exec = "remove",                     desc = "Move the files to the trash" },
-	{ on = [ "D" ],         exec = "remove --permanently",       desc = "Permanently delete the files" },
-	{ on = [ "a" ],         exec = "create",                     desc = "Create a file or directory (ends with / for directories)" },
-	{ on = [ "r" ],         exec = "rename --cursor=before_ext", desc = "Rename a file or directory" },
-	{ on = [ ";" ],         exec = "shell",                      desc = "Run a shell command" },
-	{ on = [ ":" ],         exec = "shell --block",              desc = "Run a shell command (block the UI until the command finishes)" },
-	{ on = [ "." ],         exec = "hidden toggle",              desc = "Toggle the visibility of hidden files" },
-	{ on = [ "s" ],         exec = "search fd",                  desc = "Search files by name using fd" },
-	{ on = [ "S" ],         exec = "search rg",                  desc = "Search files by content using ripgrep" },
-	{ on = [ "<C-s>" ],     exec = "search none",                desc = "Cancel the ongoing search" },
-	{ on = [ "z" ],         exec = "jump zoxide",                desc = "Jump to a directory using zoxide" },
-	{ on = [ "Z" ],         exec = "jump fzf",                   desc = "Jump to a directory, or reveal a file using fzf" },
+	{ on = [ "o" ],         run = "open",                       desc = "Open the selected files" },
+	{ on = [ "O" ],         run = "open --interactive",         desc = "Open the selected files interactively" },
+	{ on = [ "<Enter>" ],   run = "open",                       desc = "Open the selected files" },
+	{ on = [ "<C-Enter>" ], run = "open --interactive",         desc = "Open the selected files interactively" },
+	{ on = [ "y" ],         run = "yank",                       desc = "Copy the selected files" },
+	{ on = [ "Y" ],         run = "unyank",                     desc = "Cancel the yank status of files" },
+	{ on = [ "x" ],         run = "yank --cut",                 desc = "Cut the selected files" },
+	{ on = [ "p" ],         run = "paste",                      desc = "Paste the files" },
+	{ on = [ "P" ],         run = "paste --force",              desc = "Paste the files (overwrite if the destination exists)" },
+	{ on = [ "-" ],         run = "link",                       desc = "Symlink the absolute path of files" },
+	{ on = [ "_" ],         run = "link --relative",            desc = "Symlink the relative path of files" },
+	{ on = [ "d" ],         run = "remove",                     desc = "Move the files to the trash" },
+	{ on = [ "D" ],         run = "remove --permanently",       desc = "Permanently delete the files" },
+	{ on = [ "a" ],         run = "create",                     desc = "Create a file or directory (ends with / for directories)" },
+	{ on = [ "r" ],         run = "rename --cursor=before_ext", desc = "Rename a file or directory" },
+	{ on = [ ";" ],         run = "shell",                      desc = "Run a shell command" },
+	{ on = [ ":" ],         run = "shell --block",              desc = "Run a shell command (block the UI until the command finishes)" },
+	{ on = [ "." ],         run = "hidden toggle",              desc = "Toggle the visibility of hidden files" },
+	{ on = [ "s" ],         run = "search fd",                  desc = "Search files by name using fd" },
+	{ on = [ "S" ],         run = "search rg",                  desc = "Search files by content using ripgrep" },
+	{ on = [ "<C-s>" ],     run = "search none",                desc = "Cancel the ongoing search" },
+	{ on = [ "z" ],         run = "jump zoxide",                desc = "Jump to a directory using zoxide" },
+	{ on = [ "Z" ],         run = "jump fzf",                   desc = "Jump to a directory, or reveal a file using fzf" },
 
 	# Linemode
-	{ on = [ "m", "s" ], exec = "linemode size",        desc = "Set linemode to size" },
-	{ on = [ "m", "p" ], exec = "linemode permissions", desc = "Set linemode to permissions" },
-	{ on = [ "m", "m" ], exec = "linemode mtime",       desc = "Set linemode to mtime" },
-	{ on = [ "m", "n" ], exec = "linemode none",        desc = "Set linemode to none" },
+	{ on = [ "m", "s" ], run = "linemode size",        desc = "Set linemode to size" },
+	{ on = [ "m", "p" ], run = "linemode permissions", desc = "Set linemode to permissions" },
+	{ on = [ "m", "m" ], run = "linemode mtime",       desc = "Set linemode to mtime" },
+	{ on = [ "m", "n" ], run = "linemode none",        desc = "Set linemode to none" },
 
 	# Copy
-	{ on = [ "c", "c" ], exec = "copy path",             desc = "Copy the absolute path" },
-	{ on = [ "c", "d" ], exec = "copy dirname",          desc = "Copy the path of the parent directory" },
-	{ on = [ "c", "f" ], exec = "copy filename",         desc = "Copy the name of the file" },
-	{ on = [ "c", "n" ], exec = "copy name_without_ext", desc = "Copy the name of the file without the extension" },
+	{ on = [ "c", "c" ], run = "copy path",             desc = "Copy the absolute path" },
+	{ on = [ "c", "d" ], run = "copy dirname",          desc = "Copy the path of the parent directory" },
+	{ on = [ "c", "f" ], run = "copy filename",         desc = "Copy the name of the file" },
+	{ on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy the name of the file without the extension" },
 
 	# Filter
-	{ on = [ "f" ], exec = "filter --smart", desc = "Filter the files" },
+	{ on = [ "f" ], run = "filter --smart", desc = "Filter the files" },
 
 	# Find
-	{ on = [ "/" ], exec = "find --smart",            desc = "Find next file" },
-	{ on = [ "?" ], exec = "find --previous --smart", desc = "Find previous file" },
-	{ on = [ "n" ], exec = "find_arrow",              desc = "Go to next found file" },
-	{ on = [ "N" ], exec = "find_arrow --previous",   desc = "Go to previous found file" },
+	{ on = [ "/" ], run = "find --smart",            desc = "Find next file" },
+	{ on = [ "?" ], run = "find --previous --smart", desc = "Find previous file" },
+	{ on = [ "n" ], run = "find_arrow",              desc = "Go to next found file" },
+	{ on = [ "N" ], run = "find_arrow --previous",   desc = "Go to previous found file" },
 
 	# Sorting
-	{ on = [ ",", "m" ], exec = "sort modified --dir-first",               desc = "Sort by modified time" },
-	{ on = [ ",", "M" ], exec = "sort modified --reverse --dir-first",     desc = "Sort by modified time (reverse)" },
-	{ on = [ ",", "c" ], exec = "sort created --dir-first",                desc = "Sort by created time" },
-	{ on = [ ",", "C" ], exec = "sort created --reverse --dir-first",      desc = "Sort by created time (reverse)" },
-	{ on = [ ",", "e" ], exec = "sort extension --dir-first",         	   desc = "Sort by extension" },
-	{ on = [ ",", "E" ], exec = "sort extension --reverse --dir-first",    desc = "Sort by extension (reverse)" },
-	{ on = [ ",", "a" ], exec = "sort alphabetical --dir-first",           desc = "Sort alphabetically" },
-	{ on = [ ",", "A" ], exec = "sort alphabetical --reverse --dir-first", desc = "Sort alphabetically (reverse)" },
-	{ on = [ ",", "n" ], exec = "sort natural --dir-first",                desc = "Sort naturally" },
-	{ on = [ ",", "N" ], exec = "sort natural --reverse --dir-first",      desc = "Sort naturally (reverse)" },
-	{ on = [ ",", "s" ], exec = "sort size --dir-first",                   desc = "Sort by size" },
-	{ on = [ ",", "S" ], exec = "sort size --reverse --dir-first",         desc = "Sort by size (reverse)" },
+	{ on = [ ",", "m" ], run = "sort modified --dir-first",               desc = "Sort by modified time" },
+	{ on = [ ",", "M" ], run = "sort modified --reverse --dir-first",     desc = "Sort by modified time (reverse)" },
+	{ on = [ ",", "c" ], run = "sort created --dir-first",                desc = "Sort by created time" },
+	{ on = [ ",", "C" ], run = "sort created --reverse --dir-first",      desc = "Sort by created time (reverse)" },
+	{ on = [ ",", "e" ], run = "sort extension --dir-first",         	   desc = "Sort by extension" },
+	{ on = [ ",", "E" ], run = "sort extension --reverse --dir-first",    desc = "Sort by extension (reverse)" },
+	{ on = [ ",", "a" ], run = "sort alphabetical --dir-first",           desc = "Sort alphabetically" },
+	{ on = [ ",", "A" ], run = "sort alphabetical --reverse --dir-first", desc = "Sort alphabetically (reverse)" },
+	{ on = [ ",", "n" ], run = "sort natural --dir-first",                desc = "Sort naturally" },
+	{ on = [ ",", "N" ], run = "sort natural --reverse --dir-first",      desc = "Sort naturally (reverse)" },
+	{ on = [ ",", "s" ], run = "sort size --dir-first",                   desc = "Sort by size" },
+	{ on = [ ",", "S" ], run = "sort size --reverse --dir-first",         desc = "Sort by size (reverse)" },
 
 	# Tabs
-	{ on = [ "t" ], exec = "tab_create --current", desc = "Create a new tab using the current path" },
+	{ on = [ "t" ], run = "tab_create --current", desc = "Create a new tab using the current path" },
 
-	{ on = [ "1" ], exec = "tab_switch 0", desc = "Switch to the first tab" },
-	{ on = [ "2" ], exec = "tab_switch 1", desc = "Switch to the second tab" },
-	{ on = [ "3" ], exec = "tab_switch 2", desc = "Switch to the third tab" },
-	{ on = [ "4" ], exec = "tab_switch 3", desc = "Switch to the fourth tab" },
-	{ on = [ "5" ], exec = "tab_switch 4", desc = "Switch to the fifth tab" },
-	{ on = [ "6" ], exec = "tab_switch 5", desc = "Switch to the sixth tab" },
-	{ on = [ "7" ], exec = "tab_switch 6", desc = "Switch to the seventh tab" },
-	{ on = [ "8" ], exec = "tab_switch 7", desc = "Switch to the eighth tab" },
-	{ on = [ "9" ], exec = "tab_switch 8", desc = "Switch to the ninth tab" },
+	{ on = [ "1" ], run = "tab_switch 0", desc = "Switch to the first tab" },
+	{ on = [ "2" ], run = "tab_switch 1", desc = "Switch to the second tab" },
+	{ on = [ "3" ], run = "tab_switch 2", desc = "Switch to the third tab" },
+	{ on = [ "4" ], run = "tab_switch 3", desc = "Switch to the fourth tab" },
+	{ on = [ "5" ], run = "tab_switch 4", desc = "Switch to the fifth tab" },
+	{ on = [ "6" ], run = "tab_switch 5", desc = "Switch to the sixth tab" },
+	{ on = [ "7" ], run = "tab_switch 6", desc = "Switch to the seventh tab" },
+	{ on = [ "8" ], run = "tab_switch 7", desc = "Switch to the eighth tab" },
+	{ on = [ "9" ], run = "tab_switch 8", desc = "Switch to the ninth tab" },
 
-	{ on = [ "[" ], exec = "tab_switch -1 --relative", desc = "Switch to the previous tab" },
-	{ on = [ "]" ], exec = "tab_switch 1 --relative",  desc = "Switch to the next tab" },
+	{ on = [ "[" ], run = "tab_switch -1 --relative", desc = "Switch to the previous tab" },
+	{ on = [ "]" ], run = "tab_switch 1 --relative",  desc = "Switch to the next tab" },
 
-	{ on = [ "{" ], exec = "tab_swap -1", desc = "Swap the current tab with the previous tab" },
-	{ on = [ "}" ], exec = "tab_swap 1",  desc = "Swap the current tab with the next tab" },
+	{ on = [ "{" ], run = "tab_swap -1", desc = "Swap the current tab with the previous tab" },
+	{ on = [ "}" ], run = "tab_swap 1",  desc = "Swap the current tab with the next tab" },
 
 	# Tasks
-	{ on = [ "w" ], exec = "tasks_show", desc = "Show the tasks manager" },
+	{ on = [ "w" ], run = "tasks_show", desc = "Show the tasks manager" },
 
 	# Goto
-	{ on = [ "g", "h" ],       exec = "cd ~",             desc = "Go to the home directory" },
-	{ on = [ "g", "c" ],       exec = "cd ~/.config",     desc = "Go to the config directory" },
-	{ on = [ "g", "d" ],       exec = "cd ~/Downloads",   desc = "Go to the downloads directory" },
-	{ on = [ "g", "t" ],       exec = "cd /tmp",          desc = "Go to the temporary directory" },
-	{ on = [ "g", "<Space>" ], exec = "cd --interactive", desc = "Go to a directory interactively" },
+	{ on = [ "g", "h" ],       run = "cd ~",             desc = "Go to the home directory" },
+	{ on = [ "g", "c" ],       run = "cd ~/.config",     desc = "Go to the config directory" },
+	{ on = [ "g", "d" ],       run = "cd ~/Downloads",   desc = "Go to the downloads directory" },
+	{ on = [ "g", "t" ],       run = "cd /tmp",          desc = "Go to the temporary directory" },
+	{ on = [ "g", "<Space>" ], run = "cd --interactive", desc = "Go to a directory interactively" },
 
 	# Help
-	{ on = [ "~" ], exec = "help", desc = "Open help" },
+	{ on = [ "~" ], run = "help", desc = "Open help" },
 ]
 
 [tasks]
 
 keymap = [
-	{ on = [ "<Esc>" ], exec = "close", desc = "Hide the task manager" },
-	{ on = [ "<C-q>" ], exec = "close", desc = "Hide the task manager" },
-	{ on = [ "w" ],     exec = "close", desc = "Hide the task manager" },
+	{ on = [ "<Esc>" ], run = "close", desc = "Hide the task manager" },
+	{ on = [ "<C-q>" ], run = "close", desc = "Hide the task manager" },
+	{ on = [ "w" ],     run = "close", desc = "Hide the task manager" },
 
-	{ on = [ "k" ], exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "j" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "k" ], run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "j" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "<Up>" ],   exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "<Down>" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "<Up>" ],   run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<Down>" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "<Enter>" ], exec = "inspect", desc = "Inspect the task" },
-	{ on = [ "x" ],       exec = "cancel",  desc = "Cancel the task" },
+	{ on = [ "<Enter>" ], run = "inspect", desc = "Inspect the task" },
+	{ on = [ "x" ],       run = "cancel",  desc = "Cancel the task" },
 
-	{ on = [ "~" ], exec = "help", desc = "Open help" }
+	{ on = [ "~" ], run = "help", desc = "Open help" }
 ]
 
 [select]
 
 keymap = [
-	{ on = [ "<C-q>" ],   exec = "close",          desc = "Cancel selection" },
-	{ on = [ "<Esc>" ],   exec = "close",          desc = "Cancel selection" },
-	{ on = [ "<Enter>" ], exec = "close --submit", desc = "Submit the selection" },
+	{ on = [ "<C-q>" ],   run = "close",          desc = "Cancel selection" },
+	{ on = [ "<Esc>" ],   run = "close",          desc = "Cancel selection" },
+	{ on = [ "<Enter>" ], run = "close --submit", desc = "Submit the selection" },
 
-	{ on = [ "k" ], exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "j" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "k" ], run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "j" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "K" ], exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "J" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "K" ], run = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "J" ], run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
-	{ on = [ "<Up>" ],   exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "<Down>" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "<Up>" ],   run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<Down>" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "<S-Up>" ],   exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "<S-Down>" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "<S-Up>" ],   run = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "<S-Down>" ], run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
-	{ on = [ "~" ], exec = "help", desc = "Open help" }
+	{ on = [ "~" ], run = "help", desc = "Open help" }
 ]
 
 [input]
 
 keymap = [
-	{ on = [ "<C-q>" ],   exec = "close",          desc = "Cancel input" },
-	{ on = [ "<Enter>" ], exec = "close --submit", desc = "Submit the input" },
-	{ on = [ "<Esc>" ],   exec = "escape",         desc = "Go back the normal mode, or cancel input" },
+	{ on = [ "<C-q>" ],   run = "close",          desc = "Cancel input" },
+	{ on = [ "<Enter>" ], run = "close --submit", desc = "Submit the input" },
+	{ on = [ "<Esc>" ],   run = "escape",         desc = "Go back the normal mode, or cancel input" },
 
 	# Mode
-	{ on = [ "i" ], exec = "insert",                              desc = "Enter insert mode" },
-	{ on = [ "a" ], exec = "insert --append",                     desc = "Enter append mode" },
-	{ on = [ "I" ], exec = [ "move -999", "insert" ],             desc = "Move to the BOL, and enter insert mode" },
-	{ on = [ "A" ], exec = [ "move 999", "insert --append" ],     desc = "Move to the EOL, and enter append mode" },
-	{ on = [ "v" ], exec = "visual",                              desc = "Enter visual mode" },
-	{ on = [ "V" ], exec = [ "move -999", "visual", "move 999" ], desc = "Enter visual mode and select all" },
+	{ on = [ "i" ], run = "insert",                              desc = "Enter insert mode" },
+	{ on = [ "a" ], run = "insert --append",                     desc = "Enter append mode" },
+	{ on = [ "I" ], run = [ "move -999", "insert" ],             desc = "Move to the BOL, and enter insert mode" },
+	{ on = [ "A" ], run = [ "move 999", "insert --append" ],     desc = "Move to the EOL, and enter append mode" },
+	{ on = [ "v" ], run = "visual",                              desc = "Enter visual mode" },
+	{ on = [ "V" ], run = [ "move -999", "visual", "move 999" ], desc = "Enter visual mode and select all" },
 
 	# Character-wise movement
-	{ on = [ "h" ],       exec = "move -1", desc = "Move back a character" },
-	{ on = [ "l" ],       exec = "move 1",  desc = "Move forward a character" },
-	{ on = [ "<Left>" ],  exec = "move -1", desc = "Move back a character" },
-	{ on = [ "<Right>" ], exec = "move 1",  desc = "Move forward a character" },
-	{ on = [ "<C-b>" ],   exec = "move -1", desc = "Move back a character" },
-	{ on = [ "<C-f>" ],   exec = "move 1",  desc = "Move forward a character" },
+	{ on = [ "h" ],       run = "move -1", desc = "Move back a character" },
+	{ on = [ "l" ],       run = "move 1",  desc = "Move forward a character" },
+	{ on = [ "<Left>" ],  run = "move -1", desc = "Move back a character" },
+	{ on = [ "<Right>" ], run = "move 1",  desc = "Move forward a character" },
+	{ on = [ "<C-b>" ],   run = "move -1", desc = "Move back a character" },
+	{ on = [ "<C-f>" ],   run = "move 1",  desc = "Move forward a character" },
 
 	# Word-wise movement
-	{ on = [ "b" ],     exec = "backward",              desc = "Move back to the start of the current or previous word" },
-	{ on = [ "w" ],     exec = "forward",               desc = "Move forward to the start of the next word" },
-	{ on = [ "e" ],     exec = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
-	{ on = [ "<A-b>" ], exec = "backward",              desc = "Move back to the start of the current or previous word" },
-	{ on = [ "<A-f>" ], exec = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
+	{ on = [ "b" ],     run = "backward",              desc = "Move back to the start of the current or previous word" },
+	{ on = [ "w" ],     run = "forward",               desc = "Move forward to the start of the next word" },
+	{ on = [ "e" ],     run = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
+	{ on = [ "<A-b>" ], run = "backward",              desc = "Move back to the start of the current or previous word" },
+	{ on = [ "<A-f>" ], run = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
 
 	# Line-wise movement
-	{ on = [ "0" ],      exec = "move -999", desc = "Move to the BOL" },
-	{ on = [ "$" ],      exec = "move 999",  desc = "Move to the EOL" },
-	{ on = [ "<C-a>" ],  exec = "move -999", desc = "Move to the BOL" },
-	{ on = [ "<C-e>" ],  exec = "move 999",  desc = "Move to the EOL" },
-	{ on = [ "<Home>" ], exec = "move -999", desc = "Move to the BOL" },
-	{ on = [ "<End>" ],  exec = "move 999",  desc = "Move to the EOL" },
+	{ on = [ "0" ],      run = "move -999", desc = "Move to the BOL" },
+	{ on = [ "$" ],      run = "move 999",  desc = "Move to the EOL" },
+	{ on = [ "<C-a>" ],  run = "move -999", desc = "Move to the BOL" },
+	{ on = [ "<C-e>" ],  run = "move 999",  desc = "Move to the EOL" },
+	{ on = [ "<Home>" ], run = "move -999", desc = "Move to the BOL" },
+	{ on = [ "<End>" ],  run = "move 999",  desc = "Move to the EOL" },
 
 	# Delete
-	{ on = [ "<Backspace>" ], exec = "backspace",	        desc = "Delete the character before the cursor" },
-	{ on = [ "<Delete>" ],    exec = "backspace --under", desc = "Delete the character under the cursor" },
-	{ on = [ "<C-h>" ],       exec = "backspace",         desc = "Delete the character before the cursor" },
-	{ on = [ "<C-d>" ],       exec = "backspace --under", desc = "Delete the character under the cursor" },
+	{ on = [ "<Backspace>" ], run = "backspace",	        desc = "Delete the character before the cursor" },
+	{ on = [ "<Delete>" ],    run = "backspace --under", desc = "Delete the character under the cursor" },
+	{ on = [ "<C-h>" ],       run = "backspace",         desc = "Delete the character before the cursor" },
+	{ on = [ "<C-d>" ],       run = "backspace --under", desc = "Delete the character under the cursor" },
 
 	# Kill
-	{ on = [ "<C-u>" ], exec = "kill bol",      desc = "Kill backwards to the BOL" },
-	{ on = [ "<C-k>" ], exec = "kill eol",      desc = "Kill forwards to the EOL" },
-	{ on = [ "<C-w>" ], exec = "kill backward", desc = "Kill backwards to the start of the current word" },
-	{ on = [ "<A-d>" ], exec = "kill forward",  desc = "Kill forwards to the end of the current word" },
+	{ on = [ "<C-u>" ], run = "kill bol",      desc = "Kill backwards to the BOL" },
+	{ on = [ "<C-k>" ], run = "kill eol",      desc = "Kill forwards to the EOL" },
+	{ on = [ "<C-w>" ], run = "kill backward", desc = "Kill backwards to the start of the current word" },
+	{ on = [ "<A-d>" ], run = "kill forward",  desc = "Kill forwards to the end of the current word" },
 
 	# Cut/Yank/Paste
-	{ on = [ "d" ], exec = "delete --cut",                              desc = "Cut the selected characters" },
-	{ on = [ "D" ], exec = [ "delete --cut", "move 999" ],              desc = "Cut until the EOL" },
-	{ on = [ "c" ], exec = "delete --cut --insert",                     desc = "Cut the selected characters, and enter insert mode" },
-	{ on = [ "C" ], exec = [ "delete --cut --insert", "move 999" ],     desc = "Cut until the EOL, and enter insert mode" },
-	{ on = [ "x" ], exec = [ "delete --cut", "move 1 --in-operating" ], desc = "Cut the current character" },
-	{ on = [ "y" ], exec = "yank",           desc = "Copy the selected characters" },
-	{ on = [ "p" ], exec = "paste",          desc = "Paste the copied characters after the cursor" },
-	{ on = [ "P" ], exec = "paste --before", desc = "Paste the copied characters before the cursor" },
+	{ on = [ "d" ], run = "delete --cut",                              desc = "Cut the selected characters" },
+	{ on = [ "D" ], run = [ "delete --cut", "move 999" ],              desc = "Cut until the EOL" },
+	{ on = [ "c" ], run = "delete --cut --insert",                     desc = "Cut the selected characters, and enter insert mode" },
+	{ on = [ "C" ], run = [ "delete --cut --insert", "move 999" ],     desc = "Cut until the EOL, and enter insert mode" },
+	{ on = [ "x" ], run = [ "delete --cut", "move 1 --in-operating" ], desc = "Cut the current character" },
+	{ on = [ "y" ], run = "yank",           desc = "Copy the selected characters" },
+	{ on = [ "p" ], run = "paste",          desc = "Paste the copied characters after the cursor" },
+	{ on = [ "P" ], run = "paste --before", desc = "Paste the copied characters before the cursor" },
 
 	# Undo/Redo
-	{ on = [ "u" ],     exec = "undo", desc = "Undo the last operation" },
-	{ on = [ "<C-r>" ], exec = "redo", desc = "Redo the last operation" },
+	{ on = [ "u" ],     run = "undo", desc = "Undo the last operation" },
+	{ on = [ "<C-r>" ], run = "redo", desc = "Redo the last operation" },
 
 	# Help
-	{ on = [ "~" ], exec = "help", desc = "Open help" }
+	{ on = [ "~" ], run = "help", desc = "Open help" }
 ]
 
 [completion]
 
 keymap = [
-	{ on = [ "<C-q>" ],   exec = "close",                                      desc = "Cancel completion" },
-	{ on = [ "<Tab>" ],   exec = "close --submit",                             desc = "Submit the completion" },
-	{ on = [ "<Enter>" ], exec = [ "close --submit", "close_input --submit" ], desc = "Submit the completion and input" },
+	{ on = [ "<C-q>" ],   run = "close",                                      desc = "Cancel completion" },
+	{ on = [ "<Tab>" ],   run = "close --submit",                             desc = "Submit the completion" },
+	{ on = [ "<Enter>" ], run = [ "close --submit", "close_input --submit" ], desc = "Submit the completion and input" },
 
-	{ on = [ "<A-k>" ], exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "<A-j>" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "<A-k>" ], run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<A-j>" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "<Up>" ],   exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "<Down>" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "<Up>" ],   run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<Down>" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "~" ], exec = "help", desc = "Open help" }
+	{ on = [ "~" ], run = "help", desc = "Open help" }
 ]
 
 [help]
 
 keymap = [
-	{ on = [ "<Esc>" ], exec = "escape", desc = "Clear the filter, or hide the help" },
-	{ on = [ "q" ],     exec = "close",  desc = "Exit the process" },
-	{ on = [ "<C-q>" ], exec = "close",  desc = "Hide the help" },
+	{ on = [ "<Esc>" ], run = "escape", desc = "Clear the filter, or hide the help" },
+	{ on = [ "q" ],     run = "close",  desc = "Exit the process" },
+	{ on = [ "<C-q>" ], run = "close",  desc = "Hide the help" },
 
 	# Navigation
-	{ on = [ "k" ], exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "j" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "k" ], run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "j" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "K" ], exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "J" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "K" ], run = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "J" ], run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
-	{ on = [ "<Up>" ],   exec = "arrow -1", desc = "Move cursor up" },
-	{ on = [ "<Down>" ], exec = "arrow 1",  desc = "Move cursor down" },
+	{ on = [ "<Up>" ],   run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<Down>" ], run = "arrow 1",  desc = "Move cursor down" },
 
-	{ on = [ "<S-Up>" ],   exec = "arrow -5", desc = "Move cursor up 5 lines" },
-	{ on = [ "<S-Down>" ], exec = "arrow 5",  desc = "Move cursor down 5 lines" },
+	{ on = [ "<S-Up>" ],   run = "arrow -5", desc = "Move cursor up 5 lines" },
+	{ on = [ "<S-Down>" ], run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
 	# Filtering
-	{ on = [ "/" ], exec = "filter", desc = "Apply a filter for the help items" },
+	{ on = [ "/" ], run = "filter", desc = "Apply a filter for the help items" },
 ]

--- a/yazi-config/preset/theme.toml
+++ b/yazi-config/preset/theme.toml
@@ -141,7 +141,7 @@ separator_style = { fg = "darkgray" }
 
 [help]
 on      = { fg = "magenta" }
-exec    = { fg = "cyan" }
+run     = { fg = "cyan" }
 desc    = { fg = "gray" }
 hovered = { bg = "darkgray", bold = true }
 footer  = { fg = "black", bg = "white" }

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -26,28 +26,28 @@ ueberzug_offset = [ 0, 0, 0, 0 ]
 
 [opener]
 edit = [
-	{ exec = '${EDITOR:=vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
-	{ exec = 'code "%*"',    orphan = true, desc = "code",         for = "windows" },
-	{ exec = 'code -w "%*"', block = true,  desc = "code (block)", for = "windows" },
+	{ run = '${EDITOR:=vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
+	{ run = 'code "%*"',    orphan = true, desc = "code",         for = "windows" },
+	{ run = 'code -w "%*"', block = true,  desc = "code (block)", for = "windows" },
 ]
 open = [
-	{ exec = 'xdg-open "$@"',                desc = "Open", for = "linux" },
-	{ exec = 'open "$@"',                    desc = "Open", for = "macos" },
-	{ exec = 'start "" "%1"', orphan = true, desc = "Open", for = "windows" },
+	{ run = 'xdg-open "$@"',                desc = "Open", for = "linux" },
+	{ run = 'open "$@"',                    desc = "Open", for = "macos" },
+	{ run = 'start "" "%1"', orphan = true, desc = "Open", for = "windows" },
 ]
 reveal = [
-	{ exec = 'open -R "$1"',                          desc = "Reveal", for = "macos" },
-	{ exec = 'explorer /select, "%1"', orphan = true, desc = "Reveal", for = "windows" },
-	{ exec = '''exiftool "$1"; echo "Press enter to exit"; read''', block = true, desc = "Show EXIF", for = "unix" },
+	{ run = 'open -R "$1"',                          desc = "Reveal", for = "macos" },
+	{ run = 'explorer /select, "%1"', orphan = true, desc = "Reveal", for = "windows" },
+	{ run = '''exiftool "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show EXIF", for = "unix" },
 ]
 extract = [
-	{ exec = 'unar "$1"', desc = "Extract here", for = "unix" },
-	{ exec = 'unar "%1"', desc = "Extract here", for = "windows" },
+	{ run = 'unar "$1"', desc = "Extract here", for = "unix" },
+	{ run = 'unar "%1"', desc = "Extract here", for = "windows" },
 ]
 play = [
-	{ exec = 'mpv "$@"', orphan = true, for = "unix" },
-	{ exec = 'mpv "%1"', orphan = true, for = "windows" },
-	{ exec = '''mediainfo "$1"; echo "Press enter to exit"; read''', block = true, desc = "Show media info", for = "unix" },
+	{ run = 'mpv "$@"', orphan = true, for = "unix" },
+	{ run = 'mpv "%1"', orphan = true, for = "windows" },
+	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
 
 [open]
@@ -86,42 +86,42 @@ suppress_preload = false
 [plugin]
 
 preloaders = [
-	{ name = "*", cond = "!mime", exec = "mime", multi = true, prio = "high" },
+	{ name = "*", cond = "!mime", run = "mime", multi = true, prio = "high" },
 	# Image
-	{ mime = "image/vnd.djvu", exec = "noop" },
-	{ mime = "image/*",        exec = "image" },
+	{ mime = "image/vnd.djvu", run = "noop" },
+	{ mime = "image/*",        run = "image" },
 	# Video
-	{ mime = "video/*", exec = "video" },
+	{ mime = "video/*", run = "video" },
 	# PDF
-	{ mime = "application/pdf", exec = "pdf" },
+	{ mime = "application/pdf", run = "pdf" },
 ]
 previewers = [
-	{ name = "*/", exec = "folder", sync = true },
+	{ name = "*/", run = "folder", sync = true },
 	# Code
-	{ mime = "text/*",                 exec = "code" },
-	{ mime = "*/xml",                  exec = "code" },
-	{ mime = "*/javascript",           exec = "code" },
-	{ mime = "*/x-wine-extension-ini", exec = "code" },
+	{ mime = "text/*",                 run = "code" },
+	{ mime = "*/xml",                  run = "code" },
+	{ mime = "*/javascript",           run = "code" },
+	{ mime = "*/x-wine-extension-ini", run = "code" },
 	# JSON
-	{ mime = "application/json", exec = "json" },
+	{ mime = "application/json", run = "json" },
 	# Image
-	{ mime = "image/vnd.djvu", exec = "noop" },
-	{ mime = "image/*",        exec = "image" },
+	{ mime = "image/vnd.djvu", run = "noop" },
+	{ mime = "image/*",        run = "image" },
 	# Video
-	{ mime = "video/*", exec = "video" },
+	{ mime = "video/*", run = "video" },
 	# PDF
-	{ mime = "application/pdf", exec = "pdf" },
+	{ mime = "application/pdf", run = "pdf" },
 	# Archive
-	{ mime = "application/zip",             exec = "archive" },
-	{ mime = "application/gzip",            exec = "archive" },
-	{ mime = "application/x-tar",           exec = "archive" },
-	{ mime = "application/x-bzip",          exec = "archive" },
-	{ mime = "application/x-bzip2",         exec = "archive" },
-	{ mime = "application/x-7z-compressed", exec = "archive" },
-	{ mime = "application/x-rar",           exec = "archive" },
-	{ mime = "application/xz",              exec = "archive" },
+	{ mime = "application/zip",             run = "archive" },
+	{ mime = "application/gzip",            run = "archive" },
+	{ mime = "application/x-tar",           run = "archive" },
+	{ mime = "application/x-bzip",          run = "archive" },
+	{ mime = "application/x-bzip2",         run = "archive" },
+	{ mime = "application/x-7z-compressed", run = "archive" },
+	{ mime = "application/x-rar",           run = "archive" },
+	{ mime = "application/xz",              run = "archive" },
 	# Fallback
-	{ name = "*", exec = "file" },
+	{ name = "*", run = "file" },
 ]
 
 [input]

--- a/yazi-config/src/keymap/control.rs
+++ b/yazi-config/src/keymap/control.rs
@@ -1,22 +1,21 @@
-use std::{borrow::Cow, collections::VecDeque, ops::Deref};
+use std::{borrow::Cow, collections::VecDeque};
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use yazi_shared::event::Cmd;
 
 use super::Key;
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default)]
 pub struct Control {
 	pub on:   Vec<Key>,
-	#[serde(deserialize_with = "super::exec_deserialize")]
-	pub exec: Vec<Cmd>,
+	pub run:  Vec<Cmd>,
 	pub desc: Option<String>,
 }
 
 impl Control {
 	#[inline]
 	pub fn to_seq(&self) -> VecDeque<Cmd> {
-		self.exec.iter().map(|e| e.clone_without_data()).collect()
+		self.run.iter().map(|e| e.clone_without_data()).collect()
 	}
 }
 
@@ -25,58 +24,47 @@ impl Control {
 	pub fn on(&self) -> String { self.on.iter().map(ToString::to_string).collect() }
 
 	#[inline]
-	pub fn exec(&self) -> String {
-		self.exec.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")
+	pub fn run(&self) -> String {
+		self.run.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")
 	}
 
 	#[inline]
-	pub fn desc_or_exec(&self) -> Cow<str> {
-		if let Some(ref s) = self.desc { Cow::Borrowed(s) } else { self.exec().into() }
+	pub fn desc_or_run(&self) -> Cow<str> {
+		if let Some(ref s) = self.desc { Cow::Borrowed(s) } else { self.run().into() }
 	}
 
 	#[inline]
 	pub fn contains(&self, s: &str) -> bool {
 		let s = s.to_lowercase();
 		self.desc.as_ref().map(|d| d.to_lowercase().contains(&s)) == Some(true)
-			|| self.exec().to_lowercase().contains(&s)
+			|| self.run().to_lowercase().contains(&s)
 			|| self.on().to_lowercase().contains(&s)
 	}
 }
 
-#[derive(Debug)]
-pub enum ControlCow {
-	Owned(Control),
-	Borrowed(&'static Control),
-}
-
-impl From<&'static Control> for ControlCow {
-	fn from(c: &'static Control) -> Self { Self::Borrowed(c) }
-}
-
-impl From<Control> for ControlCow {
-	fn from(c: Control) -> Self { Self::Owned(c) }
-}
-
-impl Deref for ControlCow {
-	type Target = Control;
-
-	fn deref(&self) -> &Self::Target {
-		match self {
-			Self::Owned(c) => c,
-			Self::Borrowed(c) => c,
+// TODO: remove this once Yazi 0.3 is released
+impl<'de> Deserialize<'de> for Control {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		pub struct Shadow {
+			pub on:   Vec<Key>,
+			pub run:  Option<VecCmd>,
+			pub exec: Option<VecCmd>,
+			pub desc: Option<String>,
 		}
-	}
-}
 
-impl Default for ControlCow {
-	fn default() -> Self { Self::Owned(Control::default()) }
-}
+		let shadow = Shadow::deserialize(deserializer)?;
 
-impl ControlCow {
-	pub fn into_seq(self) -> VecDeque<Cmd> {
-		match self {
-			Self::Owned(c) => c.exec.into(),
-			Self::Borrowed(c) => c.to_seq(),
-		}
+		#[derive(Deserialize)]
+		struct VecCmd(#[serde(deserialize_with = "super::run_deserialize")] Vec<Cmd>);
+
+		let Some(run) = shadow.run.or(shadow.exec) else {
+			return Err(serde::de::Error::custom("missing field `run` within `[keymap]`"));
+		};
+
+		Ok(Self { on: shadow.on, run: run.0, desc: shadow.desc })
 	}
 }

--- a/yazi-config/src/keymap/cow.rs
+++ b/yazi-config/src/keymap/cow.rs
@@ -1,0 +1,43 @@
+use std::{collections::VecDeque, ops::Deref};
+
+use yazi_shared::event::Cmd;
+
+use super::Control;
+
+#[derive(Debug)]
+pub enum ControlCow {
+	Owned(Control),
+	Borrowed(&'static Control),
+}
+
+impl From<&'static Control> for ControlCow {
+	fn from(c: &'static Control) -> Self { Self::Borrowed(c) }
+}
+
+impl From<Control> for ControlCow {
+	fn from(c: Control) -> Self { Self::Owned(c) }
+}
+
+impl Deref for ControlCow {
+	type Target = Control;
+
+	fn deref(&self) -> &Self::Target {
+		match self {
+			Self::Owned(c) => c,
+			Self::Borrowed(c) => c,
+		}
+	}
+}
+
+impl Default for ControlCow {
+	fn default() -> Self { Self::Owned(Control::default()) }
+}
+
+impl ControlCow {
+	pub fn into_seq(self) -> VecDeque<Cmd> {
+		match self {
+			Self::Owned(c) => c.run.into(),
+			Self::Borrowed(c) => c.to_seq(),
+		}
+	}
+}

--- a/yazi-config/src/keymap/mod.rs
+++ b/yazi-config/src/keymap/mod.rs
@@ -1,10 +1,12 @@
 mod control;
-mod exec;
+mod cow;
 mod key;
 mod keymap;
+mod run;
 
 pub use control::*;
-#[allow(unused_imports)]
-pub use exec::*;
+pub use cow::*;
 pub use key::*;
 pub use keymap::*;
+#[allow(unused_imports)]
+pub use run::*;

--- a/yazi-config/src/plugin/mod.rs
+++ b/yazi-config/src/plugin/mod.rs
@@ -1,10 +1,12 @@
-mod exec;
 mod plugin;
 mod props;
+mod rule;
+mod run;
 
-#[allow(unused_imports)]
-pub use exec::*;
 pub use plugin::*;
 pub use props::*;
+pub use rule::*;
+#[allow(unused_imports)]
+pub use run::*;
 
 pub const MAX_PRELOADERS: u8 = 32;

--- a/yazi-config/src/plugin/plugin.rs
+++ b/yazi-config/src/plugin/plugin.rs
@@ -1,9 +1,10 @@
 use std::path::Path;
 
 use serde::Deserialize;
-use yazi_shared::{event::Cmd, Condition, MIME_DIR};
+use yazi_shared::MIME_DIR;
 
-use crate::{pattern::Pattern, plugin::MAX_PRELOADERS, Preset, Priority, MERGED_YAZI};
+use super::PluginRule;
+use crate::{plugin::MAX_PRELOADERS, Preset, MERGED_YAZI};
 
 #[derive(Deserialize)]
 pub struct Plugin {
@@ -85,30 +86,4 @@ impl Plugin {
 				|| rule.name.as_ref().is_some_and(|n| n.match_path(path, is_folder))
 		})
 	}
-}
-
-#[derive(Deserialize)]
-pub struct PluginRule {
-	#[serde(default)]
-	pub id:    u8,
-	pub cond:  Option<Condition>,
-	pub name:  Option<Pattern>,
-	pub mime:  Option<Pattern>,
-	#[serde(rename = "exec")]
-	#[serde(deserialize_with = "super::exec_deserialize")]
-	pub cmd:   Cmd,
-	#[serde(default)]
-	pub sync:  bool,
-	#[serde(default)]
-	pub multi: bool,
-	#[serde(default)]
-	pub prio:  Priority,
-}
-
-impl PluginRule {
-	#[inline]
-	fn any_file(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_file()) }
-
-	#[inline]
-	fn any_dir(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_dir()) }
 }

--- a/yazi-config/src/plugin/rule.rs
+++ b/yazi-config/src/plugin/rule.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Deserializer};
+use yazi_shared::{event::Cmd, Condition};
+
+use crate::{Pattern, Priority};
+
+pub struct PluginRule {
+	pub id:    u8,
+	pub cond:  Option<Condition>,
+	pub name:  Option<Pattern>,
+	pub mime:  Option<Pattern>,
+	pub cmd:   Cmd,
+	pub sync:  bool,
+	pub multi: bool,
+	pub prio:  Priority,
+}
+
+impl PluginRule {
+	#[inline]
+	pub fn any_file(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_file()) }
+
+	#[inline]
+	pub fn any_dir(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_dir()) }
+}
+
+// TODO: remove this once Yazi 0.3 is released
+impl<'de> Deserialize<'de> for PluginRule {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		pub struct Shadow {
+			#[serde(default)]
+			pub id:    u8,
+			pub cond:  Option<Condition>,
+			pub name:  Option<Pattern>,
+			pub mime:  Option<Pattern>,
+			pub run:   Option<WrappedCmd>,
+			pub exec:  Option<WrappedCmd>,
+			#[serde(default)]
+			pub sync:  bool,
+			#[serde(default)]
+			pub multi: bool,
+			#[serde(default)]
+			pub prio:  Priority,
+		}
+
+		let shadow = Shadow::deserialize(deserializer)?;
+
+		#[derive(Deserialize)]
+		struct WrappedCmd(#[serde(deserialize_with = "super::run_deserialize")] Cmd);
+
+		let Some(run) = shadow.run.or(shadow.exec) else {
+			return Err(serde::de::Error::custom("missing field `run` within `[plugin]`"));
+		};
+
+		Ok(Self {
+			id:    shadow.id,
+			cond:  shadow.cond,
+			name:  shadow.name,
+			mime:  shadow.mime,
+			cmd:   run.0,
+			sync:  shadow.sync,
+			multi: shadow.multi,
+			prio:  shadow.prio,
+		})
+	}
+}

--- a/yazi-config/src/plugin/run.rs
+++ b/yazi-config/src/plugin/run.rs
@@ -4,24 +4,24 @@ use anyhow::Result;
 use serde::{de::{self, Visitor}, Deserializer};
 use yazi_shared::event::Cmd;
 
-pub(super) fn exec_deserialize<'de, D>(deserializer: D) -> Result<Cmd, D::Error>
+pub(super) fn run_deserialize<'de, D>(deserializer: D) -> Result<Cmd, D::Error>
 where
 	D: Deserializer<'de>,
 {
-	struct ExecVisitor;
+	struct RunVisitor;
 
-	impl<'de> Visitor<'de> for ExecVisitor {
+	impl<'de> Visitor<'de> for RunVisitor {
 		type Value = Cmd;
 
 		fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-			formatter.write_str("a `exec` string or array of strings")
+			formatter.write_str("a `run` string or array of strings")
 		}
 
 		fn visit_seq<A>(self, _: A) -> Result<Self::Value, A::Error>
 		where
 			A: de::SeqAccess<'de>,
 		{
-			Err(de::Error::custom("`exec` within [plugin] must be a string"))
+			Err(de::Error::custom("`run` within [plugin] must be a string"))
 		}
 
 		fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -29,11 +29,11 @@ where
 			E: de::Error,
 		{
 			if value.is_empty() {
-				return Err(de::Error::custom("`exec` within [plugin] cannot be empty"));
+				return Err(de::Error::custom("`run` within [plugin] cannot be empty"));
 			}
 			Ok(Cmd { name: value.to_owned(), ..Default::default() })
 		}
 	}
 
-	deserializer.deserialize_any(ExecVisitor)
+	deserializer.deserialize_any(RunVisitor)
 }

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -155,7 +155,7 @@ pub struct Which {
 #[derive(Deserialize, Serialize)]
 pub struct Help {
 	pub on:   Style,
-	pub exec: Style,
+	pub run:  Style,
 	pub desc: Style,
 
 	pub hovered: Style,

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -129,7 +129,7 @@ impl Manager {
 			AppProxy::stop().await;
 
 			let mut child = external::shell(ShellOpt {
-				cmd:    (*opener.exec).into(),
+				cmd:    (*opener.run).into(),
 				args:   vec![OsString::new(), tmp.to_owned().into()],
 				piped:  false,
 				orphan: false,

--- a/yazi-core/src/tab/commands/select_all.rs
+++ b/yazi-core/src/tab/commands/select_all.rs
@@ -24,23 +24,19 @@ impl From<Option<bool>> for Opt {
 
 impl Tab {
 	pub fn select_all(&mut self, opt: impl Into<Opt>) {
-		let state = opt.into().state;
-		if state == Some(false) {
-			return render!(self.selected.clear());
-		}
-
 		let iter = self.current.files.iter().map(|f| &f.url);
-		let (removal, addition): (Vec<_>, Vec<_>) = if state == Some(true) {
-			(vec![], iter.collect())
-		} else {
-			iter.partition(|&u| self.selected.contains(u))
+		let (removal, addition): (Vec<_>, Vec<_>) = match opt.into().state {
+			Some(true) => (vec![], iter.collect()),
+			Some(false) => (iter.collect(), vec![]),
+			None => iter.partition(|&u| self.selected.contains(u)),
 		};
 
 		let same = !self.current.cwd.is_search();
 		render!(self.selected.remove_many(&removal, same) > 0);
-		let added = self.selected.add_many(&addition, same);
 
+		let added = self.selected.add_many(&addition, same);
 		render!(added > 0);
+
 		if added != addition.len() {
 			AppProxy::warn("Select all", "Some files cannot be selected, due to path nesting conflict.");
 		}

--- a/yazi-core/src/tab/commands/shell.rs
+++ b/yazi-core/src/tab/commands/shell.rs
@@ -5,7 +5,7 @@ use yazi_shared::event::Cmd;
 use crate::tab::Tab;
 
 pub struct Opt {
-	exec:    String,
+	run:     String,
 	block:   bool,
 	confirm: bool,
 }
@@ -13,7 +13,7 @@ pub struct Opt {
 impl From<Cmd> for Opt {
 	fn from(mut c: Cmd) -> Self {
 		Self {
-			exec:    c.take_first().unwrap_or_default(),
+			run:     c.take_first().unwrap_or_default(),
 			block:   c.named.contains_key("block"),
 			confirm: c.named.contains_key("confirm"),
 		}
@@ -30,16 +30,16 @@ impl Tab {
 		let selected = self.hovered_and_selected().into_iter().cloned().collect();
 
 		tokio::spawn(async move {
-			if !opt.confirm || opt.exec.is_empty() {
-				let mut result = InputProxy::show(InputCfg::shell(opt.block).with_value(opt.exec));
+			if !opt.confirm || opt.run.is_empty() {
+				let mut result = InputProxy::show(InputCfg::shell(opt.block).with_value(opt.run));
 				match result.recv().await {
-					Some(Ok(e)) => opt.exec = e,
+					Some(Ok(e)) => opt.run = e,
 					_ => return,
 				}
 			}
 
 			TasksProxy::open_with(selected, Opener {
-				exec:   opt.exec,
+				run:    opt.run,
 				block:  opt.block,
 				orphan: false,
 				desc:   Default::default(),

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -97,11 +97,9 @@ impl Selected {
 		count
 	}
 
-	pub fn clear(&mut self) -> bool {
-		let b = !self.inner.is_empty();
+	pub fn clear(&mut self) {
 		self.inner.clear();
 		self.parents.clear();
-		b
 	}
 }
 

--- a/yazi-core/src/which/sorter.rs
+++ b/yazi-core/src/which/sorter.rs
@@ -33,7 +33,7 @@ impl WhichSorter {
 			entities.push(match self.by {
 				SortBy::None => unreachable!(),
 				SortBy::Key => Cow::Owned(ctrl.on()),
-				SortBy::Desc => ctrl.desc_or_exec(),
+				SortBy::Desc => ctrl.desc_or_run(),
 			});
 		}
 

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -15,7 +15,7 @@ pub(crate) struct App {
 }
 
 impl App {
-	pub(crate) async fn run() -> Result<()> {
+	pub(crate) async fn serve() -> Result<()> {
 		let term = Term::start()?;
 		let signals = Signals::start()?;
 

--- a/yazi-fm/src/help/bindings.rs
+++ b/yazi-fm/src/help/bindings.rs
@@ -22,9 +22,9 @@ impl Widget for Bindings<'_> {
 		let col1: Vec<_> =
 			bindings.iter().map(|c| ListItem::new(c.on()).style(THEME.help.on)).collect();
 
-		// Exec
+		// Run
 		let col2: Vec<_> =
-			bindings.iter().map(|c| ListItem::new(c.exec()).style(THEME.help.exec)).collect();
+			bindings.iter().map(|c| ListItem::new(c.run()).style(THEME.help.run)).collect();
 
 		// Desc
 		let col3: Vec<_> = bindings

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -52,5 +52,5 @@ async fn main() -> anyhow::Result<()> {
 
 	yazi_core::init();
 
-	app::App::run().await
+	app::App::serve().await
 }

--- a/yazi-fm/src/which/cand.rs
+++ b/yazi-fm/src/which/cand.rs
@@ -32,7 +32,7 @@ impl Widget for Cand<'_> {
 		spans.push(Span::styled(&THEME.which.separator, THEME.which.separator_style));
 
 		// Description
-		spans.push(Span::styled(self.cand.desc_or_exec(), THEME.which.desc));
+		spans.push(Span::styled(self.cand.desc_or_run(), THEME.which.desc));
 
 		Line::from(spans).render(area, buf);
 	}

--- a/yazi-plugin/src/bindings/position.rs
+++ b/yazi-plugin/src/bindings/position.rs
@@ -25,7 +25,7 @@ impl<'a> TryFrom<mlua::Table<'a>> for Position {
 			offset: Offset {
 				x:      t.raw_get("x").unwrap_or_default(),
 				y:      t.raw_get("y").unwrap_or_default(),
-				width:  t.raw_get("w").unwrap_or_default(),
+				width:  t.raw_get("w")?,
 				height: 3,
 			},
 		}))

--- a/yazi-plugin/src/utils/layer.rs
+++ b/yazi-plugin/src/utils/layer.rs
@@ -37,7 +37,7 @@ impl Utils {
 					let cand = cand?;
 					cands.push(Control {
 						on:   Self::parse_keys(cand.raw_get("on")?)?,
-						exec: vec![Cmd::args("callback", vec![i.to_string()]).with_data(tx.clone())],
+						run:  vec![Cmd::args("callback", vec![i.to_string()]).with_data(tx.clone())],
 						desc: cand.raw_get("desc").ok(),
 					});
 				}

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -18,6 +18,7 @@ pub struct Scheduler {
 
 	micro:       async_priority_channel::Sender<BoxFuture<'static, ()>, u8>,
 	prog:        mpsc::UnboundedSender<TaskProg>,
+	// FIXME
 	pub running: Arc<Mutex<Running>>,
 }
 
@@ -334,7 +335,7 @@ impl Scheduler {
 
 	pub fn process_open(&self, opener: &Opener, args: &[impl AsRef<OsStr>]) {
 		let name = {
-			let s = format!("Execute `{}`", opener.exec);
+			let s = format!("Run `{}`", opener.run);
 			let args = args.iter().map(|a| a.as_ref().to_string_lossy()).collect::<Vec<_>>().join(" ");
 			if args.is_empty() { s } else { format!("{s} with `{args}`") }
 		};
@@ -364,7 +365,7 @@ impl Scheduler {
 				process
 					.open(ProcessOpOpen {
 						id,
-						cmd: opener.exec.into(),
+						cmd: opener.run.into(),
 						args,
 						block: opener.block,
 						orphan: opener.orphan,


### PR DESCRIPTION
This PR adds a new `run` attribute with the intention of eventually replacing the existing `exec`, this will be a slow and gentle process, possibly happening in the next major version Yazi v0.3.

While **the existing `exec` remains available**, so it won't affect existing users. By changing `exec` to `run` in the default configuration, new users are encouraged to use the new `run` instead of `exec` when copying the default configuration.