### PR TITLE
feat: add `<C-p>` and `<C-n>` to the select component for moving the cursor up/down

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -276,6 +276,9 @@ keymap = [
 	{ on = [ "<Up>" ],   run = "arrow -1", desc = "Move cursor up" },
 	{ on = [ "<Down>" ], run = "arrow 1",  desc = "Move cursor down" },
 
+	{ on = [ "<C-p>" ], run = "arrow -1", desc = "Move cursor up" },
+	{ on = [ "<C-n>" ], run = "arrow 1",  desc = "Move cursor down" },
+
 	{ on = [ "~" ], run = "help", desc = "Open help" }
 ]
 


### PR DESCRIPTION
Particularly, <kbd>Ctrl</kbd> + <kbd>n</kbd> and <kbd>Ctrl</kbd> + <kbd>p</kbd> to move down and up the completion menu respectively.

Closes #778