### PR TITLE
fix: respond to the `SIGTERM` signal even when Yazi is in the background and has passed control of the terminal to the spawned process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,10 +37,14 @@ body:
       label: "`yazi --debug` output"
       description: Please do a `yazi --debug` and paste the output here.
       value: |
+        <details>
+
         <!-- Paste the output between the backticks below: -->
         ```sh
 
         ```
+
+        </details>
     validations:
       required: true
   - type: textarea

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,5 +1,6 @@
 cargo publish -p yazi-shared
 cargo publish -p yazi-config
+cargo publish -p yazi-proxy
 cargo publish -p yazi-adaptor
 cargo publish -p yazi-boot
 cargo publish -p yazi-scheduler


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/796