### PR TITLE
feat!: Only return selected when hover is selected

### DIFF
--- a/yazi-core/src/tab/tab.rs
+++ b/yazi-core/src/tab/tab.rs
@@ -51,8 +51,11 @@ impl From<&Url> for Tab {
 impl Tab {
 	// --- Current
 	pub fn selected_or_hovered(&self) -> Vec<&Url> {
+		let hovered = self.current.hovered().map(|h| vec![&h.url]).unwrap_or_default();
 		if self.selected.is_empty() {
-			self.current.hovered().map(|h| vec![&h.url]).unwrap_or_default()
+			hovered
+		} else if !self.selected.contains(hovered[0]) {
+			hovered
 		} else {
 			self.selected.iter().collect()
 		}


### PR DESCRIPTION
With the cross-directory selection feature, it can be very unexpected to select items in a parent directory, and then go into a child directory to attempt to open a file. However, instead of opening the hovered file, the selected items are opened instead.

This is especially obvious when using the smart-enter plugin that combines the enter and open commands.

For the most part, users will likely be hovering over a selected item if they want to operate on the items they have selected, so this change will likely result in a net improvement in user experience.

Implements #807.

Note: I am very new to rust, so I'm not sure if `.contains(hovered[0])` is the best way to check if the hovered item is selected. It looks like it could panic if the `hovered` variable is an empty vector. If there's a better and safer way, please feel free to update it.