### PR TITLE
fix: adjust calculation for number of lines in a notification message

### DIFF
--- a/yazi-core/src/notify/message.rs
+++ b/yazi-core/src/notify/message.rs
@@ -36,11 +36,11 @@ impl Message {
 			return 0; // In case we can't get the width of the terminal
 		}
 
-		let mut num_lines = 0;
+		let mut lines = 0;
 		for line in self.content.lines() {
-			num_lines += (line.width() + 1).div_ceil(width as usize)
+			lines += (line.width() + 1).div_ceil(width as usize)
 		}
 
-		num_lines + NOTIFY_BORDER as usize
+		lines + NOTIFY_BORDER as usize
 	}
 }

--- a/yazi-core/src/notify/message.rs
+++ b/yazi-core/src/notify/message.rs
@@ -36,7 +36,11 @@ impl Message {
 			return 0; // In case we can't get the width of the terminal
 		}
 
-		let lines = (self.content.width() as f64 / width as f64).ceil();
-		lines as usize + NOTIFY_BORDER as usize
+		let mut num_lines = 0;
+		for line in self.content.lines() {
+			num_lines += (line.width() + 1).div_ceil(width as usize)
+		}
+
+		num_lines + NOTIFY_BORDER as usize
 	}
 }


### PR DESCRIPTION
Fixes #822 by fixing the width division calculation (`+1`) and taking lines within the message content itself into account