### PR TITLE
fix: disable ANSI encoding for formatted events for the `tracing_subscriber` to clean up the logs

### DIFF
--- a/yazi-fm/src/logs.rs
+++ b/yazi-fm/src/logs.rs
@@ -15,7 +15,8 @@ impl Logs {
 		let (handle, guard) = tracing_appender::non_blocking(appender);
 
 		// let filter = EnvFilter::from_default_env();
-		let subscriber = Registry::default().with(fmt::layer().pretty().with_writer(handle));
+		let subscriber =
+			Registry::default().with(fmt::layer().pretty().with_writer(handle).with_ansi(false));
 
 		tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 


### PR DESCRIPTION
Fixes #831 