### PR TITLE
perf: add `BufWriter` to `Stderr` to avoid frequent system calls and increase rendering frame rate

### DIFF
--- a/yazi-adaptor/src/emulator.rs
+++ b/yazi-adaptor/src/emulator.rs
@@ -1,4 +1,4 @@
-use std::{env, io::Read};
+use std::{env, io::{stderr, LineWriter, Read}};
 
 use anyhow::{anyhow, Result};
 use crossterm::{cursor::{RestorePosition, SavePosition}, execute, style::Print, terminal::{disable_raw_mode, enable_raw_mode}};
@@ -114,7 +114,7 @@ impl Emulator {
 	pub fn via_csi() -> Result<Self> {
 		enable_raw_mode()?;
 		execute!(
-			std::io::stderr(),
+			LineWriter::new(stderr()),
 			SavePosition,
 			Print("\x1b[>q\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c"),
 			RestorePosition

--- a/yazi-adaptor/src/iterm2.rs
+++ b/yazi-adaptor/src/iterm2.rs
@@ -1,4 +1,4 @@
-use std::{io::{stderr, BufWriter, Write}, path::Path};
+use std::{io::Write, path::Path};
 
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
@@ -19,16 +19,15 @@ impl Iterm2 {
 
 		Adaptor::Iterm2.image_hide()?;
 		Adaptor::shown_store(rect, size);
-		Term::move_lock(stderr().lock(), (rect.x, rect.y), |stderr| {
+		Term::move_lock((rect.x, rect.y), |stderr| {
 			stderr.write_all(&b)?;
 			Ok(size)
 		})
 	}
 
 	pub(super) fn image_erase(rect: Rect) -> Result<()> {
-		let stderr = BufWriter::new(stderr().lock());
 		let s = " ".repeat(rect.width as usize);
-		Term::move_lock(stderr, (0, 0), |stderr| {
+		Term::move_lock((0, 0), |stderr| {
 			for y in rect.top()..rect.bottom() {
 				Term::move_to(stderr, rect.x, y)?;
 				write!(stderr, "{s}")?;

--- a/yazi-adaptor/src/kitty.rs
+++ b/yazi-adaptor/src/kitty.rs
@@ -1,5 +1,5 @@
 use core::str;
-use std::{io::{stderr, BufWriter, Write}, path::Path};
+use std::{io::Write, path::Path};
 
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
@@ -322,7 +322,7 @@ impl Kitty {
 
 		Adaptor::Kitty.image_hide()?;
 		Adaptor::shown_store(rect, size);
-		Term::move_lock(stderr().lock(), (rect.x, rect.y), |stderr| {
+		Term::move_lock((rect.x, rect.y), |stderr| {
 			stderr.write_all(&b1)?;
 			stderr.write_all(&b2)?;
 			Ok(size)
@@ -330,9 +330,8 @@ impl Kitty {
 	}
 
 	pub(super) fn image_erase(rect: Rect) -> Result<()> {
-		let stderr = BufWriter::new(stderr().lock());
 		let s = " ".repeat(rect.width as usize);
-		Term::move_lock(stderr, (0, 0), |stderr| {
+		Term::move_lock((0, 0), |stderr| {
 			for y in rect.top()..rect.bottom() {
 				Term::move_to(stderr, rect.x, y)?;
 				write!(stderr, "{s}")?;

--- a/yazi-adaptor/src/kitty_old.rs
+++ b/yazi-adaptor/src/kitty_old.rs
@@ -1,5 +1,5 @@
 use core::str;
-use std::{io::{stderr, Write}, path::Path};
+use std::{io::{stderr, LineWriter, Write}, path::Path};
 
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
@@ -20,7 +20,7 @@ impl KittyOld {
 
 		Adaptor::KittyOld.image_hide()?;
 		Adaptor::shown_store(rect, size);
-		Term::move_lock(stderr().lock(), (rect.x, rect.y), |stderr| {
+		Term::move_lock((rect.x, rect.y), |stderr| {
 			stderr.write_all(&b)?;
 			Ok(size)
 		})
@@ -28,7 +28,7 @@ impl KittyOld {
 
 	#[inline]
 	pub(super) fn image_erase() -> Result<()> {
-		let mut stderr = stderr().lock();
+		let mut stderr = LineWriter::new(stderr());
 		write!(stderr, "{}_Gq=1,a=d,d=A{}\\{}", START, ESCAPE, CLOSE)?;
 		stderr.flush()?;
 		Ok(())

--- a/yazi-adaptor/src/sixel.rs
+++ b/yazi-adaptor/src/sixel.rs
@@ -1,4 +1,4 @@
-use std::{io::{stderr, BufWriter, Write}, path::Path};
+use std::{io::Write, path::Path};
 
 use anyhow::{bail, Result};
 use color_quant::NeuQuant;
@@ -19,16 +19,15 @@ impl Sixel {
 
 		Adaptor::Sixel.image_hide()?;
 		Adaptor::shown_store(rect, size);
-		Term::move_lock(stderr().lock(), (rect.x, rect.y), |stderr| {
+		Term::move_lock((rect.x, rect.y), |stderr| {
 			stderr.write_all(&b)?;
 			Ok(size)
 		})
 	}
 
 	pub(super) fn image_erase(rect: Rect) -> Result<()> {
-		let stderr = BufWriter::new(stderr().lock());
 		let s = " ".repeat(rect.width as usize);
-		Term::move_lock(stderr, (0, 0), |stderr| {
+		Term::move_lock((0, 0), |stderr| {
 			for y in rect.top()..rect.bottom() {
 				Term::move_to(stderr, rect.x, y)?;
 				write!(stderr, "{s}")?;

--- a/yazi-core/src/clipboard.rs
+++ b/yazi-core/src/clipboard.rs
@@ -54,7 +54,7 @@ impl Clipboard {
 
 	#[cfg(unix)]
 	pub async fn set(&self, s: impl AsRef<std::ffi::OsStr>) {
-		use std::{io::stderr, process::Stdio};
+		use std::{io::{stderr, BufWriter}, process::Stdio};
 
 		use crossterm::execute;
 		use tokio::{io::AsyncWriteExt, process::Command};
@@ -62,7 +62,7 @@ impl Clipboard {
 
 		*self.content.lock() = s.as_ref().to_owned();
 		if in_ssh_connection() {
-			execute!(stderr(), osc52::SetClipboard::new(s.as_ref())).ok();
+			execute!(BufWriter::new(stderr()), osc52::SetClipboard::new(s.as_ref())).ok();
 		}
 
 		let all = [

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -78,7 +78,7 @@ impl Selected {
 	}
 
 	fn remove_same(&mut self, urls: &[impl AsRef<Url>]) -> usize {
-		let count = urls.iter().map(|u| self.inner.remove(u.as_ref())).filter_map(|v| v).count();
+		let count = urls.iter().filter_map(|u| self.inner.remove(u.as_ref())).count();
 		if count == 0 {
 			return 0;
 		}

--- a/yazi-fm/src/app/commands/render.rs
+++ b/yazi-fm/src/app/commands/render.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::Ordering;
+use std::{io::{stderr, BufWriter}, sync::atomic::Ordering};
 
 use ratatui::{backend::{Backend, CrosstermBackend}, CompletedFrame};
 use yazi_plugin::elements::COLLISION;
@@ -71,7 +71,7 @@ impl App {
 			}
 		}
 
-		let mut backend = CrosstermBackend::new(std::io::stderr().lock());
+		let mut backend = CrosstermBackend::new(BufWriter::new(stderr().lock()));
 		backend.draw(patches.into_iter()).ok();
 		if let Some((x, y)) = cursor {
 			backend.show_cursor().ok();

--- a/yazi-shared/src/term/term.rs
+++ b/yazi-shared/src/term/term.rs
@@ -1,4 +1,4 @@
-use std::{io::{self, stderr, Stderr, Write}, mem, ops::{Deref, DerefMut}, sync::atomic::{AtomicBool, Ordering}};
+use std::{io::{self, stderr, BufWriter, Stderr, Write}, mem, ops::{Deref, DerefMut}, sync::atomic::{AtomicBool, Ordering}};
 
 use anyhow::Result;
 use crossterm::{event::{DisableBracketedPaste, DisableFocusChange, EnableBracketedPaste, EnableFocusChange, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags}, execute, queue, terminal::{disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, WindowSize}};
@@ -7,7 +7,7 @@ use ratatui::{backend::CrosstermBackend, buffer::Buffer, layout::Rect, Completed
 static CSI_U: AtomicBool = AtomicBool::new(false);
 
 pub struct Term {
-	inner:       Terminal<CrosstermBackend<Stderr>>,
+	inner:       Terminal<CrosstermBackend<BufWriter<Stderr>>>,
 	last_area:   Rect,
 	last_buffer: Buffer,
 }
@@ -15,7 +15,7 @@ pub struct Term {
 impl Term {
 	pub fn start() -> Result<Self> {
 		let mut term = Self {
-			inner:       Terminal::new(CrosstermBackend::new(stderr()))?,
+			inner:       Terminal::new(CrosstermBackend::new(BufWriter::new(stderr())))?,
 			last_area:   Default::default(),
 			last_buffer: Default::default(),
 		};
@@ -144,7 +144,7 @@ impl Drop for Term {
 }
 
 impl Deref for Term {
-	type Target = Terminal<CrosstermBackend<Stderr>>;
+	type Target = Terminal<CrosstermBackend<BufWriter<Stderr>>>;
 
 	fn deref(&self) -> &Self::Target { &self.inner }
 }


### PR DESCRIPTION
This PR fixes a performance regression introduced by the latest main branch. Recently, Yazi switched from `stdout` to `stderr`, but since `stderr` is unbuffered (previously `stdout` was line-buffered, i.e. `LineWriter`), this change caused a decrease in rendering frame rate. 

This PR adds a block buffer ( `BufWriter`) to `stderr`, while solving this performance regression, it *theoretically* can further improve performance - this is an example comparing `LineWriter` and `BufWriter`, https://github.com/orhun/rust-stdout-vs-stderr


![stdout-vs-stderr-detailed](https://github.com/orhun/rust-stdout-vs-stderr/assets/24392180/5971ba46-62b6-4964-8096-532673983058)


(Image source: https://github.com/orhun/rust-stdout-vs-stderr)