### PR TITLE
feat: readable toml parsing error

### DIFF
--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -47,11 +47,11 @@ pub static INPUT: RoCell<popup::Input> = RoCell::new();
 pub static SELECT: RoCell<popup::Select> = RoCell::new();
 pub static WHICH: RoCell<which::Which> = RoCell::new();
 
-pub fn init() {
+pub fn init() -> anyhow::Result<()> {
 	let config_dir = Xdg::config_dir();
-	MERGED_YAZI.init(Preset::yazi(&config_dir));
-	MERGED_KEYMAP.init(Preset::keymap(&config_dir));
-	MERGED_THEME.init(Preset::theme(&config_dir));
+	MERGED_YAZI.init(Preset::yazi(&config_dir)?);
+	MERGED_KEYMAP.init(Preset::keymap(&config_dir)?);
+	MERGED_THEME.init(Preset::theme(&config_dir)?);
 
 	LAYOUT.with(Default::default);
 
@@ -81,4 +81,5 @@ Add `disable_exec_warn = true` to your `yazi.toml` under `[headsup]` to suppress
 "#
 		);
 	}
+	Ok(())
 }

--- a/yazi-config/src/preset.rs
+++ b/yazi-config/src/preset.rs
@@ -8,17 +8,17 @@ use crate::theme::Flavor;
 pub(crate) struct Preset;
 
 impl Preset {
-	pub(crate) fn yazi(p: &Path) -> String {
+	pub(crate) fn yazi(p: &Path) -> anyhow::Result<String> {
 		Self::merge_path(p.join("yazi.toml"), include_str!("../preset/yazi.toml"))
 	}
 
-	pub(crate) fn keymap(p: &Path) -> String {
+	pub(crate) fn keymap(p: &Path) -> anyhow::Result<String> {
 		Self::merge_path(p.join("keymap.toml"), include_str!("../preset/keymap.toml"))
 	}
 
-	pub(crate) fn theme(p: &Path) -> String {
+	pub(crate) fn theme(p: &Path) -> anyhow::Result<String> {
 		let Ok(user) = std::fs::read_to_string(p.join("theme.toml")) else {
-			return include_str!("../preset/theme.toml").to_owned();
+			return Ok(include_str!("../preset/theme.toml").to_owned());
 		};
 		let Some(use_) = Flavor::parse_use(&user) else {
 			return Self::merge_str(&user, include_str!("../preset/theme.toml"));
@@ -29,7 +29,7 @@ impl Preset {
 			.with_context(|| format!("Failed to load flavor {:?}", p))
 			.unwrap();
 
-		Self::merge_str(&user, &Self::merge_str(&flavor, include_str!("../preset/theme.toml")))
+		Self::merge_str(&user, &Self::merge_str(&flavor, include_str!("../preset/theme.toml"))?)
 	}
 
 	#[inline]
@@ -38,21 +38,21 @@ impl Preset {
 	}
 
 	#[inline]
-	pub(crate) fn merge_str(user: &str, base: &str) -> String {
-		let mut t = user.parse().unwrap();
+	pub(crate) fn merge_str(user: &str, base: &str) -> anyhow::Result<String> {
+		let mut t = user.parse()?;
 		Self::merge(&mut t, base.parse().unwrap(), 2);
 
-		t.to_string()
+		Ok(t.to_string())
 	}
 
 	#[inline]
-	fn merge_path(user: PathBuf, base: &str) -> String {
-		let s = std::fs::read_to_string(user).unwrap_or_default();
+	fn merge_path(user: PathBuf, base: &str) -> anyhow::Result<String> {
+		let s = std::fs::read_to_string(&user).unwrap_or_default();
 		if s.is_empty() {
-			return base.to_string();
+			return Ok(base.to_string());
 		}
 
-		Self::merge_str(&s, base)
+		Ok(Self::merge_str(&s, base).context(format!("Loading {user:?}"))?)
 	}
 
 	fn merge(a: &mut Table, b: Table, max: u8) {

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 
 	_ = fdlimit::raise_fd_limit();
 
-	yazi_config::init();
+	yazi_config::init()?;
 
 	yazi_adaptor::init();
 


### PR DESCRIPTION
See commit message for the new error message.
For more information see issue GH-847. Closes https://github.com/sxyazi/yazi/issues/847

Because this is my first pull request in yazi, I've tried to keep it as minimal as possible. Here are some things I noticed while working on this issue:

- Only one file is parsed at a time, this means the user does not get information about `keymap.toml`, if `yazi.toml` has an error.
- No unit test was written for the new functionality. I would need some pointers, if this is needed.
- If `yazi.toml` is valid, but contains an unknown key, then the key appears to silently omitted.
  ```
  [manager]
  sortt_by = "natural"
  ```
- If `yazi.toml` could not be read, due to an IO error, then the file is silently omitted.
- It looks like there is some slight shotgun parsing happening in `Preset` (explanation of shotgun parsing: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/). This may be a personal preference of mine, but I would have checked that `yazi.toml` matches the format specified the by docs *before* merging it with the default values.