### PR TITLE
feat: trigger path completion with both `/` and `\` on Windows

### DIFF
--- a/yazi-core/src/completion/commands/trigger.rs
+++ b/yazi-core/src/completion/commands/trigger.rs
@@ -67,7 +67,14 @@ impl Completion {
 
 	#[inline]
 	fn split_path(s: &str) -> (String, String) {
+		#[cfg(target_os = "windows")]
 		match s.rsplit_once(['/', '\\']) {
+			Some((p, c)) => (format!("{p}{}", MAIN_SEPARATOR), c.to_owned()),
+			None => (".".to_owned(), s.to_owned()),
+		}
+
+		#[cfg(not(target_os = "windows"))]
+		match s.rsplit_once(MAIN_SEPARATOR) {
 			Some((p, c)) => (format!("{p}{}", MAIN_SEPARATOR), c.to_owned()),
 			None => (".".to_owned(), s.to_owned()),
 		}

--- a/yazi-core/src/completion/commands/trigger.rs
+++ b/yazi-core/src/completion/commands/trigger.rs
@@ -67,7 +67,7 @@ impl Completion {
 
 	#[inline]
 	fn split_path(s: &str) -> (String, String) {
-		match s.rsplit_once(MAIN_SEPARATOR) {
+		match s.rsplit_once(['/', '\\']) {
 			Some((p, c)) => (format!("{p}{}", MAIN_SEPARATOR), c.to_owned()),
 			None => (".".to_owned(), s.to_owned()),
 		}

--- a/yazi-core/src/input/commands/complete.rs
+++ b/yazi-core/src/input/commands/complete.rs
@@ -1,6 +1,14 @@
+use std::path::MAIN_SEPARATOR_STR;
+
 use yazi_shared::{event::Cmd, render};
 
 use crate::input::Input;
+
+#[cfg(windows)]
+const SEPARATOR: [char; 2] = ['/', '\\'];
+
+#[cfg(not(windows))]
+const SEPARATOR: char = std::path::MAIN_SEPARATOR;
 
 pub struct Opt {
 	word:   String,
@@ -24,19 +32,10 @@ impl Input {
 		}
 
 		let [before, after] = self.partition();
-
-		#[cfg(target_os = "windows")]
-		let new = if let Some((prefix, _)) = before.rsplit_once(['/', '\\']) {
-			format!("{prefix}/{}{after}", opt.word).replace(['/', '\\'], std::path::MAIN_SEPARATOR_STR)
+		let new = if let Some((prefix, _)) = before.rsplit_once(SEPARATOR) {
+			format!("{prefix}/{}{after}", opt.word).replace(SEPARATOR, MAIN_SEPARATOR_STR)
 		} else {
-			format!("{}{after}", opt.word).replace(['/', '\\'], std::path::MAIN_SEPARATOR_STR)
-		};
-
-		#[cfg(not(target_os = "windows"))]
-		let new = if let Some((prefix, _)) = before.rsplit_once(std::path::MAIN_SEPARATOR) {
-			format!("{prefix}/{}{after}", opt.word)
-		} else {
-			format!("{}{after}", opt.word)
+			format!("{}{after}", opt.word).replace(SEPARATOR, MAIN_SEPARATOR_STR)
 		};
 
 		let snap = self.snaps.current_mut();

--- a/yazi-core/src/input/commands/complete.rs
+++ b/yazi-core/src/input/commands/complete.rs
@@ -1,4 +1,4 @@
-use std::path::MAIN_SEPARATOR;
+use std::path::MAIN_SEPARATOR_STR;
 
 use yazi_shared::{event::Cmd, render};
 
@@ -26,19 +26,21 @@ impl Input {
 		}
 
 		let [before, after] = self.partition();
-		let new = if let Some((prefix, _)) = before.rsplit_once(MAIN_SEPARATOR) {
+		let new = if let Some((prefix, _)) = before.rsplit_once(['/', '\\']) {
 			format!("{prefix}/{}{after}", opt.word)
 		} else {
 			format!("{}{after}", opt.word)
 		};
 
+		let normalized_new = new.replace(['/', '\\'], MAIN_SEPARATOR_STR);
+
 		let snap = self.snaps.current_mut();
-		if new == snap.value {
+		if normalized_new == snap.value {
 			return;
 		}
 
-		let delta = new.chars().count() as isize - snap.value.chars().count() as isize;
-		snap.value = new;
+		let delta = normalized_new.chars().count() as isize - snap.value.chars().count() as isize;
+		snap.value = normalized_new;
 
 		self.move_(delta);
 		self.flush_value();


### PR DESCRIPTION
Fix some issues described in #782:
- Trigger completion with both `/` and `\`.
- Normalized path with `MAIN_SEPARATOR` when pressing `tab` for completion.

I've implemented them in Windows specific code. Because Linux apparently allows `\` in file name.