### PR TITLE
fix: add rustup to nix shell for building yazi

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -16,6 +16,7 @@ pkgs.mkShell {
     ripgrep
     fzf
     zoxide
+    rustup
   ];
 
   buildInputs = with pkgs;


### PR DESCRIPTION
By adding rustup to the nix flake, I was able to build yazi with these steps:

``` bash
nix develop
scripts/build.sh yazi-x86_64-unknown-linux-gnu
```