### PR TITLE
feat: allow creating a tab with the startup directory when the `tab_create` command is called without specifying a `path` parameter

### DIFF
--- a/yazi-core/src/manager/commands/tab_create.rs
+++ b/yazi-core/src/manager/commands/tab_create.rs
@@ -1,3 +1,4 @@
+use yazi_boot::BOOT;
 use yazi_proxy::AppProxy;
 use yazi_shared::{event::Cmd, fs::Url, render};
 
@@ -15,7 +16,10 @@ impl From<Cmd> for Opt {
 		if c.named.contains_key("current") {
 			Self { url: Default::default(), current: true }
 		} else {
-			Self { url: c.take_first().map_or_else(|| Url::from("."), Url::from), current: false }
+			Self {
+				url:     c.take_first().map_or_else(|| Url::from(&BOOT.cwd), Url::from),
+				current: false,
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/sxyazi/yazi/issues/912