### PR TITLE
fix: prevent pasting a directory into itself

### DIFF
--- a/yazi-scheduler/src/file/file.rs
+++ b/yazi-scheduler/src/file/file.rs
@@ -135,18 +135,12 @@ impl File {
 
 	pub async fn paste(&self, mut task: FileOpPaste) -> Result<()> {
 		// Prevent pasting of a directory into itself
-		if task.from.is_dir() {
-			let mut parent = task.to.parent_url();
-			while let Some(p) = parent {
-				if task.from == p {
-					debug!(
-						"file_paste: cannot paste directory into itself, skipping {:?} -> {:?}",
-						task.from, task.to
-					);
-					return self.succ(task.id);
-				}
-				parent = p.parent_url();
-			}
+		if task.from.is_dir() && task.to.as_path().starts_with(task.from.as_path()) {
+			debug!(
+				"file_paste: cannot paste directory into itself, skipping {:?} -> {:?}",
+				task.from, task.to
+			);
+			return self.succ(task.id);
 		}
 
 		if task.cut {

--- a/yazi-scheduler/src/file/file.rs
+++ b/yazi-scheduler/src/file/file.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::VecDeque, fs::Metadata, path::{Path, PathBuf
 use anyhow::{anyhow, Result};
 use futures::{future::BoxFuture, FutureExt};
 use tokio::{fs, io::{self, ErrorKind::{AlreadyExists, NotFound}}, sync::mpsc};
-use tracing::{debug, warn};
+use tracing::warn;
 use yazi_config::TASKS;
 use yazi_shared::fs::{accessible, calculate_size, copy_with_progress, path_relative_to, Url};
 
@@ -134,15 +134,6 @@ impl File {
 	}
 
 	pub async fn paste(&self, mut task: FileOpPaste) -> Result<()> {
-		// Prevent pasting of a directory into itself
-		if task.from.is_dir() && task.to.as_path().starts_with(task.from.as_path()) {
-			debug!(
-				"file_paste: cannot paste directory into itself, skipping {:?} -> {:?}",
-				task.from, task.to
-			);
-			return self.succ(task.id);
-		}
-
 		if task.cut {
 			match fs::rename(&task.from, &task.to).await {
 				Ok(_) => return self.succ(task.id),

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, ffi::OsString, sync::Arc, time::Duration};
 
+use anyhow::Result;
 use futures::{future::BoxFuture, FutureExt};
 use parking_lot::Mutex;
 use tokio::{fs, select, sync::{mpsc::{self, UnboundedReceiver}, oneshot}, task::JoinHandle};
@@ -71,6 +72,11 @@ impl Scheduler {
 		let mut ongoing = self.ongoing.lock();
 		let id = ongoing.add(TaskKind::User, format!("Cut {:?} to {:?}", from, to));
 
+		if to.starts_with(&from) {
+			self.new_and_fail(id, "Cannot cut directory into itself").ok();
+			return;
+		}
+
 		ongoing.hooks.insert(id, {
 			let ongoing = self.ongoing.clone();
 			let (from, to) = (from.clone(), to.clone());
@@ -103,6 +109,11 @@ impl Scheduler {
 	pub fn file_copy(&self, from: Url, mut to: Url, force: bool, follow: bool) {
 		let name = format!("Copy {:?} to {:?}", from, to);
 		let id = self.ongoing.lock().add(TaskKind::User, name);
+
+		if to.starts_with(&from) {
+			self.new_and_fail(id, "Cannot copy directory into itself").ok();
+			return;
+		}
 
 		let file = self.file.clone();
 		_ = self.micro.try_send(
@@ -398,5 +409,11 @@ impl Scheduler {
 				}
 			}
 		})
+	}
+
+	fn new_and_fail(&self, id: usize, reason: &str) -> Result<()> {
+		self.prog.send(TaskProg::New(id, 0))?;
+		self.prog.send(TaskProg::Fail(id, reason.to_owned()))?;
+		Ok(())
 	}
 }

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -72,7 +72,7 @@ impl Scheduler {
 		let mut ongoing = self.ongoing.lock();
 		let id = ongoing.add(TaskKind::User, format!("Cut {:?} to {:?}", from, to));
 
-		if to.starts_with(&from) {
+		if to.starts_with(&from) && to != from {
 			self.new_and_fail(id, "Cannot cut directory into itself").ok();
 			return;
 		}
@@ -110,7 +110,7 @@ impl Scheduler {
 		let name = format!("Copy {:?} to {:?}", from, to);
 		let id = self.ongoing.lock().add(TaskKind::User, name);
 
-		if to.starts_with(&from) {
+		if to.starts_with(&from) && to != from {
 			self.new_and_fail(id, "Cannot copy directory into itself").ok();
 			return;
 		}


### PR DESCRIPTION
Closes #894 

Just the first approach I could think of but let me know if you had something else in mind.

Edit: Figured out a much easier way - did not know about `path.startswith` haha