### PR TITLE
feat: add new `bulk` event kind to DDS

### DIFF
--- a/yazi-core/src/manager/commands/bulk_rename.rs
+++ b/yazi-core/src/manager/commands/bulk_rename.rs
@@ -98,8 +98,7 @@ impl Manager {
 		}
 
 		if !succeeded.is_empty() {
-			// Pubsub::pub_from_bulk(tab, &changes);
-
+			Pubsub::pub_from_bulk(tab, succeeded.iter().map(|(u, f)| (u, &f.url)).collect());
 			FilesOp::Upserting(cwd, succeeded).emit();
 		}
 		drop(permit);

--- a/yazi-core/src/manager/commands/bulk_rename.rs
+++ b/yazi-core/src/manager/commands/bulk_rename.rs
@@ -91,7 +91,7 @@ impl Manager {
 			} else if let Err(e) = fs::rename(&old, &new).await {
 				failed.push((o, n, e.into()));
 			} else if let Ok(f) = File::from(new.into()).await {
-				succeeded.insert(Url::from(old), f.clone());
+				succeeded.insert(Url::from(old), f);
 			} else {
 				failed.push((o, n, anyhow!("Failed to retrieve file info")));
 			}

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -54,7 +54,6 @@ impl Body<'static> {
 		match Self::from_str(kind, body) {
 			Ok(Self::Cd(b)) => b.tab,
 			Ok(Self::Hover(b)) => b.tab,
-			Ok(Self::Bulk(b)) => b.tab,
 			Ok(Self::Rename(b)) => b.tab,
 			_ => 0,
 		}

--- a/yazi-dds/src/body/bulk.rs
+++ b/yazi-dds/src/body/bulk.rs
@@ -21,7 +21,7 @@ impl<'a> BodyBulk<'a> {
 
 impl BodyBulk<'static> {
 	#[inline]
-	pub fn dummy(tab: usize, changes: &HashMap<Url, Url>) -> Body<'static> {
+	pub fn owned(tab: usize, changes: &HashMap<Url, Url>) -> Body<'static> {
 		Self { tab, changes: Cow::Owned(changes.clone()) }.into()
 	}
 }

--- a/yazi-dds/src/body/bulk.rs
+++ b/yazi-dds/src/body/bulk.rs
@@ -21,7 +21,7 @@ impl<'a> BodyBulk<'a> {
 
 impl BodyBulk<'static> {
 	#[inline]
-	pub fn owned(tab: usize, changes: &HashMap<Url, Url>) -> Body<'static> {
+	pub fn dummy(tab: usize, changes: &HashMap<Url, Url>) -> Body<'static> {
 		Self { tab, changes: Cow::Owned(changes.clone()) }.into()
 	}
 }

--- a/yazi-dds/src/body/bulk.rs
+++ b/yazi-dds/src/body/bulk.rs
@@ -9,20 +9,27 @@ use super::Body;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BodyBulk<'a> {
 	pub tab:     usize,
-	pub changes: Cow<'a, HashMap<Url, Url>>,
+	pub changes: HashMap<Cow<'a, Url>, Cow<'a, Url>>,
 }
 
 impl<'a> BodyBulk<'a> {
 	#[inline]
-	pub fn borrowed(tab: usize, changes: &'a HashMap<Url, Url>) -> Body<'a> {
-		Self { tab, changes: Cow::Borrowed(changes) }.into()
+	pub fn borrowed(tab: usize, changes: &HashMap<&'a Url, &'a Url>) -> Body<'a> {
+		let iter = changes.iter().map(|(&from, &to)| (Cow::Borrowed(from), Cow::Borrowed(to)));
+
+		Self { tab, changes: iter.collect() }.into()
 	}
 }
 
 impl BodyBulk<'static> {
 	#[inline]
-	pub fn owned(tab: usize, changes: &HashMap<Url, Url>) -> Body<'static> {
-		Self { tab, changes: Cow::Owned(changes.clone()) }.into()
+	pub fn owned(tab: usize, changes: &HashMap<&Url, &Url>) -> Body<'static> {
+		let changes = changes
+			.iter()
+			.map(|(&from, &to)| (Cow::Owned(from.clone()), Cow::Owned(to.clone())))
+			.collect();
+
+		Self { tab, changes }.into()
 	}
 }
 
@@ -32,14 +39,14 @@ impl<'a> From<BodyBulk<'a>> for Body<'a> {
 
 impl IntoLua<'_> for BodyBulk<'static> {
 	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
-		BodyBulkIter { tab: self.tab, inner: self.changes.into_owned().into_iter() }.into_lua(lua)
+		BodyBulkIter { tab: self.tab, inner: self.changes.into_iter() }.into_lua(lua)
 	}
 }
 
 // --- Iterator
 pub struct BodyBulkIter {
 	pub tab:   usize,
-	pub inner: hash_map::IntoIter<Url, Url>,
+	pub inner: hash_map::IntoIter<Cow<'static, Url>, Cow<'static, Url>>,
 }
 
 impl UserData for BodyBulkIter {
@@ -52,7 +59,7 @@ impl UserData for BodyBulkIter {
 
 		methods.add_meta_function(MetaMethod::Pairs, |lua, me: AnyUserData| {
 			let iter = lua.create_function(|lua, mut me: UserDataRefMut<Self>| {
-				if let Some((from, to)) = me.inner.next() {
+				if let Some((Cow::Owned(from), Cow::Owned(to))) = me.inner.next() {
 					(lua.create_any_userdata(from)?, lua.create_any_userdata(to)?).into_lua_multi(lua)
 				} else {
 					().into_lua_multi(lua)

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -130,15 +130,15 @@ impl Pubsub {
 		}
 	}
 
-	pub fn pub_from_bulk(tab: usize, changes: &HashMap<Url, Url>) {
+	pub fn pub_from_bulk(tab: usize, changes: HashMap<&Url, &Url>) {
 		if LOCAL.read().contains_key("bulk") {
-			Self::pub_(BodyBulk::owned(tab, changes));
+			Self::pub_(BodyBulk::owned(tab, &changes));
 		}
 		if PEERS.read().values().any(|p| p.able("bulk")) {
-			Client::push(BodyBulk::borrowed(tab, changes));
+			Client::push(BodyBulk::borrowed(tab, &changes));
 		}
 		if BOOT.local_events.contains("bulk") {
-			BodyBulk::borrowed(tab, changes).with_receiver(*ID).flush();
+			BodyBulk::borrowed(tab, &changes).with_receiver(*ID).flush();
 		}
 	}
 

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -5,7 +5,7 @@ use parking_lot::RwLock;
 use yazi_boot::BOOT;
 use yazi_shared::{fs::Url, RoCell};
 
-use crate::{body::{Body, BodyCd, BodyDelete, BodyHi, BodyHover, BodyMove, BodyMoveItem, BodyRename, BodyTrash, BodyYank}, Client, ID, PEERS};
+use crate::{body::{Body, BodyBulk, BodyCd, BodyDelete, BodyHi, BodyHover, BodyMove, BodyMoveItem, BodyRename, BodyTrash, BodyYank}, Client, ID, PEERS};
 
 pub static LOCAL: RoCell<RwLock<HashMap<String, HashMap<String, Function<'static>>>>> =
 	RoCell::new();
@@ -115,6 +115,18 @@ impl Pubsub {
 		}
 		if BOOT.local_events.contains("hover") {
 			BodyHover::borrowed(tab, url).with_receiver(*ID).flush();
+		}
+	}
+
+	pub fn pub_from_bulk(tab: usize, changes: &HashMap<Url, Url>) {
+		if LOCAL.read().contains_key("bulk") {
+			Self::pub_(BodyBulk::dummy(tab, changes));
+		}
+		if PEERS.read().values().any(|p| p.able("bulk")) {
+			Client::push(BodyBulk::borrowed(tab, changes));
+		}
+		if BOOT.local_events.contains("bulk") {
+			BodyBulk::borrowed(tab, changes).with_receiver(*ID).flush();
 		}
 	}
 

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -130,15 +130,15 @@ impl Pubsub {
 		}
 	}
 
-	pub fn pub_from_bulk(tab: usize, changes: HashMap<&Url, &Url>) {
+	pub fn pub_from_bulk(changes: HashMap<&Url, &Url>) {
 		if LOCAL.read().contains_key("bulk") {
-			Self::pub_(BodyBulk::owned(tab, &changes));
+			Self::pub_(BodyBulk::owned(&changes));
 		}
 		if PEERS.read().values().any(|p| p.able("bulk")) {
-			Client::push(BodyBulk::borrowed(tab, &changes));
+			Client::push(BodyBulk::borrowed(&changes));
 		}
 		if BOOT.local_events.contains("bulk") {
-			BodyBulk::borrowed(tab, &changes).with_receiver(*ID).flush();
+			BodyBulk::borrowed(&changes).with_receiver(*ID).flush();
 		}
 	}
 

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -118,18 +118,6 @@ impl Pubsub {
 		}
 	}
 
-	pub fn pub_from_bulk(tab: usize, changes: &HashMap<Url, Url>) {
-		if LOCAL.read().contains_key("bulk") {
-			Self::pub_(BodyBulk::dummy(tab, changes));
-		}
-		if PEERS.read().values().any(|p| p.able("bulk")) {
-			Client::push(BodyBulk::borrowed(tab, changes));
-		}
-		if BOOT.local_events.contains("bulk") {
-			BodyBulk::borrowed(tab, changes).with_receiver(*ID).flush();
-		}
-	}
-
 	pub fn pub_from_rename(tab: usize, from: &Url, to: &Url) {
 		if LOCAL.read().contains_key("rename") {
 			Self::pub_(BodyRename::dummy(tab, from, to));
@@ -139,6 +127,18 @@ impl Pubsub {
 		}
 		if BOOT.local_events.contains("rename") {
 			BodyRename::borrowed(tab, from, to).with_receiver(*ID).flush();
+		}
+	}
+
+	pub fn pub_from_bulk(tab: usize, changes: &HashMap<Url, Url>) {
+		if LOCAL.read().contains_key("bulk") {
+			Self::pub_(BodyBulk::owned(tab, changes));
+		}
+		if PEERS.read().values().any(|p| p.able("bulk")) {
+			Client::push(BodyBulk::borrowed(tab, changes));
+		}
+		if BOOT.local_events.contains("bulk") {
+			BodyBulk::borrowed(tab, changes).with_receiver(*ID).flush();
 		}
 	}
 


### PR DESCRIPTION
This makes bulk renaming send one event per rename, exactly how the existing rename events are sent.


https://github.com/sxyazi/yazi/assets/300791/b43ef535-a38d-46cc-9055-241ef4bc12d1



I have a couple of ideas related to bulk renaming that I want to explore in neovim. I think I'll open an issue for discussion separately.