### PR TITLE
feat: allow building with the system Lua

### DIFF
--- a/yazi-dds/Cargo.toml
+++ b/yazi-dds/Cargo.toml
@@ -8,13 +8,17 @@ description = "Yazi data distribution service"
 homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
+[features]
+default      = [ "vendored-lua" ]
+vendored-lua = [ "mlua/vendored" ]
+
 [dependencies]
 yazi-boot   = { path = "../yazi-boot", version = "0.2.5" }
 yazi-shared = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies
 anyhow       = "1.0.82"
-mlua         = { version = "0.9.7", features = [ "lua54", "vendored" ] }
+mlua         = { version = "0.9.7", features = [ "lua54" ] }
 parking_lot  = "0.12.1"
 serde        = { version = "1.0.198", features = [ "derive" ] }
 serde_json   = "1.0.116"

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -8,6 +8,10 @@ description = "Yazi File Manager"
 homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
+[features]
+default      = [ "vendored-lua" ]
+vendored-lua = [ "mlua/vendored" ]
+
 [dependencies]
 yazi-adaptor = { path = "../yazi-adaptor", version = "0.2.5" }
 yazi-boot    = { path = "../yazi-boot", version = "0.2.5" }
@@ -24,7 +28,7 @@ better-panic = "0.3.0"
 crossterm    = { version = "0.27.0", features = [ "event-stream" ] }
 fdlimit      = "0.3.0"
 futures      = "0.3.30"
-mlua         = { version = "0.9.7", features = [ "lua54", "vendored" ] }
+mlua         = { version = "0.9.7", features = [ "lua54" ] }
 ratatui      = "=0.26.1"
 scopeguard   = "1.2.0"
 syntect      = { version = "5.2.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -8,6 +8,10 @@ description = "Yazi plugin system"
 homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
+[features]
+default      = [ "vendored-lua" ]
+vendored-lua = [ "mlua/vendored" ]
+
 [dependencies]
 yazi-adaptor = { path = "../yazi-adaptor", version = "0.2.5" }
 yazi-boot    = { path = "../yazi-boot", version = "0.2.5" }
@@ -21,7 +25,7 @@ ansi-to-tui   = "3.1.0"
 anyhow        = "1.0.82"
 futures       = "0.3.30"
 md-5          = "0.10.6"
-mlua          = { version = "0.9.7", features = [ "lua54", "vendored", "serialize", "macros", "async" ] }
+mlua          = { version = "0.9.7", features = [ "lua54", "serialize", "macros", "async" ] }
 parking_lot   = "0.12.1"
 ratatui       = "=0.26.1"
 serde         = "1.0.198"

--- a/yazi-proxy/Cargo.toml
+++ b/yazi-proxy/Cargo.toml
@@ -8,11 +8,15 @@ description = "Yazi event proxy"
 homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
+[features]
+default      = [ "vendored-lua" ]
+vendored-lua = [ "mlua/vendored" ]
+
 [dependencies]
 yazi-config = { path = "../yazi-config", version = "0.2.5" }
 yazi-shared = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies
 anyhow = "1.0.82"
-mlua   = { version = "0.9.7", features = [ "lua54", "vendored" ] }
+mlua   = { version = "0.9.7", features = [ "lua54" ] }
 tokio  = { version = "1.37.0", features = [ "full" ] }


### PR DESCRIPTION
Still defaults to vendored lua, but that can be overridden by using `--no-default-features`