### PR TITLE
feat: add more rules to `[filetype]` and `[icon]`

### DIFF
--- a/yazi-config/preset/theme.toml
+++ b/yazi-config/preset/theme.toml
@@ -170,10 +170,10 @@ icon_error = ""
 
 rules = [
 	# Images
-	{ mime = "image/*", fg = "cyan" },
+	{ mime = "image/*", fg = "yellow" },
 
 	# Media
-	{ mime = "{audio,video}/*", fg = "yellow" },
+	{ mime = "{audio,video}/*", fg = "yellow", bold = true },
 
 	# Archives
 	{ mime = "application/*zip", fg = "magenta" },
@@ -186,7 +186,7 @@ rules = [
 	{ mime = "inode/x-empty", fg = "red" },
 
 	# Is-rules
-	{ name = "*" , is = "orphan", fg = "red" },
+	{ name = "*" , is = "orphan", fg = "cyan", crossed = true },
 	{ name = "*" , is = "link"  , fg = "cyan" },
 	{ name = "*/", is = "link"  , fg = "cyan" },
 	{ name = "*" , is = "exec"  , fg = "green" },

--- a/yazi-config/preset/theme.toml
+++ b/yazi-config/preset/theme.toml
@@ -173,23 +173,21 @@ rules = [
 	{ mime = "image/*", fg = "yellow" },
 
 	# Media
-	{ mime = "{audio,video}/*", fg = "yellow", bold = true },
+	{ mime = "{audio,video}/*", fg = "magenta" },
 
 	# Archives
-	{ mime = "application/*zip", fg = "magenta" },
-	{ mime = "application/x-{tar,bzip*,7z-compressed,xz,rar}", fg = "magenta" },
+	{ mime = "application/*zip", fg = "red" },
+	{ mime = "application/x-{tar,bzip*,7z-compressed,xz,rar}", fg = "red" },
 
 	# Documents
-	{ mime = "application/{pdf,doc,rtf,vnd.*}", fg = "green" },
+	{ mime = "application/{pdf,doc,rtf,vnd.*}", fg = "cyan" },
 
 	# Empty files
-	{ mime = "inode/x-empty", fg = "red" },
+	# { mime = "inode/x-empty", fg = "red" },
 
-	# Is-rules
-	{ name = "*" , is = "orphan", fg = "cyan", crossed = true },
-	{ name = "*" , is = "link"  , fg = "cyan" },
-	{ name = "*/", is = "link"  , fg = "cyan" },
-	{ name = "*" , is = "exec"  , fg = "green" },
+	# Special files
+	{ name = "*", is = "orphan", bg = "red" },
+	{ name = "*", is = "exec"  , fg = "green" },
 
 	# Fallback
 	# { name = "*", fg = "white" },
@@ -343,6 +341,16 @@ rules = [
 	{ name = "*/Pictures/"   , text = "" },
 	{ name = "*/Public/"     , text = "" },
 	{ name = "*/Videos/"     , text = "" },
+
+	# Special files
+	{ name = "*", is = "orphan", text = "" },
+	{ name = "*", is = "link"  , text = "" },
+	{ name = "*", is = "block" , text = "" },
+	{ name = "*", is = "char"  , text = "" },
+	{ name = "*", is = "fifo"  , text = "" },
+	{ name = "*", is = "sock"  , text = "" },
+	{ name = "*", is = "sticky", text = "" },
+	{ name = "*", is = "exec"  , text = "" },
 
 	# Default
 	{ name = "*" , text = "" },

--- a/yazi-config/preset/theme.toml
+++ b/yazi-config/preset/theme.toml
@@ -182,6 +182,15 @@ rules = [
 	# Documents
 	{ mime = "application/{pdf,doc,rtf,vnd.*}", fg = "green" },
 
+	# Empty files
+	{ mime = "inode/x-empty", fg = "red" },
+
+	# Is-rules
+	{ name = "*" , is = "orphan", fg = "red" },
+	{ name = "*" , is = "link"  , fg = "cyan" },
+	{ name = "*/", is = "link"  , fg = "cyan" },
+	{ name = "*" , is = "exec"  , fg = "green" },
+
 	# Fallback
 	# { name = "*", fg = "white" },
 	{ name = "*/", fg = "blue" }

--- a/yazi-plugin/preset/components/file.lua
+++ b/yazi-plugin/preset/components/file.lua
@@ -24,12 +24,12 @@ function File:highlights(file)
 	end
 
 	local spans, last = {}, 0
-	for _, r in ipairs(highlights) do
-		if r[1] > last then
-			spans[#spans + 1] = ui.Span(name:sub(last + 1, r[1]))
+	for _, h in ipairs(highlights) do
+		if h[1] > last then
+			spans[#spans + 1] = ui.Span(name:sub(last + 1, h[1]))
 		end
-		spans[#spans + 1] = ui.Span(name:sub(r[1] + 1, r[2])):style(THEME.manager.find_keyword)
-		last = r[2]
+		spans[#spans + 1] = ui.Span(name:sub(h[1] + 1, h[2])):style(THEME.manager.find_keyword)
+		last = h[2]
 	end
 	if last < #name then
 		spans[#spans + 1] = ui.Span(name:sub(last + 1))


### PR DESCRIPTION
This adds rules for empty files, links and executables.

Coloring is based on [eza's default theme](https://github.com/eza-community/eza/blob/main/src/theme/default_theme.rs). This also seems to be a default across  terminal file managers.