### PR TITLE
feat: add `*.opus` file icon

### DIFF
--- a/yazi-config/preset/theme.toml
+++ b/yazi-config/preset/theme.toml
@@ -268,6 +268,7 @@ rules = [
 	{ name = "*.m4a" , text = "", fg = "#66D8EF" },
 	{ name = "*.mp3" , text = "", fg = "#66D8EF" },
 	{ name = "*.ogg" , text = "", fg = "#66D8EF" },
+	{ name = "*.opus", text = "", fg = "#66D8EF" },
 	{ name = "*.wav" , text = "", fg = "#66D8EF" },
 
 	# Documents


### PR DESCRIPTION
Adds support for [Opus audio format](https://en.m.wikipedia.org/wiki/Opus_(audio_format)).Opus is widely used and has replaced mp3 in many places.