### PR TITLE
feat: allow building with the system Lua

### DIFF
--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -8,8 +8,12 @@ description = "Yazi command-line interface"
 homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
+[features]
+default      = [ "vendored-lua" ]
+vendored-lua = [ "yazi-dds/vendored-lua" ]
+
 [dependencies]
-yazi-dds = { path = "../yazi-dds", version = "0.2.5" }
+yazi-dds = { path = "../yazi-dds", version = "0.2.5", default-features = false }
 
 # External dependencies
 anyhow     = "1.0.82"

--- a/yazi-core/Cargo.toml
+++ b/yazi-core/Cargo.toml
@@ -12,9 +12,9 @@ repository  = "https://github.com/sxyazi/yazi"
 yazi-adaptor   = { path = "../yazi-adaptor", version = "0.2.5" }
 yazi-boot      = { path = "../yazi-boot", version = "0.2.5" }
 yazi-config    = { path = "../yazi-config", version = "0.2.5" }
-yazi-dds       = { path = "../yazi-dds", version = "0.2.5" }
-yazi-plugin    = { path = "../yazi-plugin", version = "0.2.5" }
-yazi-proxy     = { path = "../yazi-proxy", version = "0.2.5" }
+yazi-dds       = { path = "../yazi-dds", version = "0.2.5", default-features = false }
+yazi-plugin    = { path = "../yazi-plugin", version = "0.2.5", default-features = false }
+yazi-proxy     = { path = "../yazi-proxy", version = "0.2.5", default-features = false }
 yazi-scheduler = { path = "../yazi-scheduler", version = "0.2.5" }
 yazi-shared    = { path = "../yazi-shared", version = "0.2.5" }
 

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -10,16 +10,16 @@ repository  = "https://github.com/sxyazi/yazi"
 
 [features]
 default      = [ "vendored-lua" ]
-vendored-lua = [ "mlua/vendored" ]
+vendored-lua = [ "mlua/vendored", "yazi-dds/vendored-lua", "yazi-plugin/vendored-lua", "yazi-proxy/vendored-lua" ]
 
 [dependencies]
 yazi-adaptor = { path = "../yazi-adaptor", version = "0.2.5" }
 yazi-boot    = { path = "../yazi-boot", version = "0.2.5" }
 yazi-config  = { path = "../yazi-config", version = "0.2.5" }
 yazi-core    = { path = "../yazi-core", version = "0.2.5" }
-yazi-dds     = { path = "../yazi-dds", version = "0.2.5" }
-yazi-plugin  = { path = "../yazi-plugin", version = "0.2.5" }
-yazi-proxy   = { path = "../yazi-proxy", version = "0.2.5" }
+yazi-dds     = { path = "../yazi-dds", version = "0.2.5", default-features = false }
+yazi-plugin  = { path = "../yazi-plugin", version = "0.2.5", default-features = false }
+yazi-proxy   = { path = "../yazi-proxy", version = "0.2.5", default-features = false }
 yazi-shared  = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -16,8 +16,8 @@ vendored-lua = [ "mlua/vendored" ]
 yazi-adaptor = { path = "../yazi-adaptor", version = "0.2.5" }
 yazi-boot    = { path = "../yazi-boot", version = "0.2.5" }
 yazi-config  = { path = "../yazi-config", version = "0.2.5" }
-yazi-dds     = { path = "../yazi-dds", version = "0.2.5" }
-yazi-proxy   = { path = "../yazi-proxy", version = "0.2.5" }
+yazi-dds     = { path = "../yazi-dds", version = "0.2.5", default-features = false }
+yazi-proxy   = { path = "../yazi-proxy", version = "0.2.5", default-features = false }
 yazi-shared  = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -10,9 +10,9 @@ repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
 yazi-config = { path = "../yazi-config", version = "0.2.5" }
-yazi-dds    = { path = "../yazi-dds", version = "0.2.5" }
-yazi-plugin = { path = "../yazi-plugin", version = "0.2.5" }
-yazi-proxy  = { path = "../yazi-proxy", version = "0.2.5" }
+yazi-dds    = { path = "../yazi-dds", version = "0.2.5", default-features = false }
+yazi-plugin = { path = "../yazi-plugin", version = "0.2.5", default-features = false }
+yazi-proxy  = { path = "../yazi-proxy", version = "0.2.5", default-features = false }
 yazi-shared = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies


### PR DESCRIPTION
As per https://github.com/sxyazi/yazi/pull/943#issuecomment-2075013872

I tried to use `default-features = false` in the deps of `yazi-fm` and `yazi-cli` and have `vendored-lua` to be default in the dependencies, but when I did that it would just build with vendored lua every time. This is the only method that I could get to actually work, sorry if it's not ideal. :( 