### PR TITLE
feat: re-enable the file `created` attribute

### DIFF
--- a/yazi-shared/src/fs/cha.rs
+++ b/yazi-shared/src/fs/cha.rs
@@ -61,8 +61,7 @@ impl From<Metadata> for Cha {
 			kind:     ck,
 			len:      m.len(),
 			accessed: m.accessed().ok(),
-			// TODO: remove this once https://github.com/rust-lang/rust/issues/108277 is fixed.
-			created:  None,
+			created:  m.created().ok(),
 			modified: m.modified().ok(),
 
 			#[cfg(unix)]


### PR DESCRIPTION
Issue https://github.com/rust-lang/rust/issues/108277 has been resolved and https://github.com/rust-lang/rust/pull/114038 is released with rust 1.78.0 on May 2nd, this revision allows `h.cha.created` usage, e.g.:

```lua
function Status:date()
	local h = cx.active.current.hovered
	if not h then
		return ui.Span('')
	end

	local spans = {}
	local show = {
		modified = { 'm', 'yellow' },
		created  = { 'c', 'green' },
		accessed = { 'a', 'blue' },
	}

	for key, display in pairs(show) do
		if h.cha[key] ~= nil and h.cha[key] then
			local time = ya.round(h.cha[key])
			local ok, fmt = pcall(os.date, '%Y-%m-%d %H:%M', time)
			if ok then
				table.insert(spans, ui.Span(display[1] .. ' '))
				table.insert(spans, ui.Span(fmt .. ' '):fg(display[2]))
			end
		end
	end
	return ui.Line(spans)
end
```