### PR TITLE
fix: temporarily disable the file creation time until Rust v1.78.0 becomes popular

### DIFF
--- a/yazi-shared/src/fs/cha.rs
+++ b/yazi-shared/src/fs/cha.rs
@@ -61,7 +61,8 @@ impl From<Metadata> for Cha {
 			kind:     ck,
 			len:      m.len(),
 			accessed: m.accessed().ok(),
-			created:  m.created().ok(),
+			// TODO: remove this once https://github.com/rust-lang/rust/issues/108277 is fixed.
+			created:  None,
 			modified: m.modified().ok(),
 
 			#[cfg(unix)]


### PR DESCRIPTION
There was a bug in Rust versions before 1.78.0 that caused a crash when trying to get the creation time of a file.

Rust team recently released version 1.78.0 which fixes this bug, so in PR https://github.com/sxyazi/yazi/pull/987 we have re-enabled the creation time.

But the archlinuxcn repository currently [does not support the latest Rust](https://github.com/sxyazi/yazi/issues/990#issuecomment-2090847809) version, so let's temporarily disable it for now.

Fixes https://github.com/sxyazi/yazi/issues/990

CC @rafi