### PR TITLE
feat: support `cargo binstall yazi-fm` and `cargo binstall yazi-cli`

### DIFF
--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -28,3 +28,7 @@ serde_json            = "1.0.116"
 [[bin]]
 name = "ya"
 path = "src/main.rs"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/yazi-{ target }{ archive-suffix }"
+bin-dir = "yazi-{ target }/{ bin }{ binary-ext }"

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -50,3 +50,7 @@ tikv-jemallocator = "0.5.4"
 [[bin]]
 name = "yazi"
 path = "src/main.rs"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/yazi-{ target }{ archive-suffix }"
+bin-dir = "yazi-{ target }/{ bin }{ binary-ext }"


### PR DESCRIPTION
This will enable binstall installs work directly from github. Required for raspberry pi.
This is needed since crate name is `yazi-fm` but the archive files are named `yazi-`