### PR TITLE
feat: yazi --debug shows `ya` version in its output

### DIFF
--- a/yazi-boot/src/boot.rs
+++ b/yazi-boot/src/boot.rs
@@ -56,7 +56,7 @@ impl Boot {
 		writeln!(s, "    Debug: {}", cfg!(debug_assertions))?;
 
 		writeln!(s, "\nYa")?;
-		writeln!(s, "    Version: {:?}", Command::new("ya").args(["--version"]).output())?;
+		writeln!(s, "    Version: {:?}", Command::new("ya").arg("--version").output())?;
 
 		writeln!(s, "\nEmulator")?;
 		writeln!(s, "    Emulator.via_env: {:?}", yazi_adaptor::Emulator::via_env())?;

--- a/yazi-boot/src/boot.rs
+++ b/yazi-boot/src/boot.rs
@@ -55,6 +55,9 @@ impl Boot {
 		writeln!(s, "    OS: {}-{} ({})", OS, ARCH, FAMILY)?;
 		writeln!(s, "    Debug: {}", cfg!(debug_assertions))?;
 
+		writeln!(s, "\nYa")?;
+		writeln!(s, "    Version: {:?}", Command::new("ya").args(["--version"]).output())?;
+
 		writeln!(s, "\nEmulator")?;
 		writeln!(s, "    Emulator.via_env: {:?}", yazi_adaptor::Emulator::via_env())?;
 		writeln!(s, "    Emulator.via_csi: {:?}", yazi_adaptor::Emulator::via_csi())?;


### PR DESCRIPTION
Solves https://github.com/sxyazi/yazi/issues/995

Example output:

```sh
Yazi
    Version: 0.2.5 (aee65bc 2024-05-04)
    OS: macos-aarch64 (unix)
    Debug: true

Ya
    Version: Ok(Output { status: ExitStatus(unix_wait_status(0)), stdout: "ya 0.2.5\n", stderr: "" })

Emulator
    Emulator.via_env: ("xterm-256color", "WezTerm")
    Emulator.via_csi: Ok(WezTerm)
    Emulator.detect: WezTerm
...
```