### PR TITLE
feat: `ya pack` displays help if no arguments are given

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -83,6 +83,7 @@ impl CommandPubStatic {
 }
 
 #[derive(clap::Args)]
+#[command(arg_required_else_help = true)]
 pub(super) struct CommandPack {
 	/// Add a package.
 	#[arg(short = 'a', long)]


### PR DESCRIPTION
It used to do nothing before this change.