### PR TITLE
fix: correct wasm target condition

### DIFF
--- a/yazi-plugin/src/utils/target.rs
+++ b/yazi-plugin/src/utils/target.rs
@@ -15,7 +15,7 @@ impl Utils {
 				{
 					Ok("windows")
 				}
-				#[cfg(wasm)]
+				#[cfg(target_family = "wasm")]
 				{
 					Ok("wasm")
 				}


### PR DESCRIPTION
As of [this blog post](https://blog.rust-lang.org/2024/05/06/check-cfg.html), rust nightly checks `cfg` annotations to make sure they are valid and actually refer to a real cfg. Using one of the recent versions of nightly, I started to get warnings that `cfg(wasm)` isn't a real cfg, so this config prevents compilation of that block in all instances. 

In this PR, I fixed it to actually only compile under wasm, as per [the reference on conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html)