### PR TITLE
fix: `ya pack` supports yazi packages that end in `.yazi`

### DIFF
--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -22,8 +22,9 @@ impl Package {
 		let tracker = to.join(TRACKER);
 		if maybe_exists(&to).await && !must_exists(&tracker).await {
 			bail!(
-				"A user package with the same name `{name}` already exists.
-For safety, please manually delete it from your plugin/flavor directory and re-run the command."
+				"A user package with the same name `{}` already exists.
+For safety, please manually delete it and re-run the command.",
+				to.display()
 			);
 		}
 

--- a/yazi-cli/src/package/package.rs
+++ b/yazi-cli/src/package/package.rs
@@ -81,22 +81,6 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn test_adds_yazi_suffix() {
-		// if a package doesn't have a suffix, it should add ".yazi" to the end
-		let package = Package::new("abcd/my-plugin.yazi", None);
-		assert_eq!(package, Package {
-			repo:      "abcd/my-plugin.yazi".to_owned(),
-			child:     "".to_owned(),
-			commit:    "".to_owned(),
-			is_flavor: false,
-		});
-
-		assert_eq!(package.use_(), "abcd/my-plugin.yazi");
-		assert_eq!(package.name(), Some("my-plugin.yazi"));
-		assert_eq!(package.remote(), "https://github.com/abcd/my-plugin.yazi.git");
-	}
-
-	#[test]
 	fn test_supports_subdirectories() {
 		let package = Package::new("yazi-rs/flavors#catppuccin-mocha.yazi", None);
 		assert_eq!(package, Package {

--- a/yazi-cli/src/package/package.rs
+++ b/yazi-cli/src/package/package.rs
@@ -6,6 +6,8 @@ use yazi_shared::Xdg;
 
 pub(crate) struct Package {
 	pub(crate) repo:      String,
+	/// When a package is a subdirectory of a repository, this field will be set
+	/// to the subdirectory name.
 	pub(crate) child:     String,
 	pub(crate) commit:    String,
 	pub(super) is_flavor: bool,


### PR DESCRIPTION
This fixes the following issue:

![image](https://github.com/sxyazi/yazi/assets/300791/afbeded6-77ea-4e86-956a-96fffd27bd7c)

This is what it looks like with this fix applied:

![image](https://github.com/sxyazi/yazi/assets/300791/8e13174d-1b9b-46ac-8770-07892423ca58)
