### PR TITLE
fix: recognize `TERM=rxvt-unicode-256color`

### DIFF
--- a/yazi-adaptor/src/emulator.rs
+++ b/yazi-adaptor/src/emulator.rs
@@ -24,6 +24,7 @@ pub enum Emulator {
 	Mintty,
 	Neovim,
 	Apple,
+	Urxvt,
 }
 
 impl Emulator {
@@ -43,6 +44,7 @@ impl Emulator {
 			Self::Mintty => vec![Adaptor::Iterm2],
 			Self::Neovim => vec![],
 			Self::Apple => vec![],
+			Self::Urxvt => vec![],
 		}
 	}
 }
@@ -85,6 +87,7 @@ impl Emulator {
 			"foot" => return Self::Foot,
 			"foot-extra" => return Self::Foot,
 			"xterm-ghostty" => return Self::Ghostty,
+			"rxvt-unicode-256color" => return Self::Urxvt,
 			_ => warn!("[Adaptor] Unknown TERM: {term}"),
 		}
 


### PR DESCRIPTION
Fixes #1026.

I confirmed that <code>cargo build --release && target/release/yazi</code> and pressing <kbd>q</kbd> to exit no longer leaves characters on the next line.

`target/release/yazi --debug >/dev/null` still does, but I think that is intentional and fine. The `--debug` output contains:

```console
...
Emulator
    Emulator.via_env: ("rxvt-unicode-256color", "")
    Emulator.via_csi: Ok(Unknown([]))
    Emulator.detect: Urxvt
...
```

According to https://www.arewesixelyet.com/#urxvt, SIXEL graphics format is not supported by this terminal emulator, but I wasn't sure how to determine whether Adaptor::Iterm2 would be supported.