### PR TITLE
ci: consistently enforce Lua coding style

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,3 +39,15 @@ jobs:
 
       - name: Rustfmt
         run: cargo +nightly fmt --all -- --check
+
+  stylua:
+    name: stylua
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          # CLI arguments
+          args: --color always --check .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,6 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
   stylua:
-    name: stylua
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -49,5 +48,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          # CLI arguments
           args: --color always --check .

--- a/.styluaignore
+++ b/.styluaignore
@@ -1,0 +1,2 @@
+# this file caused some issues with the build system
+yazi-plugin/preset/plugins/mime.lua

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_width = 2
+call_parentheses = "NoSingleTable"
+collapse_simple_statement = "FunctionOnly"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,3 +1,6 @@
-indent_width = 2
-call_parentheses = "NoSingleTable"
+indent_width              = 2
+call_parentheses          = "NoSingleTable"
 collapse_simple_statement = "FunctionOnly"
+
+[sort_requires]
+enabled = true


### PR DESCRIPTION
This commit adds a GitHub Actions workflow that checks the lua files against the yazi lua coding style.

The workflow uses the `stylua` tool, which can be installed using cargo:

```sh
cargo install stylua --features lua54
```

I picked the options for the formatter in a way that forced minimal changes to the existing style.

<https://github.com/JohnnyMorganz/StyLua?tab=readme-ov-file#options>