### PR TITLE
feat: support `stdin` and pipe for `Child` API

### DIFF
--- a/yazi-core/src/input/commands/kill.rs
+++ b/yazi-core/src/input/commands/kill.rs
@@ -70,6 +70,7 @@ impl Input {
 		let snap = self.snap_mut();
 
 		match opt.kind.as_str() {
+			"all" => self.kill_range(..),
 			"bol" => {
 				let end = snap.idx(snap.cursor).unwrap_or(snap.len());
 				self.kill_range(..end)

--- a/yazi-core/src/input/input.rs
+++ b/yazi-core/src/input/input.rs
@@ -87,16 +87,17 @@ impl Input {
 	}
 
 	pub(super) fn flush_value(&mut self) {
+		let Some(tx) = &self.callback else { return };
 		self.ticket = self.ticket.wrapping_add(1);
 
 		if self.realtime {
 			let value = self.snap().value.clone();
-			self.callback.as_ref().unwrap().send(Err(InputError::Typed(value))).ok();
+			tx.send(Err(InputError::Typed(value))).ok();
 		}
 
 		if self.completion {
 			let before = self.partition()[0].to_owned();
-			self.callback.as_ref().unwrap().send(Err(InputError::Completed(before, self.ticket))).ok();
+			tx.send(Err(InputError::Completed(before, self.ticket))).ok();
 		}
 	}
 }


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/1030

Closes https://github.com/sxyazi/yazi/issues/1030

```lua
local echo = Command("echo"):arg("Hello"):stdout(Command.PIPED):spawn()

local rev = Command("rev"):stdin(echo:take_stdout()):stdout(Command.PIPED):output()

ya.err(rev.stdout) -- "olleH\n"
```