### PR TITLE
fix: remove `ignore` options from `rg` and `fd` search

### DIFF
--- a/yazi-plugin/src/external/fd.rs
+++ b/yazi-plugin/src/external/fd.rs
@@ -16,7 +16,7 @@ pub fn fd(opt: FdOpt) -> Result<UnboundedReceiver<File>> {
 		.arg("--base-directory")
 		.arg(&opt.cwd)
 		.arg("--regex")
-		.args(if opt.hidden { ["--hidden"] } else { ["--no-hidden"] })
+		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(opt.args)
 		.arg(opt.subject)
 		.kill_on_drop(true)

--- a/yazi-plugin/src/external/fd.rs
+++ b/yazi-plugin/src/external/fd.rs
@@ -16,7 +16,7 @@ pub fn fd(opt: FdOpt) -> Result<UnboundedReceiver<File>> {
 		.arg("--base-directory")
 		.arg(&opt.cwd)
 		.arg("--regex")
-		.args(if opt.hidden { ["--hidden", "--no-ignore"] } else { ["--no-hidden", "--ignore"] })
+		.args(if opt.hidden { ["--hidden"] } else { ["--no-hidden"] })
 		.args(opt.args)
 		.arg(opt.subject)
 		.kill_on_drop(true)

--- a/yazi-plugin/src/external/rg.rs
+++ b/yazi-plugin/src/external/rg.rs
@@ -15,7 +15,7 @@ pub fn rg(opt: RgOpt) -> Result<UnboundedReceiver<File>> {
 	let mut child = Command::new("rg")
 		.current_dir(&opt.cwd)
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
-		.args(if opt.hidden { ["--hidden", "--no-ignore"] } else { ["--no-hidden", "--ignore"] })
+		.args(if opt.hidden { ["--hidden"] } else { ["--no-hidden"] })
 		.args(opt.args)
 		.arg(opt.subject)
 		.kill_on_drop(true)

--- a/yazi-plugin/src/external/rg.rs
+++ b/yazi-plugin/src/external/rg.rs
@@ -15,7 +15,7 @@ pub fn rg(opt: RgOpt) -> Result<UnboundedReceiver<File>> {
 	let mut child = Command::new("rg")
 		.current_dir(&opt.cwd)
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
-		.args(if opt.hidden { ["--hidden"] } else { ["--no-hidden"] })
+		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(opt.args)
 		.arg(opt.subject)
 		.kill_on_drop(true)


### PR DESCRIPTION
When `yazi`'s `hidden` option is true, it passes `--no-ignore` to `fd` and `rg`. However, ignore files have no actual relation to hidden files. They often contain entries like `node_modules` that users want to ignore in all situations.

Example use case: In a code project, I turn on the `hidden` option to navigate to configuration files like `.editorconfig` and search their contents with <kbd>S</kbd>. I do not want the `hidden` option to expose thousands of search results in `node_modules`, `.gocache`, or `dist`.