### PR TITLE
feat: allow themes to add a custom style for file extensions

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+    "diagnostics.globals": [
+        "ui",
+        "THEME",
+        "MANAGER"
+    ]
+}

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -49,13 +49,16 @@ impl Default for Theme {
 pub struct Manager {
 	cwd: Style,
 
+	/// The style for files that have an extension
+	pub extension: Option<Style>,
+
 	// Hovered
 	hovered:         Style,
 	preview_hovered: Style,
 
 	// Find
-	find_keyword:  Style,
-	find_position: Style,
+	find_keyword:      Style,
+	pub find_position: Style,
 
 	// Marker
 	marker_copied:   Style,

--- a/yazi-fm/src/lives/file/highlightable_filename_builder.rs
+++ b/yazi-fm/src/lives/file/highlightable_filename_builder.rs
@@ -1,0 +1,261 @@
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+use std::{collections::HashMap, ops::Range};
+
+use yazi_shared::theme::Style;
+
+/// Represents the name and extension of a file or directory, that can
+/// optionally be highlighted (e.g. when searching, to highlight the matched
+/// characters), and converted to `ui.Span` elements for rendering. Consecutive
+/// highlights with the same style are merged into a single span.
+pub struct HighlightedFilenameBuilder {
+	pub(crate) stem:      String,
+	/// The extension of the file, if any. Must have a leading dot.
+	/// Example: `".txt"`
+	pub(crate) extension: Option<String>,
+
+	/// Maps the index of a character in the full text to its highlight style.
+	pub(crate) highlights: HashMap<usize, Style>,
+}
+
+// NOTE: Since rust strings are utf-8 strings, the characters are not
+// necessarily one byte long. "".chars().count() will return the number of
+// characters in the string, not the number of bytes.
+impl HighlightedFilenameBuilder {
+	pub fn new(stem: String, extension_with_leading_dot: Option<String>) -> Self {
+		assert!(
+			extension_with_leading_dot.is_none()
+				|| extension_with_leading_dot.as_ref().unwrap().starts_with('.')
+		);
+		Self { stem, extension: extension_with_leading_dot, highlights: HashMap::new() }
+	}
+
+	/// Adds a default color to the extension. It might be partially or fully
+	/// overwritten by highlights that are added later.
+	pub fn add_extension_highlight(&mut self, style: Style) {
+		if let Some(extension) = &self.extension {
+			let start = self.stem.len();
+			let end = self.stem.len() + extension.len();
+
+			self.add_highlight(start..end, style);
+		}
+	}
+
+	/// Makes the indices specified by the given Range as having the given
+	/// highlight style. Old highlights are overwritten.
+	pub fn add_highlight(&mut self, range: Range<usize>, style: Style) {
+		for i in range {
+			self.highlights.insert(i, style);
+		}
+	}
+
+	/// Consumes the builder and produces styled spans of text for rendering. The
+	/// stem and extension are separated into different spans.
+	pub fn build_spans(&mut self) -> Vec<HighlightedSpan> {
+		let (stem_highlights, extension_highlights) = {
+			let mut highlights = Vec::new();
+
+			self.stem.chars().enumerate().for_each(|(index, character)| {
+				let style = self.highlights.remove(&index);
+				highlights.insert(index, HighlightedCharacter { character, style });
+			});
+
+			if let Some(extension) = &self.extension {
+				extension.chars().enumerate().for_each(|(index, character)| {
+					let next = self.stem.chars().count() + index;
+					let style = self.highlights.remove(&next);
+					highlights
+						.insert(self.stem.chars().count() + index, HighlightedCharacter { character, style });
+				});
+			}
+
+			let extension = highlights.split_off(self.stem.chars().count());
+			let stem = highlights;
+			(stem, extension)
+		};
+
+		let mut spans = spanify(stem_highlights);
+		spans.extend(spanify(extension_highlights));
+
+		spans
+	}
+}
+
+fn spanify(highlights: Vec<HighlightedCharacter>) -> Vec<HighlightedSpan> {
+	let mut spans = Vec::new();
+	let mut current_index = 0;
+
+	while let Some(this) = highlights.get(current_index) {
+		let next_with_same_style =
+			highlights[current_index + 1..].iter().take_while(|that| this.style == that.style);
+
+		let content =
+			this.character.to_string() + &next_with_same_style.map(|c| c.character).collect::<String>();
+
+		current_index += content.len();
+		let span = HighlightedSpan { content, style: this.style };
+		spans.push(span);
+	}
+
+	spans
+}
+
+#[derive(Debug)]
+pub struct HighlightedSpan {
+	content: String,
+	style:   Option<Style>,
+}
+
+impl From<HighlightedSpan> for yazi_plugin::elements::Span {
+	fn from(value: HighlightedSpan) -> Self {
+		yazi_plugin::elements::Span(ratatui::text::Span {
+			content: value.content.into(),
+			style:   value.style.map(Into::into).unwrap_or_default(),
+		})
+	}
+}
+
+#[derive(Debug)]
+struct HighlightedCharacter {
+	character: char,
+	style:     Option<Style>,
+}
+
+#[cfg(test)]
+mod tests {
+	use yazi_shared::theme::StyleShadow;
+
+	use super::*;
+
+	fn create_style(fgcolor: ratatui::style::Color) -> yazi_shared::theme::Style {
+		Style::from(StyleShadow { fg: Some(yazi_shared::theme::Color(fgcolor)), ..Default::default() })
+	}
+
+	#[test]
+	fn test_highlight_stem() {
+		let mut hl = HighlightedFilenameBuilder::new("filename".to_string(), None);
+		// when there is no extension, the whole name is the stem
+
+		let style = create_style(ratatui::style::Color::Blue);
+		hl.add_highlight(0.."file".len(), style);
+		let spans = hl.build_spans();
+		assert_eq!(spans.len(), 2);
+
+		assert_eq!(spans[0].content, "file");
+		assert_eq!(spans[0].style, Some(style));
+
+		assert_eq!(spans[1].content, "name");
+		assert_eq!(spans[1].style, None);
+	}
+
+	#[test]
+	fn test_highlight_extension() {
+		let mut hl = HighlightedFilenameBuilder::new("filename".to_string(), Some(".txt".to_string()));
+
+		let style = create_style(ratatui::style::Color::Blue);
+		{
+			// simulate the user highlighting the extension without the dot
+			let stem_length = "filename.".chars().count();
+			let full_length = stem_length + "txt".chars().count();
+			hl.add_highlight(stem_length..full_length, style);
+		}
+
+		let spans = hl.build_spans();
+		assert_eq!(spans.len(), 3);
+
+		assert_eq!(spans[0].content, "filename");
+		assert_eq!(spans[0].style, None);
+
+		assert_eq!(spans[1].content, ".");
+		assert_eq!(spans[1].style, None);
+
+		assert_eq!(spans[2].content, "txt");
+		assert_eq!(spans[2].style, Some(style));
+	}
+
+	#[test]
+	fn test_highlight_nothing() {
+		// verify that the stem and extension are separate spans even if they are
+		// not highlighted
+		let mut hl = HighlightedFilenameBuilder::new("notes".to_string(), Some(".txt".to_string()));
+		let spans = hl.build_spans();
+
+		assert_eq!(spans.len(), 2);
+
+		assert_eq!(spans[0].content, "notes");
+		assert_eq!(spans[0].style, None);
+
+		assert_eq!(spans[1].content, ".txt");
+		assert_eq!(spans[1].style, None);
+	}
+
+	#[test]
+	fn test_empty_name() {
+		// just to make sure it doesn't crash
+		let mut hl = HighlightedFilenameBuilder::new("".to_string(), None);
+		let spans = hl.build_spans();
+		assert_eq!(spans.len(), 0);
+	}
+
+	#[test]
+	fn test_highlight_across_extension_boundary() {
+		// for "filename.txt", if the user highlights "name.t"
+		let mut hl = HighlightedFilenameBuilder::new("filename".to_string(), Some(".txt".to_string()));
+		let style = create_style(ratatui::style::Color::Blue);
+
+		{
+			let start = "file".chars().count();
+			let end = "filename.t".chars().count();
+			hl.add_highlight(start..end, style);
+		}
+
+		let spans = hl.build_spans();
+		assert_eq!(spans.len(), 4);
+
+		assert_eq!(spans[0].content, "file");
+		assert_eq!(spans[0].style, None);
+
+		assert_eq!(spans[1].content, "name");
+		assert_eq!(spans[1].style, Some(style));
+
+		assert_eq!(spans[2].content, ".t");
+		assert_eq!(spans[2].style, Some(style));
+
+		assert_eq!(spans[3].content, "xt");
+		assert_eq!(spans[3].style, None);
+	}
+
+	#[test]
+	fn test_add_extension_highlight() {
+		let mut hl = HighlightedFilenameBuilder::new("filename".to_string(), Some(".txt".to_string()));
+		let style = create_style(ratatui::style::Color::Blue);
+		hl.add_extension_highlight(style);
+
+		let spans = hl.build_spans();
+		assert_eq!(spans.len(), 2);
+
+		assert_eq!(spans[0].content, "filename");
+		assert_eq!(spans[0].style, None);
+
+		assert_eq!(spans[1].content, ".txt");
+		assert_eq!(spans[1].style, Some(style));
+	}
+
+	#[test]
+	fn test_multibyte_characters() {
+		// multi-byte characters must not cause panics even if the file name is very
+		// complex. Test both the stem and the extension.
+		let mut hl = HighlightedFilenameBuilder::new(
+			"pokémon-listing-🤔-スゴイ-H̐͌̃ē̐̅l̐͑̚l͋͋́o̐̒̓,̍̑̀ ̓̈́̚w͊̀̕o̓͆͝r̎͝͝l͑̑̇d̎̐̕! ".to_string(),
+			Some(".🤔-スH̐͌̃ē̐̅l̐͑̚txt".to_string()),
+		);
+		let style = create_style(ratatui::style::Color::Blue);
+		hl.add_highlight(0.."poké".chars().count(), style);
+		hl.add_extension_highlight(style);
+
+		let spans = hl.build_spans();
+
+		assert_eq!(spans.len(), 3);
+	}
+}

--- a/yazi-plugin/preset/components/file.lua
+++ b/yazi-plugin/preset/components/file.lua
@@ -16,26 +16,8 @@ function File:prefix(file)
 	return prefix == "" and {} or { ui.Span(prefix .. "/") }
 end
 
-function File:highlights(file)
-	local name = file.name:gsub("\r", "?", 1)
-	local highlights = file:highlights()
-	if not highlights or #highlights == 0 then
-		return { ui.Span(name) }
-	end
-
-	local spans, last = {}, 0
-	for _, h in ipairs(highlights) do
-		if h[1] > last then
-			spans[#spans + 1] = ui.Span(name:sub(last + 1, h[1]))
-		end
-		spans[#spans + 1] = ui.Span(name:sub(h[1] + 1, h[2])):style(THEME.manager.find_keyword)
-		last = h[2]
-	end
-	if last < #name then
-		spans[#spans + 1] = ui.Span(name:sub(last + 1))
-	end
-	return spans
-end
+--- Returns the name for the file, optionally highlighted
+function File:highlights(file) return file:highlights() end
 
 function File:found(file)
 	if not file:is_hovered() then

--- a/yazi-plugin/src/elements/span.rs
+++ b/yazi-plugin/src/elements/span.rs
@@ -3,8 +3,8 @@ use yazi_shared::theme::Color;
 
 use super::Style;
 
-#[derive(Clone, FromLua)]
-pub struct Span(pub(super) ratatui::text::Span<'static>);
+#[derive(Clone, FromLua, Debug)]
+pub struct Span(pub ratatui::text::Span<'static>);
 
 impl Span {
 	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {

--- a/yazi-plugin/src/elements/style.rs
+++ b/yazi-plugin/src/elements/style.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use mlua::{AnyUserData, ExternalError, ExternalResult, Lua, Table, UserData, UserDataMethods, Value};
 use yazi_shared::theme::Color;
 
-#[derive(Clone, Copy, Default)]
-pub struct Style(pub(super) ratatui::style::Style);
+#[derive(Clone, Copy, Default, PartialEq, Debug)]
+pub struct Style(pub ratatui::style::Style);
 
 impl Style {
 	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {

--- a/yazi-plugin/src/url/url.rs
+++ b/yazi-plugin/src/url/url.rs
@@ -20,6 +20,9 @@ impl Url {
 			reg.add_method("stem", |lua, me, ()| {
 				me.file_stem().map(|s| lua.create_string(s.as_encoded_bytes())).transpose()
 			});
+			reg.add_method("extension", |lua, me, ()| {
+				me.extension().map(|s| lua.create_string(s.as_encoded_bytes())).transpose()
+			});
 			reg.add_method("join", |lua, me, other: UrlRef| Self::cast(lua, me.join(&*other)));
 			reg.add_method("parent", |lua, me, ()| {
 				me.parent_url().map(|u| Self::cast(lua, u)).transpose()

--- a/yazi-shared/src/theme/color.rs
+++ b/yazi-shared/src/theme/color.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(try_from = "String")]
-pub struct Color(ratatui::style::Color);
+pub struct Color(pub ratatui::style::Color);
 
 impl FromStr for Color {
 	type Err = anyhow::Error;
@@ -23,6 +23,10 @@ impl TryFrom<String> for Color {
 
 impl From<Color> for ratatui::style::Color {
 	fn from(value: Color) -> Self { value.0 }
+}
+
+impl From<ratatui::style::Color> for Color {
+	fn from(value: ratatui::style::Color) -> Self { Self(value) }
 }
 
 impl Serialize for Color {

--- a/yazi-shared/src/theme/style.rs
+++ b/yazi-shared/src/theme/style.rs
@@ -3,7 +3,7 @@ use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 
 use super::Color;
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(from = "StyleShadow")]
 pub struct Style {
 	pub fg:       Option<Color>,
@@ -32,6 +32,16 @@ impl From<Style> for ratatui::style::Style {
 			underline_color: None,
 			add_modifier:    value.modifier,
 			sub_modifier:    Modifier::empty(),
+		}
+	}
+}
+
+impl From<ratatui::style::Style> for Style {
+	fn from(value: ratatui::style::Style) -> Self {
+		Self {
+			fg:       value.fg.map(Into::into),
+			bg:       value.bg.map(Into::into),
+			modifier: value.add_modifier,
 		}
 	}
 }


### PR DESCRIPTION
# Request for comments

> This is a draft PR, and I'm looking for feedback on the feature itself, the implementation, and the API.

This adds a feature that allows

- (optionally) specifying a custom style for file extensions.
  - by default, the extension is styled the same as the filename, so the user has to opt in to this feature.
  - this can help to visually distinguish between different file types.
  - an extension is defined as rust defines it, i.e. the part of the file name after the last `.`.
  - directories don't have extensions, so they are not affected by this feature.
- (possible in the future) solving https://github.com/sxyazi/yazi/pull/1036
  - instead of displaying a single filename, could now split the filename into two parts, the name (stem) and the extension. Then could truncate the stem to fit the screen.
  - this PR can help applying search highlights to these two parts separately.
- (possible in the future) allowing different styling for different types of extensions.
  - this PR can help applying search highlights while maintaining the custom style.

> Example: a custom style for file extensions

![image](https://github.com/sxyazi/yazi/assets/300791/2903ca03-d4a6-4d22-bdcb-5de299cb5d23)

> Example: highlights are displayed correctly when highlighting searches

![image](https://github.com/sxyazi/yazi/assets/300791/d31dc0bd-eef0-43a9-94c5-81426284e877)

> Example: the way to configure the style in `theme.toml`
```diff
diff --git a/.config/yazi/theme.toml b/.config/yazi/theme.toml
index b6392db..63d24ed 100644
--- a/.config/yazi/theme.toml
+++ b/.config/yazi/theme.toml
@@ -7,6 +7,7 @@
 
 syntect_theme = "~/dotfiles/.config/bat/themes/catppuccin-bat/themes/Catppuccin Macchiato.tmTheme"
 cwd = { fg = "#8bd5ca" }
+extension = { fg = "#6e738d", italic = true }
 
 # Hovered
 hovered = { fg = "#24273a", bg = "#8aadf4" }
```

## Open questions

- do you think this feature is useful? I can finish it if you think it is.
- currently, some multibyte unicode characters position the extension highlight incorrectly.
  - I think this is possible to solve, but I'm not sure it might behave on different platforms.
  - I noticed searching uses regex on the byte level, so maybe this could be a good way to try to solve this.