### PR TITLE
fix: ya pack --upgrade not being able to upgrade existing packages

### DIFF
--- a/yazi-cli/src/package/package.rs
+++ b/yazi-cli/src/package/package.rs
@@ -12,6 +12,8 @@ pub(crate) struct Package {
 }
 
 impl Package {
+	/// Create a new Package when adding a new package to the config.
+	/// Note that the package must end in `".yazi"`.
 	pub(super) fn new(url: &str, commit: Option<&str>) -> Self {
 		let mut parts = url.splitn(2, '#');
 
@@ -22,6 +24,17 @@ impl Package {
 			repo.push_str(".yazi");
 			String::new()
 		};
+
+		Self { repo, child, commit: commit.unwrap_or_default().to_owned(), is_flavor: false }
+	}
+
+	/// Create a new Package when installing a package from the config. The
+	/// package is name considered valid and no `".yazi"` is prepended.
+	pub(super) fn new_literal(url: &str, commit: Option<&str>) -> Self {
+		let mut parts = url.splitn(2, '#');
+
+		let repo = parts.next().unwrap_or_default().to_owned();
+		let child = if let Some(s) = parts.next() { format!("{s}.yazi") } else { String::new() };
 
 		Self { repo, child, commit: commit.unwrap_or_default().to_owned(), is_flavor: false }
 	}
@@ -75,5 +88,24 @@ impl Package {
 			Print("\n\n"),
 		)?;
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_package_new() {
+		// should add ".yazi" to the end of the package name if it doesn't have one
+		let package = Package::new("user/test", None);
+		assert_eq!(package.repo, "user/test.yazi");
+	}
+
+	#[test]
+	fn test_package_new_literal() {
+		// should not add ".yazi" to the end of the package name
+		let package = Package::new_literal("user/test.yazi", None);
+		assert_eq!(package.repo, "user/test.yazi");
 	}
 }

--- a/yazi-cli/src/package/parser.rs
+++ b/yazi-cli/src/package/parser.rs
@@ -49,7 +49,7 @@ impl Package {
 			let use_ = dep.get("use").and_then(|d| d.as_str()).context("Missing `use` field")?;
 			let commit = dep.get("commit").and_then(|d| d.as_str());
 
-			let mut package = Package::new(use_, commit);
+			let mut package = Package::new_literal(use_, commit);
 			if upgrade {
 				package.upgrade().await?;
 			} else {


### PR DESCRIPTION
With the following packages, running the `ya pack --upgrade` command results in a prompt for a username:

```sh
❯ cat ~/dotfiles/.config/yazi/package.toml
[plugin]
deps = [{ use = "DreamMaoMao/keyjump.yazi", commit = "06383de" }, { use = "Rolv-Apneseth/starship.yazi", commit = "6197e4c" }]

[flavor]
deps = []
❯ ya pack --upgrade

  Upgrading package `keyjump.yazi.yazi`

Cloning into '/Users/mikavilpas/.local/state/yazi/packages/109b2bd4c6591dcb62b40b25202be168'...
Username for 'https://github.com':
```

The problem seems to be that the plugin `DreamMaoMao/keyjump.yazi` is being resolved to `https://github.com/DreamMaoMao/keyjump.yazi.yazi` with an extra `.yazi` at the end.

We discussed this behaviour (and decided it's preferred to add `.yazi` when adding new packages) in

- https://github.com/sxyazi/yazi/pull/1019
- https://github.com/sxyazi/yazi/issues/1023

...but I did not realize at the time that it also affects upgrading packages.