### PR TITLE
feat: Chafa integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 name = "yazi-adaptor"
 version = "0.2.5"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "arc-swap",
  "base64 0.22.1",

--- a/yazi-adaptor/Cargo.toml
+++ b/yazi-adaptor/Cargo.toml
@@ -13,6 +13,7 @@ yazi-config = { path = "../yazi-config", version = "0.2.5" }
 yazi-shared = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies
+ansi-to-tui  = "3.1.0"
 anyhow       = "1.0.86"
 arc-swap     = "1.7.1"
 base64       = "0.22.1"

--- a/yazi-adaptor/src/adaptor.rs
+++ b/yazi-adaptor/src/adaptor.rs
@@ -3,10 +3,10 @@ use std::{env, fmt::Display, path::Path, sync::Arc};
 use anyhow::Result;
 use ratatui::layout::Rect;
 use tracing::warn;
-use yazi_shared::{env_exists, term::Term};
+use yazi_shared::env_exists;
 
 use super::{Iterm2, Kitty, KittyOld};
-use crate::{ueberzug::Ueberzug, Emulator, Sixel, SHOWN, TMUX};
+use crate::{Chafa, Emulator, Sixel, Ueberzug, SHOWN, TMUX};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Adaptor {
@@ -42,7 +42,8 @@ impl Adaptor {
 			Self::KittyOld => KittyOld::image_show(path, max).await,
 			Self::Iterm2 => Iterm2::image_show(path, max).await,
 			Self::Sixel => Sixel::image_show(path, max).await,
-			_ => Ueberzug::image_show(path, max).await,
+			Self::X11 | Self::Wayland => Ueberzug::image_show(path, max).await,
+			Self::Chafa => Chafa::image_show(path, max).await,
 		}
 	}
 
@@ -54,9 +55,10 @@ impl Adaptor {
 		match self {
 			Self::Kitty => Kitty::image_erase(area),
 			Self::Iterm2 => Iterm2::image_erase(area),
-			Self::KittyOld => KittyOld::image_erase(),
+			Self::KittyOld => KittyOld::image_erase(area),
 			Self::Sixel => Sixel::image_erase(area),
-			_ => Ueberzug::image_erase(area),
+			Self::X11 | Self::Wayland => Ueberzug::image_erase(area),
+			Self::Chafa => Chafa::image_erase(area),
 		}
 	}
 

--- a/yazi-adaptor/src/chafa.rs
+++ b/yazi-adaptor/src/chafa.rs
@@ -1,0 +1,63 @@
+use std::{path::Path, process::Stdio};
+
+use anyhow::{bail, Result};
+use imagesize::ImageSize;
+use ratatui::layout::Rect;
+use tokio::process::Command;
+
+use crate::Image;
+
+pub(super) struct Chafa;
+
+impl Chafa {
+	pub(super) async fn image_show(path: &Path, rect: Rect) -> Result<(u32, u32)> {
+		let p = path.to_owned();
+		let ImageSize { width: w, height: h } =
+			tokio::task::spawn_blocking(move || imagesize::size(p)).await??;
+
+		let output = Command::new("chafa")
+			.args([
+				"-f",
+				"symbols",
+				"--relative",
+				"off",
+				"--polite",
+				"on",
+				"--passthrough",
+				"none",
+				"--animate",
+				"off",
+				"--view-size",
+			])
+			.arg(format!("{}x{}", rect.width, rect.height))
+			.arg(path)
+			.stdin(Stdio::null())
+			.stderr(Stdio::null())
+			.stdout(Stdio::piped())
+			.kill_on_drop(true)
+			.output()
+			.await?;
+
+		if !output.status.success() {
+			bail!("chafa failed with status: {}", output.status);
+		}
+
+		// output.stdout
+
+		let (max_w, max_h) = Image::max_pixel(rect);
+		if w <= max_w as usize && h <= max_h as usize {
+			return Ok((w as u32, h as u32));
+		}
+
+		let ratio = f64::min(max_w as f64 / w as f64, max_h as f64 / h as f64);
+		Ok(((w as f64 * ratio).round() as u32, (h as f64 * ratio).round() as u32))
+	}
+
+	pub(super) fn image_erase(_: Rect) -> Result<()> {
+		if let Some(tx) = &*DEMON {
+			Ok(tx.send(None)?)
+		} else {
+			bail!("uninitialized ueberzugpp");
+		}
+	}
+}

--- a/yazi-adaptor/src/image.rs
+++ b/yazi-adaptor/src/image.rs
@@ -57,7 +57,7 @@ impl Image {
 		})
 		.await??;
 
-		let (mut w, mut h) = Self::max_size(rect);
+		let (mut w, mut h) = Self::max_pixel(rect);
 		if (5..=8).contains(&orientation) {
 			(w, h) = (h, w);
 		}
@@ -76,13 +76,24 @@ impl Image {
 		.await?
 	}
 
-	pub(super) fn max_size(rect: Rect) -> (u32, u32) {
+	pub(super) fn max_pixel(rect: Rect) -> (u32, u32) {
 		Term::ratio()
 			.map(|(r1, r2)| {
 				let (w, h) = ((rect.width as f64 * r1) as u32, (rect.height as f64 * r2) as u32);
 				(w.min(PREVIEW.max_width), h.min(PREVIEW.max_height))
 			})
 			.unwrap_or((PREVIEW.max_width, PREVIEW.max_height))
+	}
+
+	pub(super) fn pixel_area(size: (u32, u32), rect: Rect) -> Rect {
+		Term::ratio()
+			.map(|(r1, r2)| Rect {
+				x:      rect.x,
+				y:      rect.y,
+				width:  (size.0 as f64 / r1).ceil() as u16,
+				height: (size.1 as f64 / r2).ceil() as u16,
+			})
+			.unwrap_or(rect)
 	}
 
 	#[inline]

--- a/yazi-adaptor/src/kitty.rs
+++ b/yazi-adaptor/src/kitty.rs
@@ -3,7 +3,7 @@ use std::{io::Write, path::Path};
 
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
-use image::DynamicImage;
+use image::{DynamicImage, GenericImageView};
 use ratatui::layout::Rect;
 use yazi_shared::term::Term;
 
@@ -313,27 +313,27 @@ static DIACRITICS: [char; 297] = [
 pub(super) struct Kitty;
 
 impl Kitty {
-	pub(super) async fn image_show(path: &Path, rect: Rect) -> Result<(u32, u32)> {
-		let img = Image::downscale(path, rect).await?;
-		let size = (img.width(), img.height());
+	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+		let img = Image::downscale(path, max).await?;
+		let area = Image::pixel_area((img.width(), img.height()), max);
 
 		let b1 = Self::encode(img).await?;
-		let b2 = Self::place(&rect)?;
+		let b2 = Self::place(&area)?;
 
 		Adaptor::Kitty.image_hide()?;
-		Adaptor::shown_store(rect, size);
-		Term::move_lock((rect.x, rect.y), |stderr| {
+		Adaptor::shown_store(area);
+		Term::move_lock((area.x, area.y), |stderr| {
 			stderr.write_all(&b1)?;
 			stderr.write_all(&b2)?;
-			Ok(size)
+			Ok(area)
 		})
 	}
 
-	pub(super) fn image_erase(rect: Rect) -> Result<()> {
-		let s = " ".repeat(rect.width as usize);
+	pub(super) fn image_erase(area: Rect) -> Result<()> {
+		let s = " ".repeat(area.width as usize);
 		Term::move_lock((0, 0), |stderr| {
-			for y in rect.top()..rect.bottom() {
-				Term::move_to(stderr, rect.x, y)?;
+			for y in area.top()..area.bottom() {
+				Term::move_to(stderr, area.x, y)?;
 				write!(stderr, "{s}")?;
 			}
 
@@ -388,11 +388,11 @@ impl Kitty {
 		.await?
 	}
 
-	fn place(rect: &Rect) -> Result<Vec<u8>> {
-		let mut buf = Vec::with_capacity(rect.width as usize * rect.height as usize * 3 + 50);
-		for y in 0..rect.height {
-			write!(buf, "\x1b[{};{}H\x1b[38;5;1m", rect.y + y + 1, rect.x + 1)?;
-			for x in 0..rect.width {
+	fn place(area: &Rect) -> Result<Vec<u8>> {
+		let mut buf = Vec::with_capacity(area.width as usize * area.height as usize * 3 + 50);
+		for y in 0..area.height {
+			write!(buf, "\x1b[{};{}H\x1b[38;5;1m", area.y + y + 1, area.x + 1)?;
+			for x in 0..area.width {
 				write!(buf, "\u{10EEEE}")?;
 				write!(buf, "{}", *DIACRITICS.get(y as usize).unwrap_or(&DIACRITICS[0]))?;
 				write!(buf, "{}", *DIACRITICS.get(x as usize).unwrap_or(&DIACRITICS[0]))?;

--- a/yazi-adaptor/src/kitty.rs
+++ b/yazi-adaptor/src/kitty.rs
@@ -3,7 +3,7 @@ use std::{io::Write, path::Path};
 
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
-use image::{DynamicImage, GenericImageView};
+use image::DynamicImage;
 use ratatui::layout::Rect;
 use yazi_shared::term::Term;
 

--- a/yazi-adaptor/src/kitty_old.rs
+++ b/yazi-adaptor/src/kitty_old.rs
@@ -27,7 +27,7 @@ impl KittyOld {
 	}
 
 	#[inline]
-	pub(super) fn image_erase() -> Result<()> {
+	pub(super) fn image_erase(_: Rect) -> Result<()> {
 		let mut stderr = LineWriter::new(stderr());
 		write!(stderr, "{}_Gq=1,a=d,d=A{}\\{}", START, ESCAPE, CLOSE)?;
 		stderr.flush()?;

--- a/yazi-adaptor/src/kitty_old.rs
+++ b/yazi-adaptor/src/kitty_old.rs
@@ -13,16 +13,16 @@ use crate::{adaptor::Adaptor, CLOSE, ESCAPE, START};
 pub(super) struct KittyOld;
 
 impl KittyOld {
-	pub(super) async fn image_show(path: &Path, rect: Rect) -> Result<(u32, u32)> {
-		let img = Image::downscale(path, rect).await?;
-		let size = (img.width(), img.height());
+	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+		let img = Image::downscale(path, max).await?;
+		let area = Image::pixel_area((img.width(), img.height()), max);
 		let b = Self::encode(img).await?;
 
 		Adaptor::KittyOld.image_hide()?;
-		Adaptor::shown_store(rect, size);
-		Term::move_lock((rect.x, rect.y), |stderr| {
+		Adaptor::shown_store(area);
+		Term::move_lock((area.x, area.y), |stderr| {
 			stderr.write_all(&b)?;
-			Ok(size)
+			Ok(area)
 		})
 	}
 

--- a/yazi-adaptor/src/lib.rs
+++ b/yazi-adaptor/src/lib.rs
@@ -11,11 +11,13 @@ mod sixel;
 mod ueberzug;
 
 pub use adaptor::*;
+use chafa::*;
 pub use emulator::*;
 use iterm2::*;
 use kitty::*;
 use kitty_old::*;
 use sixel::*;
+use ueberzug::*;
 use yazi_shared::{env_exists, RoCell};
 
 pub use crate::image::*;

--- a/yazi-adaptor/src/lib.rs
+++ b/yazi-adaptor/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unit_arg)]
 
 mod adaptor;
+mod chafa;
 mod emulator;
 mod image;
 mod iterm2;

--- a/yazi-adaptor/src/sixel.rs
+++ b/yazi-adaptor/src/sixel.rs
@@ -12,24 +12,24 @@ use crate::{adaptor::Adaptor, Image, CLOSE, ESCAPE, START};
 pub(super) struct Sixel;
 
 impl Sixel {
-	pub(super) async fn image_show(path: &Path, rect: Rect) -> Result<(u32, u32)> {
-		let img = Image::downscale(path, rect).await?;
-		let size = (img.width(), img.height());
+	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+		let img = Image::downscale(path, max).await?;
+		let area = Image::pixel_area((img.width(), img.height()), max);
 		let b = Self::encode(img).await?;
 
 		Adaptor::Sixel.image_hide()?;
-		Adaptor::shown_store(rect, size);
-		Term::move_lock((rect.x, rect.y), |stderr| {
+		Adaptor::shown_store(area);
+		Term::move_lock((area.x, area.y), |stderr| {
 			stderr.write_all(&b)?;
-			Ok(size)
+			Ok(area)
 		})
 	}
 
-	pub(super) fn image_erase(rect: Rect) -> Result<()> {
-		let s = " ".repeat(rect.width as usize);
+	pub(super) fn image_erase(area: Rect) -> Result<()> {
+		let s = " ".repeat(area.width as usize);
 		Term::move_lock((0, 0), |stderr| {
-			for y in rect.top()..rect.bottom() {
-				Term::move_to(stderr, rect.x, y)?;
+			for y in area.top()..area.bottom() {
+				Term::move_to(stderr, area.x, y)?;
 				write!(stderr, "{s}")?;
 			}
 			Ok(())

--- a/yazi-adaptor/src/ueberzug.rs
+++ b/yazi-adaptor/src/ueberzug.rs
@@ -51,7 +51,7 @@ impl Ueberzug {
 			tokio::task::spawn_blocking(move || imagesize::size(p)).await??;
 
 		let area = Image::pixel_area((w as u32, h as u32), max);
-		tx.send(Some((path.to_owned(), max)))?;
+		tx.send(Some((path.to_owned(), area)))?;
 
 		Adaptor::shown_store(area);
 		Ok(area)

--- a/yazi-adaptor/src/ueberzug.rs
+++ b/yazi-adaptor/src/ueberzug.rs
@@ -41,25 +41,20 @@ impl Ueberzug {
 		DEMON.init(Some(tx))
 	}
 
-	pub(super) async fn image_show(path: &Path, rect: Rect) -> Result<(u32, u32)> {
-		if let Some(tx) = &*DEMON {
-			tx.send(Some((path.to_path_buf(), rect)))?;
-			Adaptor::shown_store(rect, (0, 0));
-		} else {
+	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+		let Some(tx) = &*DEMON else {
 			bail!("uninitialized ueberzugpp");
-		}
+		};
 
-		let path = path.to_owned();
+		let p = path.to_owned();
 		let ImageSize { width: w, height: h } =
-			tokio::task::spawn_blocking(move || imagesize::size(path)).await??;
+			tokio::task::spawn_blocking(move || imagesize::size(p)).await??;
 
-		let (max_w, max_h) = Image::max_size(rect);
-		if w <= max_w as usize && h <= max_h as usize {
-			return Ok((w as u32, h as u32));
-		}
+		let area = Image::pixel_area((w as u32, h as u32), max);
+		tx.send(Some((path.to_owned(), max)))?;
 
-		let ratio = f64::min(max_w as f64 / w as f64, max_h as f64 / h as f64);
-		Ok(((w as f64 * ratio).round() as u32, (h as f64 * ratio).round() as u32))
+		Adaptor::shown_store(area);
+		Ok(area)
 	}
 
 	pub(super) fn image_erase(_: Rect) -> Result<()> {

--- a/yazi-plugin/src/utils/image.rs
+++ b/yazi-plugin/src/utils/image.rs
@@ -2,15 +2,15 @@ use mlua::{IntoLuaMulti, Lua, Table, Value};
 use yazi_adaptor::{Image, ADAPTOR};
 
 use super::Utils;
-use crate::{elements::RectRef, url::UrlRef};
+use crate::{bindings::Cast, elements::{Rect, RectRef}, url::UrlRef};
 
 impl Utils {
 	pub(super) fn image(lua: &Lua, ya: &Table) -> mlua::Result<()> {
 		ya.raw_set(
 			"image_show",
 			lua.create_async_function(|lua, (url, rect): (UrlRef, RectRef)| async move {
-				if let Ok(size) = ADAPTOR.image_show(&url, *rect).await {
-					size.into_lua_multi(lua)
+				if let Ok(area) = ADAPTOR.image_show(&url, *rect).await {
+					Rect::cast(lua, area)?.into_lua_multi(lua)
 				} else {
 					Value::Nil.into_lua_multi(lua)
 				}


### PR DESCRIPTION
In previous versions, Yazi has been using Chafa provided by Überzug++ with the aim of minimizing external dependencies installed by users.

However, in practice, Überzug++ is not always available. It needs to obtain the pixel dimensions of the terminal when starting up, and in some terminal/desktop environments, it fails to do so, this results in Überzug++ [crashing on startup](https://github.com/jstkdng/ueberzugpp/issues/172), and is also not available on Windows.

But Chafa does not have these issues, so in Yazi v0.3, Chafa is added as an ***optional*** dependency and takes over ASCII art preview.

Also resolves https://github.com/sxyazi/yazi/issues/777