### PR TITLE
refactor!: v0.3 API changes

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -62,7 +62,7 @@ keymap = [
 	{ on = [ "o" ],         run = "open",                       desc = "Open the selected files" },
 	{ on = [ "O" ],         run = "open --interactive",         desc = "Open the selected files interactively" },
 	{ on = [ "<Enter>" ],   run = "open",                       desc = "Open the selected files" },
-	{ on = [ "<C-Enter>" ], run = "open --interactive",         desc = "Open the selected files interactively" },
+	{ on = [ "<S-Enter>" ], run = "open --interactive",         desc = "Open the selected files interactively" },
 	{ on = [ "y" ],         run = "yank",                       desc = "Copy the selected files" },
 	{ on = [ "Y" ],         run = "unyank",                     desc = "Cancel the yank status of files" },
 	{ on = [ "x" ],         run = "yank --cut",                 desc = "Cut the selected files" },

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -67,7 +67,7 @@ rules = [
 	{ mime = "application/json", use = [ "edit", "reveal" ] },
 	{ mime = "*/javascript",     use = [ "edit", "reveal" ] },
 
-	{ mime = "*", use = [ "open", "reveal" ] },
+	{ name = "*", use = [ "open", "reveal" ] },
 ]
 
 [tasks]

--- a/yazi-config/src/open/open.rs
+++ b/yazi-config/src/open/open.rs
@@ -78,6 +78,13 @@ impl<'de> Deserialize<'de> for Open {
 		}
 
 		let mut outer = Outer::deserialize(deserializer)?;
+
+		if outer.open.append_rules.iter().any(|r| r.any_file()) {
+			outer.open.rules.retain(|r| !r.any_file());
+		}
+		if outer.open.append_rules.iter().any(|r| r.any_dir()) {
+			outer.open.rules.retain(|r| !r.any_dir());
+		}
 		Preset::mix(&mut outer.open.rules, outer.open.prepend_rules, outer.open.append_rules);
 
 		let openers = outer

--- a/yazi-config/src/open/rule.rs
+++ b/yazi-config/src/open/rule.rs
@@ -14,6 +14,14 @@ pub(super) struct OpenRule {
 }
 
 impl OpenRule {
+	#[inline]
+	pub fn any_file(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_file()) }
+
+	#[inline]
+	pub fn any_dir(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_dir()) }
+}
+
+impl OpenRule {
 	fn deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 	where
 		D: Deserializer<'de>,

--- a/yazi-config/src/theme/icons.rs
+++ b/yazi-config/src/theme/icons.rs
@@ -43,10 +43,15 @@ impl Icons {
 	#[inline]
 	fn match_name(&self, file: &File) -> Option<&Icon> {
 		let name = file.name()?.to_str()?;
-		if let Some(i) = if file.is_dir() { self.dirs.get(name) } else { self.files.get(name) } {
-			return Some(i);
+		if file.is_dir() {
+			self.dirs.get(name).or_else(|| self.dirs.get(&name.to_ascii_lowercase()))
+		} else {
+			self
+				.files
+				.get(name)
+				.or_else(|| self.files.get(&name.to_ascii_lowercase()))
+				.or_else(|| self.exts.get(file.url.extension()?.to_str()?))
 		}
-		self.exts.get(file.url.extension()?.to_str()?)
 	}
 }
 

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -46,7 +46,7 @@ function M:preload()
 	end
 
 	local status = child:wait()
-	return status and status:success() and 1 or 2
+	return status and status.success and 1 or 2
 end
 
 return M

--- a/yazi-plugin/preset/plugins/fzf.lua
+++ b/yazi-plugin/preset/plugins/fzf.lua
@@ -16,8 +16,8 @@ local function entry()
 	local output, err = child:wait_with_output()
 	if not output then
 		return fail("Cannot read `fzf` output, error code %s", err)
-	elseif not output.status:success() and output.status:code() ~= 130 then
-		return fail("`fzf` exited with error code %s", output.status:code())
+	elseif not output.status.success and output.status.code ~= 130 then
+		return fail("`fzf` exited with error code %s", output.status.code)
 	end
 
 	local target = output.stdout:gsub("\n$", "")

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -37,7 +37,7 @@ function M:preload()
 	end
 
 	local status = child:wait()
-	return status and status:success() and 1 or 2
+	return status and status.success and 1 or 2
 end
 
 return M

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -59,4 +59,28 @@ function M:fetch()
 	return j == #urls and 3 or 2
 end
 
+-- TODO: remove this after v0.3 release
+local notified = ya.sync(function (state)
+	if state.notified then
+		return true
+	else
+		state.notified = true
+		return false
+	end
+end)
+function M:preload()
+	if notified() then
+		return 1
+	end
+	ya.notify {
+		title = "Error",
+		content = [[In Yazi v0.3, the `mime` plugin has been re-classified as a fetcher. Please remove it from the `preloaders` of your yazi.toml
+
+See https://github.com/sxyazi/yazi/issues/1046 for details.]],
+		timeout = 20,
+		level = "error",
+	}
+	return 1
+end
+
 return M

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -34,7 +34,7 @@ function M:preload()
 
 	if not output then
 		return 0
-	elseif not output.status:success() then
+	elseif not output.status.success then
 		local pages = tonumber(output.stderr:match("the last page %((%d+)%)")) or 0
 		if self.skip > 0 and pages > 0 then
 			ya.manager_emit("peek", { math.max(0, pages - 1), only_if = self.file.url, upper_bound = true })

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -55,7 +55,7 @@ function M:preload()
 	end
 
 	local status = child:wait()
-	return status and status:success() and 1 or 2
+	return status and status.success and 1 or 2
 end
 
 return M

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -75,8 +75,8 @@ local function entry()
 	local output, err = child:wait_with_output()
 	if not output then
 		return fail("Cannot read `zoxide` output, error code %s", err)
-	elseif not output.status:success() and output.status:code() ~= 130 then
-		return fail("`zoxide` exited with error code %s", output.status:code())
+	elseif not output.status.success and output.status.code ~= 130 then
+		return fail("`zoxide` exited with error code %s", output.status.code)
 	end
 
 	local target = output.stdout:gsub("\n$", "")

--- a/yazi-plugin/src/bindings/cha.rs
+++ b/yazi-plugin/src/bindings/cha.rs
@@ -13,13 +13,10 @@ impl Cha {
 			reg.add_field_method_get("is_hidden", |_, me| Ok(me.is_hidden()));
 			reg.add_field_method_get("is_link", |_, me| Ok(me.is_link()));
 			reg.add_field_method_get("is_orphan", |_, me| Ok(me.is_orphan()));
-			// TODO: rename to `is_block`
-			reg.add_field_method_get("is_block_device", |_, me| Ok(me.is_block()));
-			// TODO: rename to `is_char`
-			reg.add_field_method_get("is_char_device", |_, me| Ok(me.is_char()));
+			reg.add_field_method_get("is_block", |_, me| Ok(me.is_block()));
+			reg.add_field_method_get("is_char", |_, me| Ok(me.is_char()));
 			reg.add_field_method_get("is_fifo", |_, me| Ok(me.is_fifo()));
-			// TODO: rename to `is_sock`
-			reg.add_field_method_get("is_socket", |_, me| Ok(me.is_sock()));
+			reg.add_field_method_get("is_sock", |_, me| Ok(me.is_sock()));
 			reg.add_field_method_get("is_exec", |_, me| Ok(me.is_exec()));
 			reg.add_field_method_get("is_sticky", |_, me| Ok(me.is_sticky()));
 

--- a/yazi-plugin/src/process/status.rs
+++ b/yazi-plugin/src/process/status.rs
@@ -9,8 +9,8 @@ impl Status {
 }
 
 impl UserData for Status {
-	fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
-		methods.add_method("success", |_, me, ()| Ok(me.inner.success()));
-		methods.add_method("code", |_, me, ()| Ok(me.inner.code()));
+	fn add_fields<'lua, F: mlua::UserDataFields<'lua, Self>>(fields: &mut F) {
+		fields.add_field_method_get("success", |_, me| Ok(me.inner.success()));
+		fields.add_field_method_get("code", |_, me| Ok(me.inner.code()));
 	}
 }


### PR DESCRIPTION
## `success` and `code` are now properties instead of methods of [`Status`](https://yazi-rs.github.io/docs/plugins/utils#status)

```diff
local status = Command("ls"):spawn():wait()
- ya.err("success:", status:success(), "code:", status:code())
+ ya.err("success:", status.success, "code:", status.code)
```

## Renamed `is_block_device`, `is_char_device`, and `is_socket` of [`Cha`](https://yazi-rs.github.io/docs/plugins/types#shared.cha)

- `is_block_device` => `is_block`
- `is_char_device` => `is_char`
- `is_socket` => `is_sock`
