### PR TITLE
feat: add `pack --list` subcommand to Ya CLI

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -91,6 +91,9 @@ pub(super) struct CommandPack {
 	/// Install all packages.
 	#[arg(short = 'i', long)]
 	pub(super) install: bool,
+	/// List all installed packages.
+	#[arg(short = 'l', long)]
+	pub(super) list:    bool,
 	/// Upgrade all packages.
 	#[arg(short = 'u', long)]
 	pub(super) upgrade: bool,

--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -91,7 +91,7 @@ pub(super) struct CommandPack {
 	/// Install all packages.
 	#[arg(short = 'i', long)]
 	pub(super) install: bool,
-	/// List all installed packages.
+	/// List all packages.
 	#[arg(short = 'l', long)]
 	pub(super) list:    bool,
 	/// Upgrade all packages.

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -36,6 +36,9 @@ async fn main() -> anyhow::Result<()> {
 			if cmd.install {
 				package::Package::install_from_config("plugin", false).await?;
 				package::Package::install_from_config("flavor", false).await?;
+			} else if cmd.list {
+				package::Package::list_from_config("plugin").await?;
+				package::Package::list_from_config("flavor").await?;
 			} else if cmd.upgrade {
 				package::Package::install_from_config("plugin", true).await?;
 				package::Package::install_from_config("flavor", true).await?;

--- a/yazi-cli/src/package/parser.rs
+++ b/yazi-cli/src/package/parser.rs
@@ -73,22 +73,18 @@ impl Package {
 		};
 
 		let doc = s.parse::<DocumentMut>().context("Failed to parse package.toml")?;
-
 		let Some(deps) = doc.get(section).and_then(|d| d.get("deps")) else {
 			return Ok(());
 		};
 
 		let deps = deps.as_array().context("`deps` must be an array")?;
-
 		println!("{section}s:");
-		for v in deps {
-			if let Some(dep_name) =
-				v.as_inline_table().and_then(|t| t.get("use")).and_then(|v| v.as_str())
-			{
-				println!("\t{dep_name}");
+
+		for dep in deps {
+			if let Some(Value::String(use_)) = dep.as_inline_table().and_then(|t| t.get("use")) {
+				println!("\t{}", use_.value());
 			}
 		}
-
 		Ok(())
 	}
 

--- a/yazi-cli/src/package/parser.rs
+++ b/yazi-cli/src/package/parser.rs
@@ -80,7 +80,7 @@ impl Package {
 
 		let deps = deps.as_array().context("`deps` must be an array")?;
 
-		println!("{section}:");
+		println!("{section}s:");
 		for v in deps {
 			if let Some(dep_name) =
 				v.as_inline_table().and_then(|t| t.get("use")).and_then(|v| v.as_str())


### PR DESCRIPTION
Add `-l`, `--list` flags to the `ya` `pack` command.

It prints a list of the currently installed packages as specified in the `package.toml` file.

Result:

```
ya pack --list
plugin:
	dedukun/relative-motions
	DreamMaoMao/mime
flavor:

```

```
ya pack --help
Manage packages

Usage: ya pack [OPTIONS]

Options:
  -a, --add <ADD>  Add a package
  -i, --install    Install all packages
  -l, --list       List all installed packages
  -u, --upgrade    Upgrade all packages
  -h, --help       Print help
```

The implementation is probably very naive. I'm open to any feedback.