### PR TITLE
feat!: DDS client-server version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,9 +1698,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -1717,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2052,9 +2052,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2807,6 +2807,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "uzers",
+ "vergen",
  "yazi-boot",
  "yazi-shared",
 ]

--- a/yazi-adaptor/Cargo.toml
+++ b/yazi-adaptor/Cargo.toml
@@ -25,7 +25,7 @@ imagesize    = "0.12.0"
 kamadak-exif = "0.5.5"
 ratatui      = "0.26.3"
 scopeguard   = "1.2.0"
-tokio        = { version = "1.37.0", features = [ "full" ] }
+tokio        = { version = "1.38.0", features = [ "full" ] }
 
 # Logging
 tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }

--- a/yazi-boot/Cargo.toml
+++ b/yazi-boot/Cargo.toml
@@ -15,7 +15,7 @@ yazi-shared  = { path = "../yazi-shared", version = "0.2.5" }
 
 # External dependencies
 clap  = { version = "4.5.4", features = [ "derive" ] }
-serde = { version = "1.0.202", features = [ "derive" ] }
+serde = { version = "1.0.203", features = [ "derive" ] }
 
 [build-dependencies]
 clap                  = { version = "4.5.4", features = [ "derive" ] }

--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -18,7 +18,7 @@ clap       = { version = "4.5.4", features = [ "derive" ] }
 crossterm  = "0.27.0"
 md-5       = "0.10.6"
 serde_json = "1.0.117"
-tokio      = { version = "1.37.0", features = [ "full" ] }
+tokio      = { version = "1.38.0", features = [ "full" ] }
 toml_edit  = "0.22.13"
 
 [build-dependencies]

--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -26,12 +26,12 @@ pub(super) enum Command {
 
 #[derive(clap::Args)]
 pub(super) struct CommandPub {
-	/// The receiver ID.
-	#[arg(index = 1)]
-	pub(super) receiver: u64,
 	/// The kind of message.
-	#[arg(index = 2)]
+	#[arg(index = 1)]
 	pub(super) kind:     String,
+	/// The receiver ID.
+	#[arg(index = 2)]
+	pub(super) receiver: Option<u64>,
 	/// Send the message with a string body.
 	#[arg(long)]
 	pub(super) str:      Option<String>,
@@ -42,25 +42,36 @@ pub(super) struct CommandPub {
 
 impl CommandPub {
 	#[allow(dead_code)]
+	pub(super) fn receiver(&self) -> Result<u64> {
+		if let Some(receiver) = self.receiver {
+			Ok(receiver)
+		} else if let Ok(s) = std::env::var("YAZI_ID") {
+			Ok(s.parse()?)
+		} else {
+			bail!("No receiver ID provided, also no YAZI_ID environment variable found.")
+		}
+	}
+
+	#[allow(dead_code)]
 	pub(super) fn body(&self) -> Result<Cow<str>> {
 		if let Some(json) = &self.json {
 			Ok(json.into())
 		} else if let Some(str) = &self.str {
 			Ok(serde_json::to_string(str)?.into())
 		} else {
-			bail!("No body provided");
+			Ok("".into())
 		}
 	}
 }
 
 #[derive(clap::Args)]
 pub(super) struct CommandPubStatic {
-	/// The severity of the message.
-	#[arg(index = 1)]
-	pub(super) severity: u16,
 	/// The kind of message.
-	#[arg(index = 2)]
+	#[arg(index = 1)]
 	pub(super) kind:     String,
+	/// The severity of the message.
+	#[arg(index = 2)]
+	pub(super) severity: u16,
 	/// Send the message with a string body.
 	#[arg(long)]
 	pub(super) str:      Option<String>,
@@ -77,7 +88,7 @@ impl CommandPubStatic {
 		} else if let Some(str) = &self.str {
 			Ok(serde_json::to_string(str)?.into())
 		} else {
-			bail!("No body provided");
+			Ok("".into())
 		}
 	}
 }

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 	match Args::parse().command {
 		Command::Pub(cmd) => {
 			yazi_dds::init();
-			if let Err(e) = yazi_dds::Client::shot(&cmd.kind, cmd.receiver, None, &cmd.body()?).await {
+			if let Err(e) = yazi_dds::Client::shot(&cmd.kind, cmd.receiver()?, None, &cmd.body()?).await {
 				eprintln!("Cannot send message: {e}");
 				std::process::exit(1);
 			}

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -18,7 +18,7 @@ crossterm   = "0.27.0"
 globset     = "0.4.14"
 indexmap    = "2.2.6"
 ratatui     = "0.26.3"
-serde       = { version = "1.0.202", features = [ "derive" ] }
+serde       = { version = "1.0.203", features = [ "derive" ] }
 shell-words = "1.1.0"
 toml        = { version = "0.8.13", features = [ "preserve_order" ] }
 validator   = { version = "0.18.1", features = [ "derive" ] }

--- a/yazi-core/Cargo.toml
+++ b/yazi-core/Cargo.toml
@@ -29,9 +29,9 @@ parking_lot   = "0.12.3"
 ratatui       = "0.26.3"
 regex         = "1.10.4"
 scopeguard    = "1.2.0"
-serde         = "1.0.202"
+serde         = "1.0.203"
 shell-words   = "1.1.0"
-tokio         = { version = "1.37.0", features = [ "full" ] }
+tokio         = { version = "1.38.0", features = [ "full" ] }
 tokio-stream  = "0.1.15"
 tokio-util    = "0.7.11"
 unicode-width = "0.1.12"

--- a/yazi-core/src/tab/commands/escape.rs
+++ b/yazi-core/src/tab/commands/escape.rs
@@ -8,8 +8,8 @@ bitflags! {
 	pub struct Opt: u8 {
 		const FIND   = 0b00001;
 		const VISUAL = 0b00010;
-		const SELECT = 0b00100;
-		const FILTER = 0b01000;
+		const FILTER = 0b00100;
+		const SELECT = 0b01000;
 		const SEARCH = 0b10000;
 	}
 }
@@ -21,8 +21,8 @@ impl From<Cmd> for Opt {
 				("all", true) => Self::all(),
 				("find", true) => acc | Self::FIND,
 				("visual", true) => acc | Self::VISUAL,
-				("select", true) => acc | Self::SELECT,
 				("filter", true) => acc | Self::FILTER,
+				("select", true) => acc | Self::SELECT,
 				("search", true) => acc | Self::SEARCH,
 				_ => acc,
 			}
@@ -36,8 +36,8 @@ impl Tab {
 		if opt.is_empty() {
 			_ = self.escape_find()
 				|| self.escape_visual()
-				|| self.escape_select()
 				|| self.escape_filter()
+				|| self.escape_select()
 				|| self.escape_search();
 			return;
 		}
@@ -48,11 +48,11 @@ impl Tab {
 		if opt.contains(Opt::VISUAL) {
 			self.escape_visual();
 		}
-		if opt.contains(Opt::SELECT) {
-			self.escape_select();
-		}
 		if opt.contains(Opt::FILTER) {
 			self.escape_filter();
+		}
+		if opt.contains(Opt::SELECT) {
+			self.escape_select();
 		}
 		if opt.contains(Opt::SEARCH) {
 			self.escape_search();
@@ -70,6 +70,15 @@ impl Tab {
 		true
 	}
 
+	pub fn escape_filter(&mut self) -> bool {
+		if self.current.files.filter().is_none() {
+			return false;
+		}
+
+		self.filter_do(super::filter::Opt::default());
+		render_and!(true)
+	}
+
 	pub fn escape_select(&mut self) -> bool {
 		if self.selected.is_empty() {
 			return false;
@@ -79,15 +88,6 @@ impl Tab {
 		if self.current.hovered().is_some_and(|h| h.is_dir()) {
 			ManagerProxy::peek(true);
 		}
-		render_and!(true)
-	}
-
-	pub fn escape_filter(&mut self) -> bool {
-		if self.current.files.filter().is_none() {
-			return false;
-		}
-
-		self.filter_do(super::filter::Opt::default());
 		render_and!(true)
 	}
 

--- a/yazi-dds/Cargo.toml
+++ b/yazi-dds/Cargo.toml
@@ -20,11 +20,14 @@ yazi-shared = { path = "../yazi-shared", version = "0.2.5" }
 anyhow       = "1.0.86"
 mlua         = { version = "0.9.8", features = [ "lua54" ] }
 parking_lot  = "0.12.3"
-serde        = { version = "1.0.202", features = [ "derive" ] }
+serde        = { version = "1.0.203", features = [ "derive" ] }
 serde_json   = "1.0.117"
-tokio        = { version = "1.37.0", features = [ "full" ] }
+tokio        = { version = "1.38.0", features = [ "full" ] }
 tokio-stream = "0.1.15"
 tokio-util   = "0.7.11"
+
+[build-dependencies]
+vergen       = { version = "8.3.1", features = [ "build", "git", "gitcl" ] }
 
 [target."cfg(unix)".dependencies]
 uzers = "0.12.0"

--- a/yazi-dds/build.rs
+++ b/yazi-dds/build.rs
@@ -1,0 +1,9 @@
+use std::error::Error;
+
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+	EmitBuilder::builder().git_sha(true).emit()?;
+
+	Ok(())
+}

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -101,6 +101,14 @@ impl<'a> Body<'a> {
 	}
 
 	#[inline]
+	pub fn as_hey(&self) -> Option<&BodyHey> {
+		match self {
+			Self::Hey(b) => Some(b),
+			_ => None,
+		}
+	}
+
+	#[inline]
 	pub fn with_receiver(self, receiver: u64) -> Payload<'a> {
 		Payload::new(self).with_receiver(receiver)
 	}

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -101,14 +101,6 @@ impl<'a> Body<'a> {
 	}
 
 	#[inline]
-	pub fn as_hey(&self) -> Option<&BodyHey> {
-		match self {
-			Self::Hey(b) => Some(b),
-			_ => None,
-		}
-	}
-
-	#[inline]
 	pub fn with_receiver(self, receiver: u64) -> Payload<'a> {
 		Payload::new(self).with_receiver(receiver)
 	}

--- a/yazi-dds/src/body/bye.rs
+++ b/yazi-dds/src/body/bye.rs
@@ -4,11 +4,11 @@ use serde::{Deserialize, Serialize};
 use super::Body;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BodyBye {}
+pub struct BodyBye;
 
 impl BodyBye {
 	#[inline]
-	pub fn borrowed() -> Body<'static> { Self {}.into() }
+	pub fn owned() -> Body<'static> { Self.into() }
 }
 
 impl<'a> From<BodyBye> for Body<'a> {

--- a/yazi-dds/src/body/hey.rs
+++ b/yazi-dds/src/body/hey.rs
@@ -17,9 +17,6 @@ impl BodyHey {
 	pub fn owned(peers: HashMap<u64, Peer>) -> Body<'static> {
 		Self { peers, version: BodyHi::version() }.into()
 	}
-
-	#[inline]
-	pub fn match_version(&self) -> bool { self.version == BodyHi::version() }
 }
 
 impl From<BodyHey> for Body<'_> {

--- a/yazi-dds/src/body/hey.rs
+++ b/yazi-dds/src/body/hey.rs
@@ -3,12 +3,23 @@ use std::collections::HashMap;
 use mlua::{ExternalResult, IntoLua, Lua, Value};
 use serde::{Deserialize, Serialize};
 
-use super::Body;
+use super::{Body, BodyHi};
 use crate::Peer;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BodyHey {
-	pub peers: HashMap<u64, Peer>,
+	pub peers:   HashMap<u64, Peer>,
+	pub version: String,
+}
+
+impl BodyHey {
+	#[inline]
+	pub fn owned(peers: HashMap<u64, Peer>) -> Body<'static> {
+		Self { peers, version: BodyHi::version() }.into()
+	}
+
+	#[inline]
+	pub fn match_version(&self) -> bool { self.version == BodyHi::version() }
 }
 
 impl From<BodyHey> for Body<'_> {

--- a/yazi-dds/src/body/hi.rs
+++ b/yazi-dds/src/body/hi.rs
@@ -8,12 +8,22 @@ use super::Body;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BodyHi<'a> {
 	pub abilities: HashSet<Cow<'a, String>>,
+	pub version:   String,
 }
 
 impl<'a> BodyHi<'a> {
 	#[inline]
 	pub fn borrowed(abilities: HashSet<&'a String>) -> Body<'a> {
-		Self { abilities: abilities.into_iter().map(Cow::Borrowed).collect() }.into()
+		Self {
+			abilities: abilities.into_iter().map(Cow::Borrowed).collect(),
+			version:   Self::version(),
+		}
+		.into()
+	}
+
+	#[inline]
+	pub(super) fn version() -> String {
+		format!("{} {}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"))
 	}
 }
 

--- a/yazi-dds/src/body/hi.rs
+++ b/yazi-dds/src/body/hi.rs
@@ -22,9 +22,7 @@ impl<'a> BodyHi<'a> {
 	}
 
 	#[inline]
-	pub(super) fn version() -> String {
-		format!("{} {}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"))
-	}
+	pub fn version() -> String { format!("{} {}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA")) }
 }
 
 impl<'a> From<BodyHi<'a>> for Body<'a> {

--- a/yazi-dds/src/client.rs
+++ b/yazi-dds/src/client.rs
@@ -81,7 +81,7 @@ impl Client {
 			match line.split(',').next() {
 				Some("hey") => {
 					if !Payload::from_str(&line)?.body.as_hey().is_some_and(|b| b.match_version()) {
-						bail!("Server version mismatch: `yazi` and `ya` must have the same version")
+						bail!("Server version mismatch - `yazi` and `ya` must have the same version")
 					}
 				}
 				Some("bye") => break,

--- a/yazi-dds/src/client.rs
+++ b/yazi-dds/src/client.rs
@@ -92,7 +92,7 @@ impl Client {
 
 		if version != Some(BodyHi::version()) {
 			bail!(
-				"Incompatible version - Yazi {} <==> Ya {}",
+				"Incompatible version (Yazi {}, Ya {})",
 				version.as_deref().unwrap_or("Unknown"),
 				BodyHi::version()
 			);

--- a/yazi-dds/src/client.rs
+++ b/yazi-dds/src/client.rs
@@ -80,7 +80,7 @@ impl Client {
 		let mut version = None;
 		while let Ok(Some(line)) = lines.next_line().await {
 			match line.split(',').next() {
-				Some("hey") => {
+				Some("hey") if version.is_none() => {
 					if let Ok(Body::Hey(hey)) = Payload::from_str(&line).map(|p| p.body) {
 						version = Some(hey.version);
 					}
@@ -92,9 +92,9 @@ impl Client {
 
 		if version != Some(BodyHi::version()) {
 			bail!(
-				"Incompatible version (Yazi {}, Ya {})",
-				version.as_deref().unwrap_or("Unknown"),
-				BodyHi::version()
+				"Incompatible version (Ya {}, Yazi {})",
+				BodyHi::version(),
+				version.as_deref().unwrap_or("Unknown")
 			);
 		}
 		Ok(())

--- a/yazi-dds/src/server.rs
+++ b/yazi-dds/src/server.rs
@@ -2,10 +2,10 @@ use std::{collections::HashMap, str::FromStr, time::Duration};
 
 use anyhow::Result;
 use parking_lot::RwLock;
-use tokio::{io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, select, sync::mpsc, task::JoinHandle, time};
+use tokio::{io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, select, sync::mpsc::{self, UnboundedReceiver}, task::JoinHandle, time};
 use yazi_shared::RoCell;
 
-use crate::{body::{Body, BodyBye, BodyHey}, Client, Payload, Peer, Stream, STATE};
+use crate::{body::{Body, BodyBye, BodyHey}, Client, ClientWriter, Payload, Peer, Stream, STATE};
 
 pub(super) static CLIENTS: RoCell<RwLock<HashMap<u64, Client>>> = RoCell::new();
 
@@ -44,7 +44,7 @@ impl Server {
 
 								let Some(id) = id else { continue };
 								if line.starts_with("bye,") {
-									writer.write_all(BodyBye::borrowed().with_receiver(id).with_sender(0).to_string().as_bytes()).await.ok();
+									Self::handle_bye(id, rx, writer).await;
 									break;
 								}
 
@@ -77,7 +77,11 @@ impl Server {
 							else => break
 						}
 					}
-					Self::handle_bye(id);
+
+					let mut clients = CLIENTS.write();
+					if id.and_then(|id| clients.remove(&id)).is_some() {
+						Self::handle_hey(&clients);
+					}
 				});
 			}
 		}))
@@ -111,18 +115,24 @@ impl Server {
 	fn handle_hey(clients: &HashMap<u64, Client>) {
 		let payload = format!(
 			"{}\n",
-			Payload::new(
-				BodyHey { peers: clients.values().map(|c| (c.id, Peer::new(&c.abilities))).collect() }
-					.into()
-			)
+			Payload::new(BodyHey::owned(
+				clients.values().map(|c| (c.id, Peer::new(&c.abilities))).collect()
+			))
 		);
 		clients.values().for_each(|c| _ = c.tx.send(payload.clone()));
 	}
 
-	fn handle_bye(id: Option<u64>) {
-		let mut clients = CLIENTS.write();
-		if id.and_then(|id| clients.remove(&id)).is_some() {
-			Self::handle_hey(&clients);
+	async fn handle_bye(id: u64, mut rx: UnboundedReceiver<String>, mut writer: ClientWriter) {
+		while let Ok(payload) = rx.try_recv() {
+			if writer.write_all(payload.as_bytes()).await.is_err() {
+				break;
+			}
 		}
+
+		_ = writer
+			.write_all(BodyBye::owned().with_receiver(id).with_sender(0).to_string().as_bytes())
+			.await;
+
+		writer.flush().await.ok();
 	}
 }

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -32,7 +32,7 @@ mlua         = { version = "0.9.8", features = [ "lua54" ] }
 ratatui      = "0.26.3"
 scopeguard   = "1.2.0"
 syntect      = { version = "5.2.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }
-tokio        = { version = "1.37.0", features = [ "full" ] }
+tokio        = { version = "1.38.0", features = [ "full" ] }
 tokio-util   = "0.7.11"
 
 # Logging

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -30,12 +30,12 @@ md-5          = "0.10.6"
 mlua          = { version = "0.9.8", features = [ "lua54", "serialize", "macros", "async" ] }
 parking_lot   = "0.12.3"
 ratatui       = "0.26.3"
-serde         = "1.0.202"
+serde         = "1.0.203"
 serde_json    = "1.0.117"
 shell-escape  = "0.1.5"
 shell-words   = "1.1.0"
 syntect       = { version = "5.2.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }
-tokio         = { version = "1.37.0", features = [ "full" ] }
+tokio         = { version = "1.38.0", features = [ "full" ] }
 tokio-stream  = "0.1.15"
 tokio-util    = "0.7.11"
 unicode-width = "0.1.12"

--- a/yazi-proxy/Cargo.toml
+++ b/yazi-proxy/Cargo.toml
@@ -19,4 +19,4 @@ yazi-shared = { path = "../yazi-shared", version = "0.2.5" }
 # External dependencies
 anyhow = "1.0.86"
 mlua   = { version = "0.9.8", features = [ "lua54" ] }
-tokio  = { version = "1.37.0", features = [ "full" ] }
+tokio  = { version = "1.38.0", features = [ "full" ] }

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -21,7 +21,7 @@ async-priority-channel = "0.2.0"
 futures                = "0.3.30"
 parking_lot            = "0.12.3"
 scopeguard             = "1.2.0"
-tokio                  = { version = "1.37.0", features = [ "full" ] }
+tokio                  = { version = "1.38.0", features = [ "full" ] }
 
 # Logging
 tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }

--- a/yazi-shared/Cargo.toml
+++ b/yazi-shared/Cargo.toml
@@ -20,9 +20,9 @@ parking_lot      = "0.12.3"
 percent-encoding = "2.3.1"
 ratatui          = "0.26.3"
 regex            = "1.10.4"
-serde            = { version = "1.0.202", features = [ "derive" ] }
+serde            = { version = "1.0.203", features = [ "derive" ] }
 shell-words      = "1.1.0"
-tokio            = { version = "1.37.0", features = [ "full" ] }
+tokio            = { version = "1.38.0", features = [ "full" ] }
 
 # Logging
 tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }


### PR DESCRIPTION
This PR also simplifies the parameters for `ya pub`:

- Now you can omit the body, meaning an empty body is allowed. This allows:
    ```bash
    ya pub "$YAZI_ID" dds-test -str ""
    ```
    to be written as:
    ```bash
    ya pub "$YAZI_ID" dds-test
    ```

- Now you can omit the receiver. When the receiver is not specified, it uses the value from the environment variable `YAZI_ID`. This allows:
    ```bash
    ya pub "$YAZI_ID" dds-test
    ```
    to be written as:
    ```bash
    ya pub dds-test
    # Or
    ya pub dds-test "$YAZI_ID"
    ```

    Note: To achieve this, the receiver has been moved from the first parameter to the second parameter, i.e., `ya pub <receiver> <kind>` becomes `ya pub <kind> <receiver>`. 

    This is a breaking change in Yazi v0.3. `ya pub` was added in the previous version, so the amount of code broken by this is reasonably small. Tagging the owners of affected repos as a headsup: https://github.com/search?q=ya+pub+%24YAZI_ID&type=code

    - @qsdrqs - https://github.com/qsdrqs/mydotfiles/blob/ea41d5442a094278e2c35c0d65a464266b75fb4a/.zshrc#L478
    - @chenrry666 - https://github.com/chenrry666/dotfiles/blob/67fbc8b4e81d562204505a66ff0566b0aa27b1eb/.config/zsh/alias.zsh#L12
