### PR TITLE
feat: add some dependency version information to `yazi --debug`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_fig",
  "clap_complete_nushell",
+ "regex",
  "serde",
  "vergen",
  "yazi-adaptor",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Yazi (means "duck") is a terminal file manager written in Rust, based on non-blo
 - 💫 Vim-like input/select/which/notify component, auto-completion for cd paths
 - 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, directories, code, etc.)
 - 🔄 Bulk Renaming, Visual Mode, File Chooser
-- 🎨 Theme System, Custom Layouts, Trash Bin, CSI u
+- 🎨 Theme System, Mouse Support, Trash Bin, Custom Layouts, CSI u
 - ... and more!
 
 https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265cc7

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -34,7 +34,7 @@
     # Resize logo
     for RES in 16 24 32 48 64 128 256; do
       mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-      convert assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
+      magick assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
     done
 
     mkdir -p $out/share/applications

--- a/yazi-boot/Cargo.toml
+++ b/yazi-boot/Cargo.toml
@@ -9,6 +9,7 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
+regex        = "1.10.4"
 yazi-adaptor = { path = "../yazi-adaptor", version = "0.2.5" }
 yazi-config  = { path = "../yazi-config", version = "0.2.5" }
 yazi-shared  = { path = "../yazi-shared", version = "0.2.5" }

--- a/yazi-boot/src/boot.rs
+++ b/yazi-boot/src/boot.rs
@@ -1,25 +1,35 @@
-use std::{collections::HashSet, env, ffi::OsString, fmt::Write, path::{Path, PathBuf}, process};
+use std::{
+	collections::HashSet,
+	env,
+	ffi::OsString,
+	fmt::Write,
+	path::{Path, PathBuf},
+	process,
+};
 
 use clap::Parser;
 use serde::Serialize;
 use yazi_config::PREVIEW;
-use yazi_shared::{fs::{current_cwd, expand_path}, Xdg};
+use yazi_shared::{
+	fs::{current_cwd, expand_path},
+	Xdg,
+};
 
 use super::Args;
 use crate::ARGS;
 
 #[derive(Debug, Serialize)]
 pub struct Boot {
-	pub cwd:  PathBuf,
+	pub cwd: PathBuf,
 	pub file: Option<OsString>,
 
-	pub local_events:  HashSet<String>,
+	pub local_events: HashSet<String>,
 	pub remote_events: HashSet<String>,
 
 	pub config_dir: PathBuf,
 	pub flavor_dir: PathBuf,
 	pub plugin_dir: PathBuf,
-	pub state_dir:  PathBuf,
+	pub state_dir: PathBuf,
 }
 
 impl Boot {
@@ -47,7 +57,10 @@ impl Boot {
 	}
 
 	fn action_debug() -> Result<String, std::fmt::Error> {
-		use std::{env::consts::{ARCH, FAMILY, OS}, process::Command};
+		use std::{
+			env::consts::{ARCH, FAMILY, OS},
+			process::Command,
+		};
 		let mut s = String::new();
 
 		writeln!(s, "\nYazi")?;
@@ -56,7 +69,15 @@ impl Boot {
 		writeln!(s, "    Debug: {}", cfg!(debug_assertions))?;
 
 		writeln!(s, "\nYa")?;
-		writeln!(s, "    Version: {:?}", Command::new("ya").arg("--version").output())?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("ya")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
 
 		writeln!(s, "\nEmulator")?;
 		writeln!(s, "    Emulator.via_env: {:?}", yazi_adaptor::Emulator::via_env())?;
@@ -92,7 +113,11 @@ impl Boot {
 		writeln!(
 			s,
 			"    Version: {:?}",
-			Command::new(env::var_os("YAZI_FILE_ONE").unwrap_or("file".into())).arg("--version").output()
+			Command::new(env::var_os("YAZI_FILE_ONE").unwrap_or("file".into()))
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
 		)?;
 
 		writeln!(s, "\nText Opener")?;
@@ -106,8 +131,116 @@ impl Boot {
 		writeln!(s, "\ntmux")?;
 		writeln!(s, "    TMUX: {:?}", *yazi_adaptor::TMUX)?;
 
+		writeln!(s, "\nDependencies Versions")?;
+		writeln!(s, "\nffmpegthumbnailer")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("ffmpegthumbnailer")
+				.arg("-v")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
 		writeln!(s, "\nUeberzug++")?;
-		writeln!(s, "    Version: {:?}", Command::new("ueberzugpp").arg("--version").output())?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("ueberzugpp")
+				.arg("version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\nunar")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("unar")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\njq")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("jq")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\nfd")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("fd")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\nrg")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("rg")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\nfzf")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("fzf")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\nzoxide")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("zoxide")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\nchafa")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("chafa")
+				.arg("--version")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
+
+		writeln!(s, "\ntmux")?;
+		writeln!(
+			s,
+			"    Version: {:?}",
+			Command::new("tmux")
+				.arg("-V")
+				.output()
+				.and_then(|output| Ok(String::from_utf8(output.stdout)))
+				.unwrap_or(Ok("Nill".to_string()))
+		)?;
 
 		writeln!(s, "\n\n--------------------------------------------------")?;
 		writeln!(

--- a/yazi-boot/src/boot.rs
+++ b/yazi-boot/src/boot.rs
@@ -1,35 +1,25 @@
-use std::{
-	collections::HashSet,
-	env,
-	ffi::OsString,
-	fmt::Write,
-	path::{Path, PathBuf},
-	process,
-};
+use std::{collections::HashSet, env, ffi::OsString, fmt::Write, path::{Path, PathBuf}, process};
 
 use clap::Parser;
 use serde::Serialize;
 use yazi_config::PREVIEW;
-use yazi_shared::{
-	fs::{current_cwd, expand_path},
-	Xdg,
-};
+use yazi_shared::{fs::{current_cwd, expand_path}, Xdg};
 
 use super::Args;
 use crate::ARGS;
 
 #[derive(Debug, Serialize)]
 pub struct Boot {
-	pub cwd: PathBuf,
+	pub cwd:  PathBuf,
 	pub file: Option<OsString>,
 
-	pub local_events: HashSet<String>,
+	pub local_events:  HashSet<String>,
 	pub remote_events: HashSet<String>,
 
 	pub config_dir: PathBuf,
 	pub flavor_dir: PathBuf,
 	pub plugin_dir: PathBuf,
-	pub state_dir: PathBuf,
+	pub state_dir:  PathBuf,
 }
 
 impl Boot {
@@ -57,10 +47,7 @@ impl Boot {
 	}
 
 	fn action_debug() -> Result<String, std::fmt::Error> {
-		use std::{
-			env::consts::{ARCH, FAMILY, OS},
-			process::Command,
-		};
+		use std::{env::consts::{ARCH, FAMILY, OS}, process::Command};
 		let mut s = String::new();
 
 		writeln!(s, "\nYazi")?;

--- a/yazi-boot/src/boot.rs
+++ b/yazi-boot/src/boot.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashSet, env, ffi::OsString, fmt::Write, path::{Path, PathBuf}, process};
+use std::{collections::HashSet, env, ffi::{OsStr, OsString}, fmt::Write, path::{Path, PathBuf}, process};
 
 use clap::Parser;
+use regex::Regex;
 use serde::Serialize;
 use yazi_config::PREVIEW;
 use yazi_shared::{fs::{current_cwd, expand_path}, Xdg};
@@ -37,6 +38,22 @@ impl Boot {
 		(parent.unwrap().to_owned(), Some(entry.file_name().unwrap().to_owned()))
 	}
 
+	fn process_output(name: impl AsRef<OsStr>, arg: impl AsRef<OsStr>) -> String {
+		match std::process::Command::new(name.as_ref()).arg(arg).output() {
+			Ok(out) if out.status.success() => {
+				let line =
+					String::from_utf8_lossy(&out.stdout).trim().lines().next().unwrap_or_default().to_owned();
+				Regex::new(r"\d+\.\d+(\.\d+-\d+|\.\d+|\b)")
+					.unwrap()
+					.find(&line)
+					.map(|m| m.as_str().to_owned())
+					.unwrap_or(line)
+			}
+			Ok(out) => format!("{:?}, {:?}", out.status, String::from_utf8_lossy(&out.stderr)),
+			Err(e) => format!("{e}"),
+		}
+	}
+
 	fn action_version() -> String {
 		format!(
 			"{} ({} {})",
@@ -47,37 +64,29 @@ impl Boot {
 	}
 
 	fn action_debug() -> Result<String, std::fmt::Error> {
-		use std::{env::consts::{ARCH, FAMILY, OS}, process::Command};
+		use std::env::consts::{ARCH, FAMILY, OS};
 		let mut s = String::new();
 
 		writeln!(s, "\nYazi")?;
 		writeln!(s, "    Version: {}", Self::action_version())?;
-		writeln!(s, "    OS: {}-{} ({})", OS, ARCH, FAMILY)?;
-		writeln!(s, "    Debug: {}", cfg!(debug_assertions))?;
+		writeln!(s, "    Debug  : {}", cfg!(debug_assertions))?;
+		writeln!(s, "    OS     : {}-{} ({})", OS, ARCH, FAMILY)?;
 
 		writeln!(s, "\nYa")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("ya")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
+		writeln!(s, "    Version: {}", Self::process_output("ya", "--version"))?;
 
 		writeln!(s, "\nEmulator")?;
 		writeln!(s, "    Emulator.via_env: {:?}", yazi_adaptor::Emulator::via_env())?;
 		writeln!(s, "    Emulator.via_csi: {:?}", yazi_adaptor::Emulator::via_csi())?;
-		writeln!(s, "    Emulator.detect: {:?}", yazi_adaptor::Emulator::detect())?;
+		writeln!(s, "    Emulator.detect : {:?}", yazi_adaptor::Emulator::detect())?;
 
 		writeln!(s, "\nAdaptor")?;
 		writeln!(s, "    Adaptor.matches: {:?}", yazi_adaptor::Adaptor::matches())?;
 
 		writeln!(s, "\nDesktop")?;
 		writeln!(s, "    XDG_SESSION_TYPE: {:?}", env::var_os("XDG_SESSION_TYPE"))?;
-		writeln!(s, "    WAYLAND_DISPLAY: {:?}", env::var_os("WAYLAND_DISPLAY"))?;
-		writeln!(s, "    DISPLAY: {:?}", env::var_os("DISPLAY"))?;
+		writeln!(s, "    WAYLAND_DISPLAY : {:?}", env::var_os("WAYLAND_DISPLAY"))?;
+		writeln!(s, "    DISPLAY         : {:?}", env::var_os("DISPLAY"))?;
 
 		writeln!(s, "\nSSH")?;
 		writeln!(s, "    shared.in_ssh_connection: {:?}", yazi_shared::in_ssh_connection())?;
@@ -90,22 +99,11 @@ impl Boot {
 		)?;
 
 		writeln!(s, "\nVariables")?;
-		writeln!(s, "    SHELL: {:?}", env::var_os("SHELL"))?;
-		writeln!(s, "    EDITOR: {:?}", env::var_os("EDITOR"))?;
+		writeln!(s, "    SHELL              : {:?}", env::var_os("SHELL"))?;
+		writeln!(s, "    EDITOR             : {:?}", env::var_os("EDITOR"))?;
 		writeln!(s, "    ZELLIJ_SESSION_NAME: {:?}", env::var_os("ZELLIJ_SESSION_NAME"))?;
-		writeln!(s, "    YAZI_FILE_ONE: {:?}", env::var_os("YAZI_FILE_ONE"))?;
-		writeln!(s, "    YAZI_CONFIG_HOME: {:?}", env::var_os("YAZI_CONFIG_HOME"))?;
-
-		writeln!(s, "\nfile(1)")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new(env::var_os("YAZI_FILE_ONE").unwrap_or("file".into()))
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
+		writeln!(s, "    YAZI_FILE_ONE      : {:?}", env::var_os("YAZI_FILE_ONE"))?;
+		writeln!(s, "    YAZI_CONFIG_HOME   : {:?}", env::var_os("YAZI_CONFIG_HOME"))?;
 
 		writeln!(s, "\nText Opener")?;
 		writeln!(
@@ -113,121 +111,28 @@ impl Boot {
 			"    default: {:?}",
 			yazi_config::OPEN.openers("f75a.txt", "text/plain").and_then(|a| a.first().cloned())
 		)?;
-		writeln!(s, "    block: {:?}", yazi_config::OPEN.block_opener("bulk.txt", "text/plain"))?;
+		writeln!(s, "    block  : {:?}", yazi_config::OPEN.block_opener("bulk.txt", "text/plain"))?;
 
 		writeln!(s, "\ntmux")?;
-		writeln!(s, "    TMUX: {:?}", *yazi_adaptor::TMUX)?;
+		writeln!(s, "    TMUX   : {:?}", *yazi_adaptor::TMUX)?;
+		writeln!(s, "    Version: {}", Self::process_output("tmux", "-V"))?;
 
-		writeln!(s, "\nDependencies Versions")?;
-		writeln!(s, "\nffmpegthumbnailer")?;
+		writeln!(s, "\nDependencies")?;
 		writeln!(
 			s,
-			"    Version: {:?}",
-			Command::new("ffmpegthumbnailer")
-				.arg("-v")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
+			"    file             : {}",
+			Self::process_output(env::var_os("YAZI_FILE_ONE").unwrap_or("file".into()), "--version")
 		)?;
-
-		writeln!(s, "\nUeberzug++")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("ueberzugpp")
-				.arg("version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\nunar")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("unar")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\njq")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("jq")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\nfd")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("fd")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\nrg")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("rg")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\nfzf")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("fzf")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\nzoxide")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("zoxide")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\nchafa")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("chafa")
-				.arg("--version")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
-
-		writeln!(s, "\ntmux")?;
-		writeln!(
-			s,
-			"    Version: {:?}",
-			Command::new("tmux")
-				.arg("-V")
-				.output()
-				.and_then(|output| Ok(String::from_utf8(output.stdout)))
-				.unwrap_or(Ok("Nill".to_string()))
-		)?;
+		writeln!(s, "    ueberzugpp       : {}", Self::process_output("ueberzugpp", "--version"))?;
+		writeln!(s, "    ffmpegthumbnailer: {}", Self::process_output("ffmpegthumbnailer", "-v"))?;
+		writeln!(s, "    magick           : {}", Self::process_output("magick", "--version"))?;
+		writeln!(s, "    fzf              : {}", Self::process_output("fzf", "--version"))?;
+		writeln!(s, "    fd               : {}", Self::process_output("fd", "--version"))?;
+		writeln!(s, "    rg               : {}", Self::process_output("rg", "--version"))?;
+		writeln!(s, "    chafa            : {}", Self::process_output("chafa", "--version"))?;
+		writeln!(s, "    zoxide           : {}", Self::process_output("zoxide", "--version"))?;
+		writeln!(s, "    unar             : {}", Self::process_output("unar", "--version"))?;
+		writeln!(s, "    jq               : {}", Self::process_output("jq", "--version"))?;
 
 		writeln!(s, "\n\n--------------------------------------------------")?;
 		writeln!(

--- a/yazi-fm/src/components/current.rs
+++ b/yazi-fm/src/components/current.rs
@@ -5,7 +5,7 @@ use yazi_plugin::{bindings::{Cast, MouseEvent}, LUA};
 pub(crate) struct Current;
 
 impl Current {
-	pub fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
+	pub(crate) fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
 		let evt = MouseEvent::cast(&LUA, event)?;
 		let comp: Table = LUA.globals().raw_get("Current")?;
 

--- a/yazi-fm/src/components/header.rs
+++ b/yazi-fm/src/components/header.rs
@@ -21,7 +21,7 @@ impl Widget for Header {
 }
 
 impl Header {
-	pub fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
+	pub(crate) fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
 		let evt = MouseEvent::cast(&LUA, event)?;
 		let comp: Table = LUA.globals().raw_get("Header")?;
 

--- a/yazi-fm/src/components/parent.rs
+++ b/yazi-fm/src/components/parent.rs
@@ -5,7 +5,7 @@ use yazi_plugin::{bindings::{Cast, MouseEvent}, LUA};
 pub(crate) struct Parent;
 
 impl Parent {
-	pub fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
+	pub(crate) fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
 		let evt = MouseEvent::cast(&LUA, event)?;
 		let comp: Table = LUA.globals().raw_get("Parent")?;
 

--- a/yazi-fm/src/components/preview.rs
+++ b/yazi-fm/src/components/preview.rs
@@ -13,7 +13,7 @@ impl<'a> Preview<'a> {
 	#[inline]
 	pub(crate) fn new(cx: &'a Ctx) -> Self { Self { cx } }
 
-	pub fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
+	pub(crate) fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
 		let evt = MouseEvent::cast(&LUA, event)?;
 		let comp: Table = LUA.globals().raw_get("Preview")?;
 

--- a/yazi-fm/src/components/status.rs
+++ b/yazi-fm/src/components/status.rs
@@ -21,7 +21,7 @@ impl Widget for Status {
 }
 
 impl Status {
-	pub fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
+	pub(crate) fn mouse(event: crossterm::event::MouseEvent) -> mlua::Result<()> {
 		let evt = MouseEvent::cast(&LUA, event)?;
 		let comp: Table = LUA.globals().raw_get("Status")?;
 

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -22,7 +22,7 @@ function M:preload()
 		return 1
 	end
 
-	local child, code = Command("convert"):args({
+	local child, code = Command("magick"):args({
 		"-size",
 		"800x560",
 		"-gravity",
@@ -41,7 +41,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("spawn `convert` command returns " .. tostring(code))
+		ya.err("spawn `magick` command returns " .. tostring(code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -20,7 +20,7 @@ function M:preload()
 		return 1
 	end
 
-	local child, code = Command("convert"):args({
+	local child, code = Command("magick"):args({
 		"-density",
 		"200",
 		"-resize",
@@ -32,7 +32,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("spawn `convert` command returns " .. tostring(code))
+		ya.err("spawn `magick` command returns " .. tostring(code))
 		return 0
 	end
 


### PR DESCRIPTION
Fixes #1104
 
I made it so that it would print Nill if the user doesn't have that dependency and the version otherwise

Here is a sample output after changes:

Yazi
    Version: 0.2.5 (0b2089b 2024-06-02)
    OS: linux-x86_64 (unix)
    Debug: true

Ya
    Version: Ok("ya 0.2.5\n")

Emulator
    Emulator.via_env: ("alacritty", "")
    Emulator.via_csi: Ok(Unknown([]))
    Emulator.detect: Unknown([])

Adaptor
    Adaptor.matches: X11

Desktop
    XDG_SESSION_TYPE: Some("x11")
    WAYLAND_DISPLAY: None
    DISPLAY: Some(":0")

SSH
    shared.in_ssh_connection: false

WSL
    /proc/sys/fs/binfmt_misc/WSLInterop: false

Variables
    SHELL: Some("/usr/bin/zsh")
    EDITOR: Some("nvim")
    ZELLIJ_SESSION_NAME: None
    YAZI_FILE_ONE: None
    YAZI_CONFIG_HOME: None

file(1)
    Version: Ok("file-5.45\nmagic file from /usr/share/file/misc/magic\nseccomp support included\n")

Text Opener
    default: Some(Opener { run: "${EDITOR:=vi} \"$@\"", block: true, orphan: false, desc: "$EDITOR", for_: None, spread: true })
    block: Some(Opener { run: "${EDITOR:=vi} \"$@\"", block: true, orphan: false, desc: "$EDITOR", for_: None, spread: true })

tmux
    TMUX: false

Dependencies Versions

ffmpegthumbnailer
    Version: Ok("ffmpegthumbnailer version: 2.2.2\n")

Ueberzug++
    Version: Ok("Nill")

unar
    Version: Ok("v1.10.7\n")

jq
    Version: Ok("jq-1.7.1\n")

fd
    Version: Ok("fd 8.7.0\n")

rg
    Version: Ok("ripgrep 14.1.0\n\nfeatures:-simd-accel,+pcre2\nsimd(compile):+SSE2,-SSSE3,-AVX2\nsimd(runtime):+SSE2,+SSSE3,+AVX2\n\nPCRE2 10.42 is available (JIT is available)\n")

fzf
    Version: Ok("0.52.0 (bcda25a5)\n")

zoxide
    Version: Ok("zoxide 0.9.4\n")

chafa
    Version: Ok("Chafa version 1.14.0\n\nLoaders:  AVIF GIF JPEG PNG QOI SVG TIFF WebP XWD\nFeatures: mmx sse4.1 popcnt avx2\nApplying: mmx sse4.1 popcnt avx2\n\nCopyright (C) 2018-2023 Hans Petter Jansson et al.\nIncl. libnsgif copyright (C) 2004 Richard Wilson, copyright (C) 2008 Sean Fox\nIncl. LodePNG copyright (C) 2005-2018 Lode Vandevenne\nIncl. QOI decoder copyright (C) 2021 Dominic Szablewski\n\nThis is free software; see the source for copying conditions. There is NO\nwarranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n")

tmux
    Version: Ok("tmux 3.4\n")