### PR TITLE
feat: support `enable` for which-key

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -185,10 +185,11 @@ open_origin = "hovered"
 open_offset = [ 0, 1, 50, 7 ]
 
 [which]
+enable           = true
 sort_by      	 = "none"
-sort_sensitive = false
+sort_sensitive   = false
 sort_reverse 	 = false
-sort_translit  = false
+sort_translit    = false
 
 [log]
 enabled = false

--- a/yazi-config/src/which/which.rs
+++ b/yazi-config/src/which/which.rs
@@ -6,6 +6,7 @@ use crate::MERGED_YAZI;
 
 #[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct Which {
+	pub enable:         bool,
 	// Sorting
 	pub sort_by:        SortBy,
 	pub sort_sensitive: bool,

--- a/yazi-core/src/which/commands/show.rs
+++ b/yazi-core/src/which/commands/show.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, str::FromStr};
 
-use yazi_config::{keymap::{Control, Key}, KEYMAP};
+use yazi_config::{keymap::{Control, Key}, KEYMAP, WHICH};
 use yazi_shared::{event::Cmd, render, Layer};
 
 use crate::which::{Which, WhichSorter};
@@ -43,6 +43,10 @@ impl Which {
 	}
 
 	pub fn show_with(&mut self, key: &Key, layer: Layer) {
+		if !WHICH.enable {
+			return;
+		}
+
 		let mut seen = HashSet::new();
 
 		self.layer = layer;


### PR DESCRIPTION
### Description

This PR adds an `enable` feature for the "which key" functionality. When `enable` is set to `false`, the "which key" feature will be disabled, and the corresponding key hints will not be shown. The `enable` defaults to `true` to keep backward compatibility.

### Changes Made

1. Added `enable` field in the `Which` struct in `yazi-config/src/which/which.rs`.
2. Updated the default configuration in `yazi-config/preset/yazi.toml` to include the `enable` field.
3. Modified the `show_with` method in `yazi-core/src/which/commands/show.rs` to respect the `enable` setting.