### PR TITLE
feat: word wrapping in `code` previewer

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -18,6 +18,7 @@ title_format   = "Yazi: {cwd}"
 
 [preview]
 tab_size        = 2
+word_wrap		= false
 max_width       = 600
 max_height      = 900
 cache_dir       = ""

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -17,8 +17,8 @@ mouse_events   = [ "click", "scroll" ]
 title_format   = "Yazi: {cwd}"
 
 [preview]
+wrap            = "no"
 tab_size        = 2
-word_wrap       = false
 max_width       = 600
 max_height      = 900
 cache_dir       = ""

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -18,7 +18,7 @@ title_format   = "Yazi: {cwd}"
 
 [preview]
 tab_size        = 2
-word_wrap		= false
+word_wrap       = false
 max_width       = 600
 max_height      = 900
 cache_dir       = ""

--- a/yazi-config/src/preview/mod.rs
+++ b/yazi-config/src/preview/mod.rs
@@ -1,3 +1,5 @@
 mod preview;
+mod wrap;
 
 pub use preview::*;
+pub use wrap::*;

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -5,12 +5,16 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 use yazi_shared::fs::expand_path;
 
+use super::PreviewWrap;
 use crate::Xdg;
+
+#[rustfmt::skip]
+const TABS: &[&str] = &["", " ", "  ", "   ", "    ", "     ", "      ", "       ", "        ", "         ", "          ", "           ", "            ", "             ", "              ", "               ", "                "];
 
 #[derive(Debug, Serialize)]
 pub struct Preview {
+	pub wrap:       PreviewWrap,
 	pub tab_size:   u8,
-	pub word_wrap:  bool,
 	pub max_width:  u32,
 	pub max_height: u32,
 
@@ -33,19 +37,11 @@ impl Preview {
 	}
 
 	#[inline]
-	pub fn indent(&self) -> Cow<'static, str> {
-		match self.tab_size {
-			0 => Cow::Borrowed(""),
-			1 => Cow::Borrowed(" "),
-			2 => Cow::Borrowed("  "),
-			3 => Cow::Borrowed("   "),
-			4 => Cow::Borrowed("    "),
-			5 => Cow::Borrowed("     "),
-			6 => Cow::Borrowed("      "),
-			7 => Cow::Borrowed("       "),
-			8 => Cow::Borrowed("        "),
-			n => Cow::Owned(" ".repeat(n as usize)),
-		}
+	pub fn indent(&self) -> Cow<'static, str> { Self::indent_with(self.tab_size as usize) }
+
+	#[inline]
+	pub fn indent_with(n: usize) -> Cow<'static, str> {
+		if let Some(s) = TABS.get(n) { Cow::Borrowed(s) } else { Cow::Owned(" ".repeat(n)) }
 	}
 }
 
@@ -59,8 +55,8 @@ impl FromStr for Preview {
 		}
 		#[derive(Deserialize, Validate)]
 		struct Shadow {
+			wrap:       PreviewWrap,
 			tab_size:   u8,
-			word_wrap:  bool,
 			max_width:  u32,
 			max_height: u32,
 
@@ -86,8 +82,8 @@ impl FromStr for Preview {
 		std::fs::create_dir_all(&cache_dir).context("Failed to create cache directory")?;
 
 		Ok(Preview {
+			wrap: preview.wrap,
 			tab_size: preview.tab_size,
-			word_wrap: preview.word_wrap,
 			max_width: preview.max_width,
 			max_height: preview.max_height,
 

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -10,7 +10,7 @@ use crate::Xdg;
 #[derive(Debug, Serialize)]
 pub struct Preview {
 	pub tab_size:   u8,
-	pub word_wrap: bool,
+	pub word_wrap:  bool,
 	pub max_width:  u32,
 	pub max_height: u32,
 

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -10,6 +10,7 @@ use crate::Xdg;
 #[derive(Debug, Serialize)]
 pub struct Preview {
 	pub tab_size:   u8,
+	pub word_wrap: bool,
 	pub max_width:  u32,
 	pub max_height: u32,
 
@@ -59,6 +60,7 @@ impl FromStr for Preview {
 		#[derive(Deserialize, Validate)]
 		struct Shadow {
 			tab_size:   u8,
+			word_wrap:  bool,
 			max_width:  u32,
 			max_height: u32,
 
@@ -85,6 +87,7 @@ impl FromStr for Preview {
 
 		Ok(Preview {
 			tab_size: preview.tab_size,
+			word_wrap: preview.word_wrap,
 			max_width: preview.max_width,
 			max_height: preview.max_height,
 

--- a/yazi-config/src/preview/wrap.rs
+++ b/yazi-config/src/preview/wrap.rs
@@ -1,0 +1,29 @@
+use std::str::FromStr;
+
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(try_from = "String")]
+pub enum PreviewWrap {
+	No,
+	Yes,
+}
+
+impl FromStr for PreviewWrap {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s {
+			"no" => Self::No,
+			"yes" => Self::Yes,
+			_ => bail!("Invalid `wrap` value: {s}"),
+		})
+	}
+}
+
+impl TryFrom<String> for PreviewWrap {
+	type Error = anyhow::Error;
+
+	fn try_from(value: String) -> Result<Self, Self::Error> { Self::from_str(&value) }
+}

--- a/yazi-plugin/preset/plugins/code.lua
+++ b/yazi-plugin/preset/plugins/code.lua
@@ -4,7 +4,7 @@ function M:peek()
 	local err, bound = ya.preview_code(self)
 	if bound then
 		ya.manager_emit("peek", { bound, only_if = self.file.url, upper_bound = true })
-	elseif err then
+	elseif err and not err:find("cancelled", 1, true) then
 		ya.preview_widgets(self, {
 			ui.Paragraph(self.area, { ui.Line(err):reverse() }),
 		})

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -56,7 +56,7 @@ function M:fallback_to_builtin()
 	local err, bound = ya.preview_code(self)
 	if bound then
 		ya.manager_emit("peek", { bound, only_if = self.file.url, upper_bound = true })
-	elseif err then
+	elseif err and not err:find("cancelled", 1, true) then
 		ya.preview_widgets(self, {
 			ui.Paragraph(self.area, { ui.Line(err):reverse() }),
 		})

--- a/yazi-plugin/src/elements/paragraph.rs
+++ b/yazi-plugin/src/elements/paragraph.rs
@@ -10,9 +10,9 @@ const CENTER: u8 = 1;
 const RIGHT: u8 = 2;
 
 // Wrap
-const WRAP_NO: u8 = 0;
-const WRAP: u8 = 1;
-const WRAP_TRIM: u8 = 2;
+pub const WRAP_NO: u8 = 0;
+pub const WRAP: u8 = 1;
+pub const WRAP_TRIM: u8 = 2;
 
 #[derive(Clone, Debug, Default)]
 pub struct Paragraph {
@@ -45,7 +45,7 @@ impl Paragraph {
 			("CENTER", CENTER.into_lua(lua)?),
 			("RIGHT", RIGHT.into_lua(lua)?),
 			// Wrap
-			("WRAP_OFF", WRAP_NO.into_lua(lua)?),
+			("WRAP_NO", WRAP_NO.into_lua(lua)?),
 			("WRAP", WRAP.into_lua(lua)?),
 			("WRAP_TRIM", WRAP_TRIM.into_lua(lua)?),
 		])?;


### PR DESCRIPTION
This PR tries to add feature described in #1089 

I tried to implement feature without introducing new dependencies, like it was asked in #1142. Also I used #1142 commits as baseline to my changes (configuration from yazi.toml, highlight signature). 

I tried to separate new logic with two methods: `before_after` and `before_after_wrapped`. `before_after` is almost the same with minor change in readability `no_more_scroll`.
`before_after_wrapped` is more complicated. I had to read whole file first and apply logic afterwards. We have to decide if file is plaintext or not because we only apply indentation (tab_size in config) to plaintext files (in this method at least).
After that I chunk every line of file in chunks by column width using [unicode-width](https://crates.io/crates/unicode-width) crate as was said. I tried my solution in some cases including ascii characters, cyrrilic alphabet, emojis. All of them looks fine.

It's my first PR using rust, I tried to come up with optimized solution, but this is as far as I could go. If you have any suggestions how we can improve it, please tell, I'm open to suggestions. 