### PR TITLE
feat!: include the `sender` ID in static messages

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -18,8 +18,6 @@ pub(super) struct Args {
 pub(super) enum Command {
 	/// Publish a message to remote instance(s).
 	Pub(CommandPub),
-	/// Publish a static message to all remote instances.
-	PubStatic(CommandPubStatic),
 	/// Manage packages.
 	Pack(CommandPack),
 	/// Subscribe to messages from all remote instances.
@@ -54,35 +52,6 @@ impl CommandPub {
 		}
 	}
 
-	#[allow(dead_code)]
-	pub(super) fn body(&self) -> Result<Cow<str>> {
-		if let Some(json) = &self.json {
-			Ok(json.into())
-		} else if let Some(str) = &self.str {
-			Ok(serde_json::to_string(str)?.into())
-		} else {
-			Ok("".into())
-		}
-	}
-}
-
-#[derive(clap::Args)]
-pub(super) struct CommandPubStatic {
-	/// The kind of message.
-	#[arg(index = 1)]
-	pub(super) kind:     String,
-	/// The severity of the message.
-	#[arg(index = 2)]
-	pub(super) severity: u16,
-	/// Send the message with a string body.
-	#[arg(long)]
-	pub(super) str:      Option<String>,
-	/// Send the message with a JSON body.
-	#[arg(long)]
-	pub(super) json:     Option<String>,
-}
-
-impl CommandPubStatic {
 	#[allow(dead_code)]
 	pub(super) fn body(&self) -> Result<Cow<str>> {
 		if let Some(json) = &self.json {

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -19,14 +19,7 @@ async fn main() -> anyhow::Result<()> {
 	match Args::parse().command {
 		Command::Pub(cmd) => {
 			yazi_dds::init();
-			if let Err(e) = yazi_dds::Client::shot(&cmd.kind, cmd.receiver()?, None, &cmd.body()?).await {
-				eprintln!("Cannot send message: {e}");
-				std::process::exit(1);
-			}
-		}
-		Command::PubStatic(cmd) => {
-			yazi_dds::init();
-			if let Err(e) = yazi_dds::Client::shot(&cmd.kind, 0, Some(cmd.severity), &cmd.body()?).await {
+			if let Err(e) = yazi_dds::Client::shot(&cmd.kind, cmd.receiver()?, &cmd.body()?).await {
 				eprintln!("Cannot send message: {e}");
 				std::process::exit(1);
 			}

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -32,7 +32,7 @@ impl Body<'static> {
 			"hover" => Self::Hover(serde_json::from_str(body)?),
 			"rename" => Self::Rename(serde_json::from_str(body)?),
 			"bulk" => Self::Bulk(serde_json::from_str(body)?),
-			"yank" => Self::Yank(serde_json::from_str(body)?),
+			"@yank" => Self::Yank(serde_json::from_str(body)?),
 			"move" => Self::Move(serde_json::from_str(body)?),
 			"trash" => Self::Trash(serde_json::from_str(body)?),
 			"delete" => Self::Delete(serde_json::from_str(body)?),
@@ -55,7 +55,7 @@ impl Body<'static> {
 				| "hover"
 				| "rename"
 				| "bulk"
-				| "yank"
+				| "@yank"
 				| "move"
 				| "trash"
 				| "delete"
@@ -63,7 +63,11 @@ impl Body<'static> {
 			bail!("Cannot construct system event");
 		}
 
-		if !kind.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
+		let mut it = kind.bytes().peekable();
+		if it.peek() == Some(&b'@') {
+			it.next(); // Skip `@` as it's a prefix for static messages
+		}
+		if !it.all(|b| b.is_ascii_alphanumeric() || b == b'-') {
 			bail!("Kind must be alphanumeric with dashes");
 		}
 
@@ -82,7 +86,7 @@ impl<'a> Body<'a> {
 			Self::Hover(_) => "hover",
 			Self::Rename(_) => "rename",
 			Self::Bulk(_) => "bulk",
-			Self::Yank(_) => "yank",
+			Self::Yank(_) => "@yank",
 			Self::Move(_) => "move",
 			Self::Trash(_) => "trash",
 			Self::Delete(_) => "delete",

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -45,20 +45,6 @@ impl Body<'static> {
 		BodyCustom::from_lua(kind, value)
 	}
 
-	pub fn tab(kind: &str, body: &str) -> usize {
-		match kind {
-			"cd" | "hover" | "bulk" | "rename" => {}
-			_ => return 0,
-		}
-
-		match Self::from_str(kind, body) {
-			Ok(Self::Cd(b)) => b.tab,
-			Ok(Self::Hover(b)) => b.tab,
-			Ok(Self::Rename(b)) => b.tab,
-			_ => 0,
-		}
-	}
-
 	pub fn validate(kind: &str) -> Result<()> {
 		if matches!(
 			kind,
@@ -111,11 +97,6 @@ impl<'a> Body<'a> {
 
 	#[inline]
 	pub fn with_sender(self, sender: u64) -> Payload<'a> { Payload::new(self).with_sender(sender) }
-
-	#[inline]
-	pub fn with_severity(self, severity: u16) -> Payload<'a> {
-		Payload::new(self).with_severity(severity)
-	}
 }
 
 impl IntoLua<'_> for Body<'static> {

--- a/yazi-dds/src/client.rs
+++ b/yazi-dds/src/client.rs
@@ -64,12 +64,11 @@ impl Client {
 	}
 
 	/// Connect to an existing server to send a single message.
-	pub async fn shot(kind: &str, receiver: u64, severity: Option<u16>, body: &str) -> Result<()> {
+	pub async fn shot(kind: &str, receiver: u64, body: &str) -> Result<()> {
 		Body::validate(kind)?;
 
-		let sender = severity.map(Into::into).unwrap_or(*ID);
 		let payload = format!(
-			"{}\n{kind},{receiver},{sender},{body}\n{}\n",
+			"{}\n{kind},{receiver},{ID},{body}\n{}\n",
 			Payload::new(BodyHi::borrowed(Default::default())),
 			Payload::new(BodyBye::owned())
 		);

--- a/yazi-dds/src/payload.rs
+++ b/yazi-dds/src/payload.rs
@@ -41,11 +41,6 @@ impl<'a> Payload<'a> {
 		self.sender = sender;
 		self
 	}
-
-	pub(super) fn with_severity(mut self, severity: u16) -> Self {
-		self.sender = severity as u64;
-		self
-	}
 }
 
 impl Payload<'static> {

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -137,13 +137,13 @@ impl Pubsub {
 	}
 
 	pub fn pub_from_yank(cut: bool, urls: &HashSet<Url>) {
-		if LOCAL.read().contains_key("yank") {
+		if LOCAL.read().contains_key("@yank") {
 			Self::pub_(BodyYank::dummy());
 		}
-		if Self::own_static_ability("yank") {
+		if Self::own_static_ability("@yank") {
 			Client::push(BodyYank::borrowed(cut, urls));
 		}
-		if BOOT.local_events.contains("yank") {
+		if BOOT.local_events.contains("@yank") {
 			BodyYank::borrowed(cut, urls).with_receiver(*ID).flush();
 		}
 	}

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -80,12 +80,6 @@ impl Pubsub {
 		}
 	}
 
-	pub fn pub_static(severity: u16, body: Body) {
-		if Self::own_static_ability(body.kind()) {
-			Client::push(body.with_severity(severity));
-		}
-	}
-
 	pub fn pub_from_hi() -> bool {
 		let abilities = REMOTE.read().keys().cloned().collect();
 		let abilities = BOOT.remote_events.union(&abilities).map(|s| s.as_str()).collect();
@@ -98,8 +92,8 @@ impl Pubsub {
 		if LOCAL.read().contains_key("cd") {
 			Self::pub_(BodyCd::dummy(tab));
 		}
-		if Self::own_static_ability("cd") {
-			Client::push(BodyCd::borrowed(tab, url).with_severity(100));
+		if PEERS.read().values().any(|p| p.able("cd")) {
+			Client::push(BodyCd::borrowed(tab, url));
 		}
 		if BOOT.local_events.contains("cd") {
 			BodyCd::borrowed(tab, url).with_receiver(*ID).flush();
@@ -110,8 +104,8 @@ impl Pubsub {
 		if LOCAL.read().contains_key("hover") {
 			Self::pub_(BodyHover::dummy(tab));
 		}
-		if Self::own_static_ability("hover") {
-			Client::push(BodyHover::borrowed(tab, url).with_severity(200));
+		if PEERS.read().values().any(|p| p.able("hover")) {
+			Client::push(BodyHover::borrowed(tab, url));
 		}
 		if BOOT.local_events.contains("hover") {
 			BodyHover::borrowed(tab, url).with_receiver(*ID).flush();
@@ -147,7 +141,7 @@ impl Pubsub {
 			Self::pub_(BodyYank::dummy());
 		}
 		if Self::own_static_ability("yank") {
-			Client::push(BodyYank::borrowed(cut, urls).with_severity(300));
+			Client::push(BodyYank::borrowed(cut, urls));
 		}
 		if BOOT.local_events.contains("yank") {
 			BodyYank::borrowed(cut, urls).with_receiver(*ID).flush();

--- a/yazi-dds/src/server.rs
+++ b/yazi-dds/src/server.rs
@@ -66,7 +66,7 @@ impl Server {
 									continue;
 								}
 
-								if receiver == 0 {
+								if receiver == 0 && kind.starts_with('@') {
 									let Some(body) = parts.next() else { continue };
 									if !STATE.set(kind, sender, body) { continue }
 								}

--- a/yazi-dds/src/server.rs
+++ b/yazi-dds/src/server.rs
@@ -66,9 +66,9 @@ impl Server {
 									continue;
 								}
 
-								if receiver == 0 && sender <= u16::MAX as u64 {
+								if receiver == 0 {
 									let Some(body) = parts.next() else { continue };
-									if !STATE.set(kind, sender as u16, body) { continue }
+									if !STATE.set(kind, sender, body) { continue }
 								}
 
 								line.push('\n');
@@ -90,10 +90,6 @@ impl Server {
 	fn handle_hi(s: String, id: &mut Option<u64>, tx: mpsc::UnboundedSender<String>) {
 		let Ok(payload) = Payload::from_str(&s) else { return };
 		let Body::Hi(hi) = payload.body else { return };
-
-		if payload.sender <= u16::MAX as u64 {
-			return; // The kind of static messages cannot be "hi"
-		}
 
 		if id.is_none() {
 			if let Some(ref state) = *STATE.read() {

--- a/yazi-plugin/preset/plugins/session.lua
+++ b/yazi-plugin/preset/plugins/session.lua
@@ -1,6 +1,6 @@
 local function setup(_, opts)
 	if opts.sync_yanked then
-		ps.sub_remote("yank", function(body) ya.manager_emit("update_yanked", { cut = body.cut, urls = body }) end)
+		ps.sub_remote("@yank", function(body) ya.manager_emit("update_yanked", { cut = body.cut, urls = body }) end)
 	end
 end
 

--- a/yazi-plugin/src/pubsub/pubsub.rs
+++ b/yazi-plugin/src/pubsub/pubsub.rs
@@ -26,14 +26,6 @@ impl Pubsub {
 		)?;
 
 		ps.raw_set(
-			"pub_static",
-			lua.create_function(|_, (severity, kind, value): (u16, mlua::String, Value)| {
-				yazi_dds::Pubsub::pub_static(severity, Body::from_lua(kind.to_str()?, value)?);
-				Ok(())
-			})?,
-		)?;
-
-		ps.raw_set(
 			"sub",
 			lua.create_function(|lua, (kind, f): (mlua::String, Function)| {
 				let Some(ref cur) = lua.named_registry_value::<RtRef>("rt")?.current else {


### PR DESCRIPTION
In practice, the `severity` of static messages has proven to be meaningless and increases protocol complexity.

This PR replacing `severity` with `sender` to resolves https://github.com/sxyazi/yazi/pull/1004#discussion_r1596707396

## ⚠️ Breaking changes

This PR removes the `ps.pub_static()` method and replaces it with `ps.pub_to()`:

```diff
- ps.pub_static(10, "greeting", "Hello, World!")
+ ps.pub_to(0, "@greeting", "Hello, World!")
```

Messages with a `kind` that starts with `@` indicate they are static messages. Accordingly, `ps.sub_remote()` subscribes to static messages using that kind:

```diff
- ps.sub_remote("greeting", function() end)
+ ps.sub_remote("@greeting", function() end)
```

The `ya pub-static` command has also been removed and replaced with `ya pub`:

```diff
- ya pub-static 10 "greeting" --str "Hello, World!"
+ ya pub "@greeting" 0 --str "Hello, World!"
```