### PR TITLE
fix: accommodate all `hover` events for DDS

### DIFF
--- a/yazi-core/src/manager/commands/hover.rs
+++ b/yazi-core/src/manager/commands/hover.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use yazi_dds::Pubsub;
 use yazi_shared::{event::{Cmd, Data}, fs::Url, render};
 
 use crate::manager::Manager;
@@ -42,5 +43,8 @@ impl Manager {
 			}
 		}
 		self.watcher.watch(to_watch);
+
+		// Publish through DDS
+		Pubsub::pub_from_hover(self.active().idx, self.hovered().map(|h| &h.url));
 	}
 }

--- a/yazi-core/src/tab/commands/arrow.rs
+++ b/yazi-core/src/tab/commands/arrow.rs
@@ -1,4 +1,3 @@
-use yazi_dds::Pubsub;
 use yazi_proxy::ManagerProxy;
 use yazi_shared::{event::{Cmd, Data}, render};
 
@@ -44,7 +43,6 @@ impl Tab {
 			}
 		}
 
-		Pubsub::pub_from_hover(self.idx, self.current.hovered().map(|h| &h.url));
 		ManagerProxy::hover(None);
 		render!();
 	}

--- a/yazi-core/src/tab/commands/cd.rs
+++ b/yazi-core/src/tab/commands/cd.rs
@@ -66,6 +66,7 @@ impl Tab {
 		}
 
 		Pubsub::pub_from_cd(self.idx, &self.current.cwd);
+		Pubsub::pub_from_hover(self.idx, self.current.hovered().map(|h| &h.url));
 		ManagerProxy::refresh();
 		render!();
 	}

--- a/yazi-core/src/tab/commands/cd.rs
+++ b/yazi-core/src/tab/commands/cd.rs
@@ -66,7 +66,6 @@ impl Tab {
 		}
 
 		Pubsub::pub_from_cd(self.idx, &self.current.cwd);
-		Pubsub::pub_from_hover(self.idx, self.current.hovered().map(|h| &h.url));
 		ManagerProxy::refresh();
 		render!();
 	}


### PR DESCRIPTION
Original issue here: https://github.com/sxyazi/yazi/issues/1186

Fixed the issue by add `pub_from_hover` in `cd` command.