### PR TITLE
feat: add `--hovered` option to the `rename` and `remove` commands

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -113,7 +113,7 @@ previewers = [
 	{ mime = "application/pdf", run = "pdf" },
 	# Archive
 	{ mime = "application/{,g}zip", run = "archive" },
-	{ mime = "application/x-{tar,bzip*,7z-compressed,xz,rar}", run = "archive" },
+	{ mime = "application/x-{tar,bzip*,7z-compressed,xz,rar,iso9660-image}", run = "archive" },
 	# Font
 	{ mime = "font/*", run = "font" },
 	{ mime = "application/vnd.ms-opentype", run = "font" },

--- a/yazi-core/src/manager/commands/remove.rs
+++ b/yazi-core/src/manager/commands/remove.rs
@@ -27,10 +27,13 @@ impl Manager {
 		if !self.active_mut().try_escape_visual() {
 			return;
 		}
+		let Some(hovered) = self.hovered().map(|h| &h.url) else {
+			return;
+		};
 
 		let mut opt = opt.into() as Opt;
 		opt.targets = if opt.hovered {
-			self.hovered().map(|h| vec![h.clone().url]).unwrap_or_default()
+			vec![hovered.clone()]
 		} else {
 			self.selected_or_hovered(false).cloned().collect()
 		};

--- a/yazi-core/src/manager/commands/remove.rs
+++ b/yazi-core/src/manager/commands/remove.rs
@@ -7,6 +7,7 @@ use crate::{manager::Manager, tasks::Tasks};
 pub struct Opt {
 	force:       bool,
 	permanently: bool,
+	hovered:     bool,
 	targets:     Vec<Url>,
 }
 
@@ -15,6 +16,7 @@ impl From<Cmd> for Opt {
 		Self {
 			force:       c.bool("force"),
 			permanently: c.bool("permanently"),
+			hovered:     c.bool("hovered"),
 			targets:     c.take_any("targets").unwrap_or_default(),
 		}
 	}
@@ -27,7 +29,11 @@ impl Manager {
 		}
 
 		let mut opt = opt.into() as Opt;
-		opt.targets = self.selected_or_hovered(false).cloned().collect();
+		opt.targets = if opt.hovered {
+			self.hovered().map(|h| vec![h.clone().url]).unwrap_or_default()
+		} else {
+			self.selected_or_hovered(false).cloned().collect()
+		};
 
 		if opt.force {
 			return self.remove_do(opt, tasks);

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -10,8 +10,8 @@ use yazi_shared::{event::Cmd, fs::{maybe_exists, ok_or_not_found, paths_to_same_
 use crate::manager::Manager;
 
 pub struct Opt {
-	force:   bool,
 	hovered: bool,
+	force:   bool,
 	empty:   String,
 	cursor:  String,
 }
@@ -19,8 +19,8 @@ pub struct Opt {
 impl From<Cmd> for Opt {
 	fn from(mut c: Cmd) -> Self {
 		Self {
-			force:   c.bool("force"),
 			hovered: c.bool("hovered"),
+			force:   c.bool("force"),
 			empty:   c.take_str("empty").unwrap_or_default(),
 			cursor:  c.take_str("cursor").unwrap_or_default(),
 		}

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -29,16 +29,17 @@ impl From<Cmd> for Opt {
 
 impl Manager {
 	pub fn rename(&mut self, opt: impl Into<Opt>) {
-		let opt = opt.into() as Opt;
 		if !self.active_mut().try_escape_visual() {
 			return;
-		} else if !opt.hovered && !self.active().selected.is_empty() {
-			return self.bulk_rename();
 		}
-
 		let Some(hovered) = self.hovered().map(|h| h.url()) else {
 			return;
 		};
+
+		let opt = opt.into() as Opt;
+		if !opt.hovered && !self.active().selected.is_empty() {
+			return self.bulk_rename();
+		}
 
 		let name = Self::empty_url_part(&hovered, &opt.empty);
 		let cursor = match opt.cursor.as_str() {

--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -10,26 +10,29 @@ use yazi_shared::{event::Cmd, fs::{maybe_exists, ok_or_not_found, paths_to_same_
 use crate::manager::Manager;
 
 pub struct Opt {
-	force:  bool,
-	empty:  String,
-	cursor: String,
+	force:   bool,
+	hovered: bool,
+	empty:   String,
+	cursor:  String,
 }
 
 impl From<Cmd> for Opt {
 	fn from(mut c: Cmd) -> Self {
 		Self {
-			force:  c.bool("force"),
-			empty:  c.take_str("empty").unwrap_or_default(),
-			cursor: c.take_str("cursor").unwrap_or_default(),
+			force:   c.bool("force"),
+			hovered: c.bool("hovered"),
+			empty:   c.take_str("empty").unwrap_or_default(),
+			cursor:  c.take_str("cursor").unwrap_or_default(),
 		}
 	}
 }
 
 impl Manager {
 	pub fn rename(&mut self, opt: impl Into<Opt>) {
+		let opt = opt.into() as Opt;
 		if !self.active_mut().try_escape_visual() {
 			return;
-		} else if !self.active().selected.is_empty() {
+		} else if !opt.hovered && !self.active().selected.is_empty() {
 			return self.bulk_rename();
 		}
 
@@ -37,7 +40,6 @@ impl Manager {
 			return;
 		};
 
-		let opt = opt.into() as Opt;
 		let name = Self::empty_url_part(&hovered, &opt.empty);
 		let cursor = match opt.cursor.as_str() {
 			"start" => Some(0),

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -45,7 +45,7 @@ function M:peek()
 		if size > 0 then
 			sizes[#sizes + 1] = ui.Line(string.format(" %s ", ya.readable_size(size)))
 		else
-			sizes[#sizes + 1] = ui.Line(" - ")
+			sizes[#sizes + 1] = ui.Line("")
 		end
 
 		::continue::


### PR DESCRIPTION
This allows users to only rename or remove the currently hovered file.

Fixes #1226