### PR TITLE
feat: ownership linemode

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -88,6 +88,7 @@ keymap = [
 	{ on = [ "m", "s" ], run = "linemode size",        desc = "Set linemode to size" },
 	{ on = [ "m", "p" ], run = "linemode permissions", desc = "Set linemode to permissions" },
 	{ on = [ "m", "m" ], run = "linemode mtime",       desc = "Set linemode to mtime" },
+	{ on = [ "m", "o" ], run = "linemode owner",       desc = "Set linemode to owner" },
 	{ on = [ "m", "n" ], run = "linemode none",        desc = "Set linemode to none" },
 
 	# Copy

--- a/yazi-plugin/preset/components/folder.lua
+++ b/yazi-plugin/preset/components/folder.lua
@@ -24,7 +24,7 @@ function Folder:linemode(area, files)
 		elseif mode == "owner" then
 			if f.cha.uid and f.cha.gid then
 				local user = ya.user_name(f.cha.uid)
-				local group = ya.user_name(f.cha.uid)
+				local group = ya.group_name(f.cha.gid)
 				if user and group then
 					spans[#spans + 1] = ui.Span(user .. ":" .. group)
 				end

--- a/yazi-plugin/preset/components/folder.lua
+++ b/yazi-plugin/preset/components/folder.lua
@@ -22,13 +22,8 @@ function Folder:linemode(area, files)
 		elseif mode == "permissions" then
 			spans[#spans + 1] = ui.Span(f.cha:permissions() or "")
 		elseif mode == "owner" then
-			if f.cha.uid and f.cha.gid then
-				local user = ya.user_name(f.cha.uid)
-				local group = ya.group_name(f.cha.gid)
-				if user and group then
-					spans[#spans + 1] = ui.Span(user .. ":" .. group)
-				end
-			end
+			spans[#spans + 1] = ya.user_name and ui.Span(ya.user_name(f.cha.uid) .. ":" .. ya.group_name(f.cha.gid))
+				or ui.Span("")
 		end
 
 		spans[#spans + 1] = ui.Span(" ")

--- a/yazi-plugin/preset/components/folder.lua
+++ b/yazi-plugin/preset/components/folder.lua
@@ -21,6 +21,14 @@ function Folder:linemode(area, files)
 			spans[#spans + 1] = ui.Span(time and os.date("%y-%m-%d %H:%M", time // 1) or "")
 		elseif mode == "permissions" then
 			spans[#spans + 1] = ui.Span(f.cha:permissions() or "")
+		elseif mode == "owner" then
+			if f.cha.uid and f.cha.gid then
+				local user = ya.user_name(f.cha.uid)
+				local group = ya.user_name(f.cha.uid)
+				if user and group then
+					spans[#spans + 1] = ui.Span(user .. ":" .. group)
+				end
+			end
 		end
 
 		spans[#spans + 1] = ui.Span(" ")

--- a/yazi-plugin/src/cha/cha.rs
+++ b/yazi-plugin/src/cha/cha.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef};
+use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef, Value::Nil};
 use yazi_shared::fs::ChaKind;
 
 use crate::bindings::Cast;
@@ -23,10 +23,20 @@ impl Cha {
 			reg.add_field_method_get("is_exec", |_, me| Ok(me.is_exec()));
 			reg.add_field_method_get("is_sticky", |_, me| Ok(me.is_sticky()));
 
-			#[cfg(unix)]
+			#[allow(unused_variables)]
 			{
-				reg.add_field_method_get("uid", |_, me| Ok(me.uid));
-				reg.add_field_method_get("gid", |_, me| Ok(me.gid));
+				reg.add_field_method_get("uid", |_, me| {
+					#[cfg(unix)]
+					return Ok(me.uid);
+					#[cfg(windows)]
+					return Ok(Nil);
+				});
+				reg.add_field_method_get("gid", |_, me| {
+					#[cfg(unix)]
+					return Ok(me.gid);
+					#[cfg(windows)]
+					return Ok(Nil);
+				});
 			}
 
 			reg.add_field_method_get("length", |_, me| Ok(me.len));
@@ -39,6 +49,7 @@ impl Cha {
 			reg.add_field_method_get("accessed", |_, me| {
 				Ok(me.accessed.and_then(|t| t.duration_since(UNIX_EPOCH).map(|d| d.as_secs_f64()).ok()))
 			});
+			#[allow(unused_variables)]
 			reg.add_method("permissions", |_, me, ()| {
 				Ok(
 					#[cfg(unix)]

--- a/yazi-plugin/src/cha/cha.rs
+++ b/yazi-plugin/src/cha/cha.rs
@@ -1,8 +1,8 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef};
 #[cfg(windows)]
 use mlua::Value::Nil;
+use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef};
 use yazi_shared::fs::ChaKind;
 
 use crate::bindings::Cast;

--- a/yazi-plugin/src/cha/cha.rs
+++ b/yazi-plugin/src/cha/cha.rs
@@ -1,7 +1,5 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[cfg(windows)]
-use mlua::Value::Nil;
 use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef};
 use yazi_shared::fs::ChaKind;
 
@@ -25,20 +23,10 @@ impl Cha {
 			reg.add_field_method_get("is_exec", |_, me| Ok(me.is_exec()));
 			reg.add_field_method_get("is_sticky", |_, me| Ok(me.is_sticky()));
 
-			#[allow(unused_variables)]
+			#[cfg(unix)]
 			{
-				reg.add_field_method_get("uid", |_, me| {
-					#[cfg(unix)]
-					return Ok(me.uid);
-					#[cfg(windows)]
-					return Ok(Nil);
-				});
-				reg.add_field_method_get("gid", |_, me| {
-					#[cfg(unix)]
-					return Ok(me.gid);
-					#[cfg(windows)]
-					return Ok(Nil);
-				});
+				reg.add_field_method_get("uid", |_, me| Ok(me.uid));
+				reg.add_field_method_get("gid", |_, me| Ok(me.gid));
 			}
 
 			reg.add_field_method_get("length", |_, me| Ok(me.len));
@@ -51,7 +39,6 @@ impl Cha {
 			reg.add_field_method_get("accessed", |_, me| {
 				Ok(me.accessed.and_then(|t| t.duration_since(UNIX_EPOCH).map(|d| d.as_secs_f64()).ok()))
 			});
-			#[allow(unused_variables)]
 			reg.add_method("permissions", |_, me, ()| {
 				Ok(
 					#[cfg(unix)]

--- a/yazi-plugin/src/cha/cha.rs
+++ b/yazi-plugin/src/cha/cha.rs
@@ -1,6 +1,8 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef, Value::Nil};
+use mlua::{AnyUserData, ExternalError, Lua, Table, UserDataFields, UserDataMethods, UserDataRef};
+#[cfg(windows)]
+use mlua::Value::Nil;
 use yazi_shared::fs::ChaKind;
 
 use crate::bindings::Cast;


### PR DESCRIPTION
Allowed uid and gid to be called on windows. When uid or gid is called on Windows it will return nil. This is similar to how "permissions" works.

This is a continuation of #932 I decided to not support ownership on Windows and instead have the same behaviour as permissions, which is to have the keybind do nothing.

Additionally added #[allow(unused_variables)] to permissions in order to suppress compiler warnings for unused variable "me" when compiling on Windows.