### PR TITLE
feat: add `title_format` manager config option

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -14,7 +14,7 @@ show_hidden    = false
 show_symlink   = true
 scrolloff      = 5
 mouse_events   = [ "click", "scroll" ]
-update_title   = true
+title_format   = "Yazi: {cwd}"
 
 [preview]
 tab_size        = 2

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -14,6 +14,7 @@ show_hidden    = false
 show_symlink   = true
 scrolloff      = 5
 mouse_events   = [ "click", "scroll" ]
+update_title   = true
 
 [preview]
 tab_size        = 2

--- a/yazi-config/src/manager/manager.rs
+++ b/yazi-config/src/manager/manager.rs
@@ -23,6 +23,7 @@ pub struct Manager {
 	pub show_symlink: bool,
 	pub scrolloff:    u8,
 	pub mouse_events: MouseEvents,
+	pub update_title: bool,
 }
 
 impl FromStr for Manager {

--- a/yazi-config/src/manager/manager.rs
+++ b/yazi-config/src/manager/manager.rs
@@ -23,7 +23,7 @@ pub struct Manager {
 	pub show_symlink: bool,
 	pub scrolloff:    u8,
 	pub mouse_events: MouseEvents,
-	pub update_title: bool,
+	pub title_format: String,
 }
 
 impl FromStr for Manager {

--- a/yazi-core/src/manager/commands/refresh.rs
+++ b/yazi-core/src/manager/commands/refresh.rs
@@ -9,18 +9,20 @@ use crate::{manager::Manager, tasks::Tasks};
 impl Manager {
 	fn title(&self) -> String {
 		let home = dirs::home_dir().unwrap_or_default();
-		if let Some(p) = self.cwd().strip_prefix(home) {
-			format!("Yazi: ~{}{}", MAIN_SEPARATOR, p.display())
+		let cwd = if let Some(p) = self.cwd().strip_prefix(home) {
+			format!("~{}{}", MAIN_SEPARATOR, p.display())
 		} else {
-			format!("Yazi: {}", self.cwd().display())
-		}
+			format!("{}", self.cwd().display())
+		};
+
+		MANAGER.title_format.replace("{cwd}", &cwd)
 	}
 
 	pub fn refresh(&mut self, _: Cmd, tasks: &Tasks) {
 		env::set_current_dir(self.cwd()).ok();
 		env::set_var("PWD", self.cwd());
 
-		if MANAGER.update_title {
+		if !MANAGER.title_format.is_empty() {
 			execute!(std::io::stderr(), SetTitle(self.title())).ok();
 		}
 

--- a/yazi-core/src/manager/commands/refresh.rs
+++ b/yazi-core/src/manager/commands/refresh.rs
@@ -1,6 +1,7 @@
 use std::{env, path::MAIN_SEPARATOR};
 
 use crossterm::{execute, terminal::SetTitle};
+use yazi_config::MANAGER;
 use yazi_shared::event::Cmd;
 
 use crate::{manager::Manager, tasks::Tasks};
@@ -18,7 +19,10 @@ impl Manager {
 	pub fn refresh(&mut self, _: Cmd, tasks: &Tasks) {
 		env::set_current_dir(self.cwd()).ok();
 		env::set_var("PWD", self.cwd());
-		execute!(std::io::stderr(), SetTitle(self.title())).ok();
+
+		if MANAGER.update_title {
+			execute!(std::io::stderr(), SetTitle(self.title())).ok();
+		}
 
 		self.active_mut().apply_files_attrs();
 

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use crossterm::{cursor::{RestorePosition, SavePosition}, event::{DisableBracketedPaste, EnableBracketedPaste, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags}, execute, queue, style::Print, terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle}};
 use ratatui::{backend::CrosstermBackend, buffer::Buffer, layout::Rect, CompletedFrame, Frame, Terminal};
 use yazi_adapter::Emulator;
-use yazi_config::INPUT;
+use yazi_config::{INPUT, MANAGER};
 
 static CSI_U: AtomicBool = AtomicBool::new(false);
 
@@ -73,9 +73,12 @@ impl Term {
 			execute!(stderr(), PopKeyboardEnhancementFlags).ok();
 		}
 
+		if MANAGER.update_title {
+			execute!(stderr(), SetTitle("")).ok();
+		}
+
 		execute!(
 			stderr(),
-			SetTitle(""),
 			mouse::SetMouse(false),
 			DisableBracketedPaste,
 			LeaveAlternateScreen,

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -73,7 +73,7 @@ impl Term {
 			execute!(stderr(), PopKeyboardEnhancementFlags).ok();
 		}
 
-		if MANAGER.update_title {
+		if !MANAGER.title_format.is_empty() {
 			execute!(stderr(), SetTitle("")).ok();
 		}
 


### PR DESCRIPTION
This PR introduces an `update_title` manager config option, which controls whether Yazi updates the terminal title using ANSI escape sequences. For some users, this behavior is undesirable since:

1. Yazi may be invoked within another process (like Vim). If Yazi updates the terminal title, it overrides the title set by / for the parent process.
2. Users may have their own mechanisms or preferences for setting the terminal title and may not want it overridden.

Apologies that this feature request is a PR and not an issue, but I was eager to experiment with Rust. :) Happy to have it closed in favor of another implementation.

Closes https://github.com/sxyazi/yazi/issues/1350