### PR TITLE
feat: help users migrate shell key bindings to v0.3

### DIFF
--- a/yazi-config/src/keymap/control.rs
+++ b/yazi-config/src/keymap/control.rs
@@ -33,8 +33,6 @@ impl Control {
 		if let Some(ref s) = self.desc { Cow::Borrowed(s) } else { self.run().into() }
 	}
 
-	pub fn key_desc(&self) -> String { format!("`{}` ({})", self.on(), self.desc_or_run()) }
-
 	#[inline]
 	pub fn contains(&self, s: &str) -> bool {
 		let s = s.to_lowercase();

--- a/yazi-config/src/keymap/control.rs
+++ b/yazi-config/src/keymap/control.rs
@@ -33,6 +33,8 @@ impl Control {
 		if let Some(ref s) = self.desc { Cow::Borrowed(s) } else { self.run().into() }
 	}
 
+	pub fn key_desc(&self) -> String { format!("`{}` ({})", self.on(), self.desc_or_run()) }
+
 	#[inline]
 	pub fn contains(&self, s: &str) -> bool {
 		let s = s.to_lowercase();

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -65,10 +65,12 @@ pub fn init() -> anyhow::Result<()> {
 				continue;
 			}
 			if !r.bool("confirm") && !r.bool("interactive") {
+				let key_desc = c.key_desc();
 				eprintln!(
-					r#"WARNING: In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with `--interactive`.
+					r#"WARNING: In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with either `--interactive` or `--confirm`.
 
-Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` with `shell "my-template" --interactive`, in your keymap.toml"#
+Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` with `shell "my-template" --interactive`, in your keymap.toml
+for the key {key_desc}"#
 				);
 				return Ok(());
 			} else if r.bool("confirm") && r.bool("interactive") {

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -65,12 +65,11 @@ pub fn init() -> anyhow::Result<()> {
 				continue;
 			}
 			if !r.bool("confirm") && !r.bool("interactive") {
-				let key_desc = c.key_desc();
+				let s = format!("`{}` ({})", c.on(), c.desc_or_run());
 				eprintln!(
 					r#"WARNING: In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with either `--interactive` or `--confirm`.
 
-Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` with `shell "my-template" --interactive`, in your keymap.toml
-for the key {key_desc}"#
+Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` with `shell "my-template" --interactive`, in your keymap.toml for the key: {s}"#
 				);
 				return Ok(());
 			} else if r.bool("confirm") && r.bool("interactive") {

--- a/yazi-core/src/tab/commands/shell.rs
+++ b/yazi-core/src/tab/commands/shell.rs
@@ -38,7 +38,7 @@ impl Tab {
 		if !opt.interactive && !opt.confirm {
 			AppProxy::notify_error(
 				"`shell` command",
-				r#"In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with `--interactive`.
+				r#"WARNING: In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with either `--interactive` or `--confirm`.
 
 Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` with `shell "my-template" --interactive`, in your keymap.toml"#,
 			);


### PR DESCRIPTION
I hit an issue in my config and found the existing migration error messages slightly confusing.

My issue was that I had key bindings using `--interactive` and `--block` at the same time, which seems to be disallowed in v0.3.

https://github.com/mikavilpas/dotfiles/commit/d2c8040760e49bf74d29c62390f4ca8be1b488a9