### PR TITLE
refactor: fix Clippy warnings

### DIFF
--- a/yazi-dds/src/body/delete.rs
+++ b/yazi-dds/src/body/delete.rs
@@ -28,9 +28,15 @@ impl<'a> From<BodyDelete<'a>> for Body<'a> {
 impl IntoLua<'_> for BodyDelete<'static> {
 	fn into_lua(self, lua: &Lua) -> mlua::Result<Value<'_>> {
 		let urls = lua.create_table_with_capacity(self.urls.len(), 0)?;
+
+		#[allow(clippy::unnecessary_to_owned)]
+		// In most cases, self.urls will be Cow::Owned, so
+		// .into_owned().into_iter() can avoid any cloning, whereas
+		// .iter().cloned() will clone each element.
 		for (i, url) in self.urls.into_owned().into_iter().enumerate() {
 			urls.raw_set(i + 1, lua.create_any_userdata(url)?)?;
 		}
+
 		lua.create_table_from([("urls", urls)])?.into_lua(lua)
 	}
 }

--- a/yazi-dds/src/body/delete.rs
+++ b/yazi-dds/src/body/delete.rs
@@ -29,10 +29,10 @@ impl IntoLua<'_> for BodyDelete<'static> {
 	fn into_lua(self, lua: &Lua) -> mlua::Result<Value<'_>> {
 		let urls = lua.create_table_with_capacity(self.urls.len(), 0)?;
 
+		// In most cases, `self.urls` will be `Cow::Owned`, so
+		// `.into_owned().into_iter()` can avoid any cloning, whereas
+		// `.iter().cloned()` will clone each element.
 		#[allow(clippy::unnecessary_to_owned)]
-		// In most cases, self.urls will be Cow::Owned, so
-		// .into_owned().into_iter() can avoid any cloning, whereas
-		// .iter().cloned() will clone each element.
 		for (i, url) in self.urls.into_owned().into_iter().enumerate() {
 			urls.raw_set(i + 1, lua.create_any_userdata(url)?)?;
 		}

--- a/yazi-dds/src/body/trash.rs
+++ b/yazi-dds/src/body/trash.rs
@@ -29,10 +29,10 @@ impl IntoLua<'_> for BodyTrash<'static> {
 	fn into_lua(self, lua: &Lua) -> mlua::Result<Value<'_>> {
 		let urls = lua.create_table_with_capacity(self.urls.len(), 0)?;
 
+		// In most cases, `self.urls` will be `Cow::Owned`, so
+		// `.into_owned().into_iter()` can avoid any cloning, whereas
+		// `.iter().cloned()` will clone each element.
 		#[allow(clippy::unnecessary_to_owned)]
-		// In most cases, self.urls will be Cow::Owned, so
-		// .into_owned().into_iter() can avoid any cloning, whereas
-		// .iter().cloned() will clone each element.
 		for (i, url) in self.urls.into_owned().into_iter().enumerate() {
 			urls.raw_set(i + 1, lua.create_any_userdata(url)?)?;
 		}

--- a/yazi-dds/src/body/trash.rs
+++ b/yazi-dds/src/body/trash.rs
@@ -28,9 +28,15 @@ impl<'a> From<BodyTrash<'a>> for Body<'a> {
 impl IntoLua<'_> for BodyTrash<'static> {
 	fn into_lua(self, lua: &Lua) -> mlua::Result<Value<'_>> {
 		let urls = lua.create_table_with_capacity(self.urls.len(), 0)?;
+
+		#[allow(clippy::unnecessary_to_owned)]
+		// In most cases, self.urls will be Cow::Owned, so
+		// .into_owned().into_iter() can avoid any cloning, whereas
+		// .iter().cloned() will clone each element.
 		for (i, url) in self.urls.into_owned().into_iter().enumerate() {
 			urls.raw_set(i + 1, lua.create_any_userdata(url)?)?;
 		}
+
 		lua.create_table_from([("urls", urls)])?.into_lua(lua)
 	}
 }

--- a/yazi-fm/src/lives/lives.rs
+++ b/yazi-fm/src/lives/lives.rs
@@ -37,7 +37,9 @@ impl Lives {
 	) -> mlua::Result<T> {
 		let result = LUA.scope(|scope| {
 			defer! { SCOPE.drop(); };
-			SCOPE.init(unsafe { mem::transmute(scope) });
+			SCOPE.init(unsafe {
+				mem::transmute::<&mlua::Scope<'a, 'a>, &mlua::Scope<'static, 'static>>(scope)
+			});
 			LUA.set_named_registry_value("cx", scope.create_any_userdata_ref(cx)?)?;
 
 			let globals = LUA.globals();

--- a/yazi-shared/src/ro_cell.rs
+++ b/yazi-shared/src/ro_cell.rs
@@ -7,6 +7,10 @@ pub struct RoCell<T>(UnsafeCell<Option<T>>);
 
 unsafe impl<T> Sync for RoCell<T> {}
 
+impl<T> Default for RoCell<T> {
+	fn default() -> Self { Self::new() }
+}
+
 impl<T> RoCell<T> {
 	#[inline]
 	pub const fn new() -> Self { Self(UnsafeCell::new(None)) }

--- a/yazi-shared/src/ro_cell.rs
+++ b/yazi-shared/src/ro_cell.rs
@@ -7,10 +7,6 @@ pub struct RoCell<T>(UnsafeCell<Option<T>>);
 
 unsafe impl<T> Sync for RoCell<T> {}
 
-impl<T> Default for RoCell<T> {
-	fn default() -> Self { Self::new() }
-}
-
 impl<T> RoCell<T> {
 	#[inline]
 	pub const fn new() -> Self { Self(UnsafeCell::new(None)) }
@@ -45,6 +41,10 @@ impl<T> RoCell<T> {
 
 	#[inline]
 	fn initialized(&self) -> bool { unsafe { (*self.0.get()).is_some() } }
+}
+
+impl<T> Default for RoCell<T> {
+	fn default() -> Self { Self::new() }
 }
 
 impl<T> Deref for RoCell<T> {


### PR DESCRIPTION
Clippy showed these warnings before this commit

```
warning: you should consider adding a `Default` implementation for `RoCell<T>`
  --> yazi-shared/src/ro_cell.rs:12:2
   |
12 |     pub const fn new() -> Self { Self(UnsafeCell::new(None)) }
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
   = note: `#[warn(clippy::new_without_default)]` on by default
help: try adding this
   |
10 + impl<T> Default for RoCell<T> {
11 +     fn default() -> Self {
12 +         Self::new()
13 +     }
14 + }
   |

warning: useless conversion to the same type: `image::ColorType`
  --> yazi-adapter/src/image.rs:43:5
   |
43 |                 img.color().into(),
   |                 ^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `img.color()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
   = note: `#[warn(clippy::useless_conversion)]` on by default

warning: unnecessary use of `into_owned`
  --> yazi-dds/src/body/delete.rs:31:19
   |
31 |         for (i, url) in self.urls.into_owned().into_iter().enumerate() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `self.urls.iter().cloned()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned
   = note: `#[warn(clippy::unnecessary_to_owned)]` on by default

warning: unnecessary use of `into_owned`
  --> yazi-dds/src/body/trash.rs:31:19
   |
31 |         for (i, url) in self.urls.into_owned().into_iter().enumerate() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `self.urls.iter().cloned()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned

warning: transmute used without annotations
  --> yazi-fm/src/lives/lives.rs:40:29
   |
40 |             SCOPE.init(unsafe { mem::transmute(scope) });
   |                                      ^^^^^^^^^ help: consider adding missing annotations: `transmute::<&mlua::Scope<'_, '_>, &mlua::Scope<'_, '_>>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
   = note: `#[warn(clippy::missing_transmute_annotations)]` on by default
```