### PR TITLE
fix: can't rewatch a directory that has been deleted once before

### DIFF
--- a/yazi-core/src/manager/watcher.rs
+++ b/yazi-core/src/manager/watcher.rs
@@ -72,7 +72,14 @@ impl Watcher {
 				(old.difference(new).cloned().collect(), new.difference(old).cloned().collect())
 			};
 
-			to_unwatch.retain(|u| watcher.unwatch(u).is_ok() || !u.exists());
+			to_unwatch.retain(|u| match watcher.unwatch(u) {
+				Ok(_) => true,
+				Err(e) if matches!(e.kind, notify::ErrorKind::WatchNotFound) => true,
+				Err(e) => {
+					error!("Unwatch failed: {e:?}");
+					false
+				}
+			});
 			to_watch.retain(|u| watcher.watch(u, RecursiveMode::NonRecursive).is_ok());
 
 			{

--- a/yazi-core/src/manager/watcher.rs
+++ b/yazi-core/src/manager/watcher.rs
@@ -72,7 +72,7 @@ impl Watcher {
 				(old.difference(new).cloned().collect(), new.difference(old).cloned().collect())
 			};
 
-			to_unwatch.retain(|u| watcher.unwatch(u).is_ok());
+			to_unwatch.retain(|u| watcher.unwatch(u).is_ok() || !u.exists());
 			to_watch.retain(|u| watcher.watch(u, RecursiveMode::NonRecursive).is_ok());
 
 			{


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/1313

The retrun is_ok from to_unwatch a `deleted path` is always false. 
![image](https://github.com/user-attachments/assets/ada7b9f2-fb88-4fce-ba9e-ecab89dacf1f)


But the directory has actually been unwatch, because the return is false, so it was not actively removed from the `WATCHED`, 
![image](https://github.com/user-attachments/assets/1216c982-a92f-47c3-b55e-dc46a294eec0)


so when the same name path is created, the path recognize as a watching path in  `old` var.  
![image](https://github.com/user-attachments/assets/15eb4330-04f1-4548-8ca1-89131532d72f)

so the new path with the same name will not add to the `to_watch` to rewatcher.

