### PR TITLE
Keybinding for filtering help items was not listed among those help items

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -153,7 +153,7 @@ keymap = [
 	# Help
 	{ on = "~",		run = "help", 	desc = "Open help" },
 	{ on = "<F1>",	run = "help", 	desc = "Open help" },
-	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "F",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [tasks]
@@ -176,7 +176,7 @@ keymap = [
 	# Help
 	{ on = "~",		run = "help", 	desc = "Open help" },
 	{ on = "<F1>",	run = "help", 	desc = "Open help" },
-	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "F",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [select]
@@ -202,7 +202,7 @@ keymap = [
 	# Help
 	{ on = "~",		run = "help", 	desc = "Open help" },
 	{ on = "<F1>",	run = "help", 	desc = "Open help" },
-	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "F",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [input]
@@ -273,7 +273,7 @@ keymap = [
 	# Help
 	{ on = "~",		run = "help", 	desc = "Open help" },
 	{ on = "<F1>",	run = "help", 	desc = "Open help" },
-	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "F",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [completion]
@@ -295,7 +295,7 @@ keymap = [
 	# Help
 	{ on = "~",		run = "help", 	desc = "Open help" },
 	{ on = "<F1>",	run = "help", 	desc = "Open help" },
-	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "F",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [help]
@@ -320,5 +320,5 @@ keymap = [
 	{ on = "<S-Down>", run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
 	# Filtering
-	{ on = "/", run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "F", run = "filter", desc = "Apply a filter for the help items" },
 ]

--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -151,8 +151,9 @@ keymap = [
 	{ on = [ "g", "<Space>" ], run = "cd --interactive", desc = "Go to a directory interactively" },
 
 	# Help
-	{ on = "~",    run = "help", desc = "Open help" },
-	{ on = "<F1>", run = "help", desc = "Open help" },
+	{ on = "~",		run = "help", 	desc = "Open help" },
+	{ on = "<F1>",	run = "help", 	desc = "Open help" },
+	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [tasks]
@@ -173,8 +174,9 @@ keymap = [
 	{ on = "x",       run = "cancel",  desc = "Cancel the task" },
 
 	# Help
-	{ on = "~",    run = "help", desc = "Open help" },
-	{ on = "<F1>", run = "help", desc = "Open help" },
+	{ on = "~",		run = "help", 	desc = "Open help" },
+	{ on = "<F1>",	run = "help", 	desc = "Open help" },
+	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [select]
@@ -198,8 +200,9 @@ keymap = [
 	{ on = "<S-Down>", run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
 	# Help
-	{ on = "~",    run = "help", desc = "Open help" },
-	{ on = "<F1>", run = "help", desc = "Open help" },
+	{ on = "~",		run = "help", 	desc = "Open help" },
+	{ on = "<F1>",	run = "help", 	desc = "Open help" },
+	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [input]
@@ -268,8 +271,9 @@ keymap = [
 	{ on = "<C-r>", run = "redo", desc = "Redo the last operation" },
 
 	# Help
-	{ on = "~",    run = "help", desc = "Open help" },
-	{ on = "<F1>", run = "help", desc = "Open help" },
+	{ on = "~",		run = "help", 	desc = "Open help" },
+	{ on = "<F1>",	run = "help", 	desc = "Open help" },
+	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [completion]
@@ -289,8 +293,9 @@ keymap = [
 	{ on = "<C-n>", run = "arrow 1",  desc = "Move cursor down" },
 
 	# Help
-	{ on = "~",    run = "help", desc = "Open help" },
-	{ on = "<F1>", run = "help", desc = "Open help" },
+	{ on = "~",		run = "help", 	desc = "Open help" },
+	{ on = "<F1>",	run = "help", 	desc = "Open help" },
+	{ on = "/",		run = "filter", desc = "Apply a filter for the help items" },
 ]
 
 [help]


### PR DESCRIPTION
There is a command to filter help items. By default it was bind to "/" in `keymap.toml` for `help` section.

```rust
[help]

keymap = [
...
   # Filtering
   { on = "/", run = "filter", desc = "Apply a filter for the help items" },
]
```
But it was missing for other sections, like `manager`. Thus it was never displayed. And this is a very useful feature for newcomers. 
I've added it to all sections. I also had to replace `"/"` binding with `"F"`. By default, `"/"` is used for finding in manager, while `"f"` is used for filtering. Unfortunately we can't bind filtering for help items to `"f"` because it will collide with manager's command and only one will be displayed.

I also think that filtering help items should be displayed as the first item on the list since it's very useful when looking at big list of commands like in manager's section. But it's more like follow up suggestion and not included in this PR.