### PR TITLE
feat: add filtering tip in help component

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,7 @@
 cargo publish -p yazi-shared
 cargo publish -p yazi-config
 cargo publish -p yazi-proxy
+cargo publish -p yazi-fs
 cargo publish -p yazi-adapter
 cargo publish -p yazi-boot
 cargo publish -p yazi-dds

--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -315,5 +315,5 @@ keymap = [
 	{ on = "<S-Down>", run = "arrow 5",  desc = "Move cursor down 5 lines" },
 
 	# Filtering
-	{ on = "/", run = "filter", desc = "Apply a filter for the help items" },
+	{ on = "f", run = "filter", desc = "Apply a filter for the help items" },
 ]

--- a/yazi-config/src/keymap/keymap.rs
+++ b/yazi-config/src/keymap/keymap.rs
@@ -30,6 +30,18 @@ impl Keymap {
 			Layer::Which => unreachable!(),
 		}
 	}
+	
+	pub fn get_shortcut_for_command(&self, cmd_name: &str, layer: Layer) -> Option<String> {
+		let control = self
+			.get(layer)
+			.iter()
+			.find(|&c| c.run.iter().any(|cmd| cmd.name.eq(cmd_name)));
+
+		match control {
+			Some(c) => Some(c.on()),
+			None => None
+		}
+	}
 }
 
 impl FromStr for Keymap {

--- a/yazi-config/src/keymap/keymap.rs
+++ b/yazi-config/src/keymap/keymap.rs
@@ -30,18 +30,6 @@ impl Keymap {
 			Layer::Which => unreachable!(),
 		}
 	}
-	
-	pub fn get_shortcut_for_command(&self, cmd_name: &str, layer: Layer) -> Option<String> {
-		let control = self
-			.get(layer)
-			.iter()
-			.find(|&c| c.run.iter().any(|cmd| cmd.name.eq(cmd_name)));
-
-		match control {
-			Some(c) => Some(c.on()),
-			None => None
-		}
-	}
 }
 
 impl FromStr for Keymap {

--- a/yazi-core/src/help/commands/escape.rs
+++ b/yazi-core/src/help/commands/escape.rs
@@ -4,10 +4,11 @@ use crate::help::Help;
 
 impl Help {
 	pub fn escape(&mut self, _: Cmd) {
-		if self.in_filter.is_none() {
+		if self.keyword().is_none() {
 			return self.toggle(self.layer);
 		}
 
+		self.keyword = String::new();
 		self.in_filter = None;
 		self.filter_apply();
 		render!();

--- a/yazi-fm/src/help/layout.rs
+++ b/yazi-fm/src/help/layout.rs
@@ -1,6 +1,6 @@
 use ratatui::{buffer::Buffer, layout::{self, Constraint, Rect}, text::Line, widgets::Widget};
-use yazi_config::THEME;
-
+use yazi_config::{KEYMAP, THEME};
+use yazi_shared::Layer;
 use super::Bindings;
 use crate::Ctx;
 
@@ -18,8 +18,9 @@ impl<'a> Widget for Layout<'a> {
 		yazi_plugin::elements::Clear::default().render(area, buf);
 
 		let chunks = layout::Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).split(area);
+		let filter_key = KEYMAP.get_shortcut_for_command("filter", Layer::Help).unwrap_or_else(|| "[undefined]".into());
 		Line::styled(
-			help.keyword().unwrap_or_else(|| format!("{}.help", help.layer)),
+			help.keyword().unwrap_or_else(|| format!("{}.help (press {} to filter)", help.layer, filter_key)),
 			THEME.help.footer,
 		)
 		.render(chunks[1], buf);

--- a/yazi-fm/src/help/layout.rs
+++ b/yazi-fm/src/help/layout.rs
@@ -1,6 +1,6 @@
 use ratatui::{buffer::Buffer, layout::{self, Constraint, Rect}, text::Line, widgets::Widget};
 use yazi_config::{KEYMAP, THEME};
-use yazi_shared::Layer;
+
 use super::Bindings;
 use crate::Ctx;
 
@@ -10,6 +10,13 @@ pub(crate) struct Layout<'a> {
 
 impl<'a> Layout<'a> {
 	pub fn new(cx: &'a Ctx) -> Self { Self { cx } }
+
+	fn tips() -> String {
+		match KEYMAP.help.iter().find(|&c| c.run.iter().any(|c| c.name == "filter")) {
+			Some(c) => format!(" (Press `{}` to filter)", c.on()),
+			None => String::new(),
+		}
+	}
 }
 
 impl<'a> Widget for Layout<'a> {
@@ -18,9 +25,8 @@ impl<'a> Widget for Layout<'a> {
 		yazi_plugin::elements::Clear::default().render(area, buf);
 
 		let chunks = layout::Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).split(area);
-		let filter_key = KEYMAP.get_shortcut_for_command("filter", Layer::Help).unwrap_or_else(|| "[undefined]".into());
 		Line::styled(
-			help.keyword().unwrap_or_else(|| format!("{}.help (press {} to filter)", help.layer, filter_key)),
+			help.keyword().unwrap_or_else(|| format!("{}.help{}", help.layer, Self::tips())),
 			THEME.help.footer,
 		)
 		.render(chunks[1], buf);


### PR DESCRIPTION
This is a follow up to https://github.com/sxyazi/yazi/pull/1360 conversation in attempt to get users more familiar with filtering help items feature.

[simplescreenrecorder-2024-07-27_23.35.40.webm](https://github.com/user-attachments/assets/d08d35b6-3b09-40d7-8f95-ae663638bf01)

It will work correctly in case if a user overrides it with combination of keys like that:
![image](https://github.com/user-attachments/assets/49ac6667-e673-4b68-9b21-c775c0973dd8)

By default filtering key changed to `f` for consistency with manager keymap