### PR TITLE
feat(nix): set `VERGEN_*` build env vars

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,15 +27,13 @@
       (system:
         let
           pkgs = import nixpkgs { inherit system overlays; };
-          versionSuffix = "pre${
-            builtins.substring 0 8
-            (self.lastModifiedDate or self.lastModified or "19700101")
-          }_${self.shortRev or "dirty"}";
+          rev = self.shortRev or "dirty";
+          date = (self.lastModifiedDate or self.lastModified or "19700101");
           version = (builtins.fromTOML
             (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
-          + versionSuffix;
+          + "pre${builtins.substring 0 8 date}_${rev}";
 
-          yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix { inherit version; };
+          yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix { inherit version rev date; };
           yazi = pkgs.callPackage ./nix/yazi.nix { inherit yazi-unwrapped; };
         in
         {

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -1,6 +1,8 @@
 { makeRustPlatform
 , rustToolchain
 , version ? "git"
+, rev
+, date
 , lib
 
 , installShellFiles
@@ -12,7 +14,7 @@
 
 (makeRustPlatform { cargo = rustToolchain; rustc = rustToolchain; }).buildRustPackage rec {
   pname = "yazi";
-  inherit version;
+  inherit version rev;
 
   src = ../.;
 
@@ -24,6 +26,8 @@
   };
 
   env.YAZI_GEN_COMPLETIONS = true;
+  env.VERGEN_GIT_SHA = rev;
+  env.VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
 
   nativeBuildInputs = [ installShellFiles imagemagick ];
   buildInputs = lib.optionals stdenv.isDarwin (


### PR DESCRIPTION
Similar to my recent https://github.com/NixOS/nixpkgs/pull/330520 (but without the need for https://github.com/NixOS/nixpkgs/pull/330619 since this is entirely automatic). Changes the `yazi --version` output from the not-so-helpful `Yazi 0.2.5 (VERGEN_IDEMPOTENT_OUTPUT 1980-01-01)` to `Yazi 0.2.5 (cdb34de 2024-07-31)`. 