### PR TITLE
refactor(nix): cleanup and switch to `nixfmt-rfc-style`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       # Nixpkgs overlays
       overlays = [
         rust-overlay.overlays.default
-        (final: prev: {
+        (final: _: {
           rustToolchain = final.rust-bin.stable.latest.default.override {
             extensions = [ "rust-src" ];
           };
@@ -28,7 +28,7 @@
         let
           pkgs = import nixpkgs { inherit system overlays; };
           rev = self.shortRev or "dirty";
-          date = (self.lastModifiedDate or self.lastModified or "19700101");
+          date = self.lastModifiedDate or self.lastModified or "19700101";
           version = (builtins.fromTOML
             (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
           + "pre${builtins.substring 0 8 date}_${rev}";
@@ -49,9 +49,9 @@
     // {
       overlays = rec {
         default = yazi;
-        yazi = final: prev: {
-          yazi-unwrapped = self.packages."${final.system}".yazi-unwrapped;
-          yazi = self.packages."${final.system}".yazi;
+        yazi = final: _: {
+          inherit (self.packages."${final.system}") yazi-unwrapped;
+          inherit (self.packages."${final.system}") yazi;
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -50,8 +50,7 @@
       overlays = rec {
         default = yazi;
         yazi = final: _: {
-          inherit (self.packages."${final.system}") yazi-unwrapped;
-          inherit (self.packages."${final.system}") yazi;
+          inherit (self.packages."${final.system}") yazi yazi-unwrapped;
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -11,47 +11,51 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }@inputs:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }@inputs:
     let
       # Nixpkgs overlays
       overlays = [
         rust-overlay.overlays.default
         (final: _: {
-          rustToolchain = final.rust-bin.stable.latest.default.override {
-            extensions = [ "rust-src" ];
-          };
+          rustToolchain = final.rust-bin.stable.latest.default.override { extensions = [ "rust-src" ]; };
         })
       ];
     in
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = import nixpkgs { inherit system overlays; };
-          rev = self.shortRev or "dirty";
-          date = self.lastModifiedDate or self.lastModified or "19700101";
-          version = (builtins.fromTOML
-            (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system overlays; };
+        rev = self.shortRev or "dirty";
+        date = self.lastModifiedDate or self.lastModified or "19700101";
+        version =
+          (builtins.fromTOML (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
           + "pre${builtins.substring 0 8 date}_${rev}";
 
-          yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix { inherit version rev date; };
-          yazi = pkgs.callPackage ./nix/yazi.nix { inherit yazi-unwrapped; };
-        in
-        {
-          packages = {
-            inherit yazi-unwrapped yazi;
-            default = yazi;
-          };
+        yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix { inherit version rev date; };
+        yazi = pkgs.callPackage ./nix/yazi.nix { inherit yazi-unwrapped; };
+      in
+      {
+        packages = {
+          inherit yazi-unwrapped yazi;
+          default = yazi;
+        };
 
-          formatter = pkgs.nixpkgs-fmt;
+        formatter = pkgs.nixfmt-rfc-style;
 
-          devShells.default = import ./nix/shell.nix { inherit pkgs inputs; };
-        })
+        devShells.default = import ./nix/shell.nix { inherit pkgs inputs; };
+      }
+    )
     // {
       overlays = rec {
         default = yazi;
-        yazi = final: _: {
-          inherit (self.packages."${final.system}") yazi yazi-unwrapped;
-        };
+        yazi = final: _: { inherit (self.packages."${final.system}") yazi yazi-unwrapped; };
       };
     };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -18,9 +18,11 @@ pkgs.mkShell {
     zoxide
   ];
 
-  buildInputs = with pkgs;
-    lib.optionals stdenv.isDarwin
-      (with darwin.apple_sdk.frameworks; [ Foundation ]);
+  buildInputs =
+    with pkgs;
+    lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Foundation ]);
 
-  env = { RUST_BACKTRACE = "1"; };
+  env = {
+    RUST_BACKTRACE = "1";
+  };
 }

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -12,9 +12,9 @@
 , imagemagick
 }:
 
-(makeRustPlatform { cargo = rustToolchain; rustc = rustToolchain; }).buildRustPackage rec {
+(makeRustPlatform { cargo = rustToolchain; rustc = rustToolchain; }).buildRustPackage {
   pname = "yazi";
-  inherit version rev;
+  inherit version;
 
   src = ../.;
 

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -30,9 +30,11 @@
       };
     };
 
-    env.YAZI_GEN_COMPLETIONS = true;
-    env.VERGEN_GIT_SHA = rev;
-    env.VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
+    env = {
+      YAZI_GEN_COMPLETIONS = true;
+      VERGEN_GIT_SHA = rev;
+      VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
+    };
 
     nativeBuildInputs = [
       installShellFiles

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -1,59 +1,65 @@
-{ makeRustPlatform
-, rustToolchain
-, version ? "git"
-, rev
-, date
-, lib
+{
+  makeRustPlatform,
+  rustToolchain,
+  version ? "git",
+  rev,
+  date,
+  lib,
 
-, installShellFiles
-, stdenv
-, darwin
+  installShellFiles,
+  stdenv,
+  darwin,
 
-, imagemagick
+  imagemagick,
 }:
 
-(makeRustPlatform { cargo = rustToolchain; rustc = rustToolchain; }).buildRustPackage {
-  pname = "yazi";
-  inherit version;
+(makeRustPlatform {
+  cargo = rustToolchain;
+  rustc = rustToolchain;
+}).buildRustPackage
+  {
+    pname = "yazi";
+    inherit version;
 
-  src = ../.;
+    src = ../.;
 
-  cargoLock = {
-    lockFile = ../Cargo.lock;
-    outputHashes = {
-      "notify-6.1.1" = "sha256-5Ft2yvRPi2EaErcGBkF/3Xv6K7ijFGbdjmSqI4go/h4=";
+    cargoLock = {
+      lockFile = ../Cargo.lock;
+      outputHashes = {
+        "notify-6.1.1" = "sha256-5Ft2yvRPi2EaErcGBkF/3Xv6K7ijFGbdjmSqI4go/h4=";
+      };
     };
-  };
 
-  env.YAZI_GEN_COMPLETIONS = true;
-  env.VERGEN_GIT_SHA = rev;
-  env.VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
+    env.YAZI_GEN_COMPLETIONS = true;
+    env.VERGEN_GIT_SHA = rev;
+    env.VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
 
-  nativeBuildInputs = [ installShellFiles imagemagick ];
-  buildInputs = lib.optionals stdenv.isDarwin (
-    with darwin.apple_sdk.frameworks; [ Foundation ]
-  );
+    nativeBuildInputs = [
+      installShellFiles
+      imagemagick
+    ];
+    buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Foundation ]);
 
-  postInstall = ''
-    installShellCompletion --cmd yazi \
-      --bash ./yazi-boot/completions/yazi.bash \
-      --fish ./yazi-boot/completions/yazi.fish \
-      --zsh  ./yazi-boot/completions/_yazi
+    postInstall = ''
+      installShellCompletion --cmd yazi \
+        --bash ./yazi-boot/completions/yazi.bash \
+        --fish ./yazi-boot/completions/yazi.fish \
+        --zsh  ./yazi-boot/completions/_yazi
 
-    # Resize logo
-    for RES in 16 24 32 48 64 128 256; do
-      mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-      magick assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
-    done
+      # Resize logo
+      for RES in 16 24 32 48 64 128 256; do
+        mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
+        magick assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
+      done
 
-    mkdir -p $out/share/applications
-    install -m644 assets/yazi.desktop $out/share/applications/
-  '';
+      mkdir -p $out/share/applications
+      install -m644 assets/yazi.desktop $out/share/applications/
+    '';
 
-  meta = {
-    description = "Blazing fast terminal file manager written in Rust, based on async I/O";
-    homepage = "https://github.com/sxyazi/yazi";
-    license = lib.licenses.mit;
-    mainProgram = "yazi";
-  };
-}
+    meta = {
+      description = "Blazing fast terminal file manager written in Rust, based on async I/O";
+      homepage = "https://github.com/sxyazi/yazi";
+      license = lib.licenses.mit;
+      mainProgram = "yazi";
+    };
+  }

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -50,10 +50,10 @@
     install -m644 assets/yazi.desktop $out/share/applications/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Blazing fast terminal file manager written in Rust, based on async I/O";
     homepage = "https://github.com/sxyazi/yazi";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "yazi";
   };
 }

--- a/nix/yazi.nix
+++ b/nix/yazi.nix
@@ -23,8 +23,10 @@
 , zoxide
 }:
 
+
 let
-  runtimePaths = with lib; optional withFile file
+  inherit (lib) optional makeBinPath;
+  runtimePaths = optional withFile file
     ++ optional withJq jq
     ++ optional withPoppler poppler_utils
     ++ optional withUnar unar
@@ -44,5 +46,5 @@ runCommand yazi-unwrapped.name
   ln -s ${yazi-unwrapped}/share $out/share
   ln -s ${yazi-unwrapped}/bin/ya $out/bin/ya
   makeWrapper ${yazi-unwrapped}/bin/yazi $out/bin/yazi \
-    --prefix PATH : "${lib.makeBinPath runtimePaths}"
+    --prefix PATH : "${makeBinPath runtimePaths}"
 ''

--- a/nix/yazi.nix
+++ b/nix/yazi.nix
@@ -24,8 +24,7 @@
 }:
 
 let
-  runtimePaths = with lib; [ ]
-    ++ optional withFile file
+  runtimePaths = with lib; optional withFile file
     ++ optional withJq jq
     ++ optional withPoppler poppler_utils
     ++ optional withUnar unar

--- a/nix/yazi.nix
+++ b/nix/yazi.nix
@@ -1,32 +1,33 @@
-{ lib
-, runCommand
-, makeWrapper
-, yazi-unwrapped
+{
+  lib,
+  runCommand,
+  makeWrapper,
+  yazi-unwrapped,
 
-, withFile ? true
-, file
-, withJq ? true
-, jq
-, withPoppler ? true
-, poppler_utils
-, withUnar ? true
-, unar
-, withFfmpegthumbnailer ? true
-, ffmpegthumbnailer
-, withFd ? true
-, fd
-, withRipgrep ? true
-, ripgrep
-, withFzf ? true
-, fzf
-, withZoxide ? true
-, zoxide
+  withFile ? true,
+  file,
+  withJq ? true,
+  jq,
+  withPoppler ? true,
+  poppler_utils,
+  withUnar ? true,
+  unar,
+  withFfmpegthumbnailer ? true,
+  ffmpegthumbnailer,
+  withFd ? true,
+  fd,
+  withRipgrep ? true,
+  ripgrep,
+  withFzf ? true,
+  fzf,
+  withZoxide ? true,
+  zoxide,
 }:
-
 
 let
   inherit (lib) optional makeBinPath;
-  runtimePaths = optional withFile file
+  runtimePaths =
+    optional withFile file
     ++ optional withJq jq
     ++ optional withPoppler poppler_utils
     ++ optional withUnar unar
@@ -37,14 +38,15 @@ let
     ++ optional withZoxide zoxide;
 in
 runCommand yazi-unwrapped.name
-{
-  inherit (yazi-unwrapped) pname version meta;
+  {
+    inherit (yazi-unwrapped) pname version meta;
 
-  nativeBuildInputs = [ makeWrapper ];
-} ''
-  mkdir -p $out/bin
-  ln -s ${yazi-unwrapped}/share $out/share
-  ln -s ${yazi-unwrapped}/bin/ya $out/bin/ya
-  makeWrapper ${yazi-unwrapped}/bin/yazi $out/bin/yazi \
-    --prefix PATH : "${makeBinPath runtimePaths}"
-''
+    nativeBuildInputs = [ makeWrapper ];
+  }
+  ''
+    mkdir -p $out/bin
+    ln -s ${yazi-unwrapped}/share $out/share
+    ln -s ${yazi-unwrapped}/bin/ya $out/bin/ya
+    makeWrapper ${yazi-unwrapped}/bin/yazi $out/bin/yazi \
+      --prefix PATH : "${makeBinPath runtimePaths}"
+  ''


### PR DESCRIPTION
Cleans up the code with the `statix` and `deadnix` tools, and switches the formatter to `nixfmt-rfc-style`.