### PR TITLE
refactor(nix): home keeping

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1722415718,
@@ -18,6 +36,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -39,6 +58,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722141560,
-        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
         "type": "github"
       },
       "original": {
@@ -36,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -48,31 +29,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1722133294,
-        "narHash": "sha256-XKSVN+lmjVEFPjMa5Ui0VTay2Uvqa74h0MQT0HU1pqw=",
+        "lastModified": 1722391647,
+        "narHash": "sha256-JTi7l1oxnatF1uX/gnGMlRnyFMtylRw4MqhCUdoN2K4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9803f6e04ca37a2c072783e8297d2080f8d0e739",
+        "rev": "0fd4a5d2098faa516a9b83022aec7db766cd1de8",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
                   (
                     final: prev:
                     let
-                      toolchain = final.rust-bin.stable.latest.default.override { extensions = [ "rust-src" ]; };
+                      toolchain = final.rust-bin.stable.latest.default;
                     in
                     {
                       rustPlatform = prev.makeRustPlatform {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -12,73 +13,52 @@
       self,
       nixpkgs,
       rust-overlay,
+      flake-utils,
       ...
     }:
-    let
-      systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ];
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlays.default
+            (
+              final: prev:
+              let
+                toolchain = final.rust-bin.stable.latest.default;
+              in
+              {
+                rustPlatform = prev.makeRustPlatform {
+                  cargo = toolchain;
+                  rustc = toolchain;
+                };
+              }
+            )
+          ];
+        };
 
-      inherit (nixpkgs) lib;
-
-      forEachSystem =
-        f:
-        (lib.listToAttrs (
-          map (system: {
-            name = system;
-            value = f {
-              inherit system;
-              pkgs = import nixpkgs {
-                inherit system;
-                overlays = [
-                  rust-overlay.overlays.default
-
-                  (
-                    final: prev:
-                    let
-                      toolchain = final.rust-bin.stable.latest.default;
-                    in
-                    {
-                      rustPlatform = prev.makeRustPlatform {
-                        cargo = toolchain;
-                        rustc = toolchain;
-                      };
-                    }
-                  )
-                ];
-              };
-            };
-          }) systems
-        ));
-
-      rev = self.shortRev or self.dirtyShortRev or "dirty";
-      date = self.lastModifiedDate or self.lastModified or "19700101";
-      version =
-        (builtins.fromTOML (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
-        + "pre${builtins.substring 0 8 date}_${rev}";
-    in
-    {
-      packages = forEachSystem (
-        { pkgs, system }:
-        {
+        rev = self.shortRev or self.dirtyShortRev or "dirty";
+        date = self.lastModifiedDate or self.lastModified or "19700101";
+        version =
+          (builtins.fromTOML (builtins.readFile ./yazi-fm/Cargo.toml)).package.version
+          + "pre${builtins.substring 0 8 date}_${rev}";
+      in
+      {
+        packages = {
           yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix { inherit version rev date; };
           yazi = pkgs.callPackage ./nix/yazi.nix { inherit (self.packages.${system}) yazi-unwrapped; };
           default = self.packages.${system}.yazi;
-        }
-      );
+        };
 
-      devShells = forEachSystem (
-        { pkgs, ... }:
-        {
+        devShells = {
           default = pkgs.callPackage ./nix/shell.nix { };
-        }
-      );
+        };
 
-      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixfmt-rfc-style);
-
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    )
+    // {
       overlays = {
         default = self.overlays.yazi;
         yazi = _: prev: { inherit (self.packages.${prev.stdenv.system}) yazi yazi-unwrapped; };

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,28 +1,23 @@
-{ pkgs, ... }:
-
-pkgs.mkShell {
-  packages = with pkgs; [
-    rustToolchain
-    rust-analyzer
+{
+  callPackage,
+  rust-bin,
+  nodePackages,
+}:
+let
+  mainPkg = callPackage ./yazi.nix { };
+in
+mainPkg.overrideAttrs (oa: {
+  nativeBuildInputs = [
+    (rust-bin.stable.latest.default.override {
+      extensions = [
+        "rustfmt"
+        "rust-analyzer"
+        "clippy"
+      ];
+    })
 
     nodePackages.cspell
+  ] ++ (oa.nativeBuildInputs or [ ]);
 
-    file
-    jq
-    poppler_utils
-    unar
-    ffmpegthumbnailer
-    fd
-    ripgrep
-    fzf
-    zoxide
-  ];
-
-  buildInputs =
-    with pkgs;
-    lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Foundation ]);
-
-  env = {
-    RUST_BACKTRACE = "1";
-  };
-}
+  env.RUST_BACKTRACE = "1";
+})

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,6 +10,7 @@ mainPkg.overrideAttrs (oa: {
   nativeBuildInputs = [
     (rust-bin.stable.latest.default.override {
       extensions = [
+        "rust-src"
         "rustfmt"
         "rust-analyzer"
         "clippy"

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -18,19 +18,9 @@ let
     fileset = lib.fileset.intersection (lib.fileset.fromSource (lib.sources.cleanSource ../.)) (
       lib.fileset.unions [
         ../assets
-        ../yazi-adapter
-        ../yazi-boot
-        ../yazi-cli
-        ../yazi-config
-        ../yazi-core
-        ../yazi-dds
-        ../yazi-fm
-        ../yazi-plugin
-        ../yazi-proxy
-        ../yazi-scheduler
-        ../yazi-shared
         ../Cargo.toml
         ../Cargo.lock
+        (lib.fileset.fileFilter (file: file.hasExt "rs" || file.hasExt "toml") ../.)
       ]
     );
   };

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -15,14 +15,12 @@
 let
   src = lib.fileset.toSource {
     root = ../.;
-    fileset = lib.fileset.intersection (lib.fileset.fromSource (lib.sources.cleanSource ../.)) (
-      lib.fileset.unions [
-        ../assets
-        ../Cargo.toml
-        ../Cargo.lock
-        (lib.fileset.fileFilter (file: file.hasExt "rs" || file.hasExt "toml") ../.)
-      ]
-    );
+    fileset = lib.fileset.unions [
+      ../assets
+      ../Cargo.toml
+      ../Cargo.lock
+      (lib.fileset.fromSource (lib.sources.sourceByRegex ../. [ "^yazi-.*" ]))
+    ];
   };
 in
 rustPlatform.buildRustPackage rec {

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -1,67 +1,86 @@
 {
-  makeRustPlatform,
-  rustToolchain,
+  rustPlatform,
   version ? "git",
-  rev,
-  date,
+  rev ? "unknown",
+  date ? "19700101",
   lib,
 
   installShellFiles,
   stdenv,
   darwin,
+  rust-jemalloc-sys,
 
   imagemagick,
 }:
+let
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.intersection (lib.fileset.fromSource (lib.sources.cleanSource ../.)) (
+      lib.fileset.unions [
+        ../assets
+        ../yazi-adapter
+        ../yazi-boot
+        ../yazi-cli
+        ../yazi-config
+        ../yazi-core
+        ../yazi-dds
+        ../yazi-fm
+        ../yazi-plugin
+        ../yazi-proxy
+        ../yazi-scheduler
+        ../yazi-shared
+        ../Cargo.toml
+        ../Cargo.lock
+      ]
+    );
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "yazi";
+  inherit version src;
 
-(makeRustPlatform {
-  cargo = rustToolchain;
-  rustc = rustToolchain;
-}).buildRustPackage
-  {
-    pname = "yazi";
-    inherit version;
-
-    src = ../.;
-
-    cargoLock = {
-      lockFile = ../Cargo.lock;
-      outputHashes = {
-        "notify-6.1.1" = "sha256-5Ft2yvRPi2EaErcGBkF/3Xv6K7ijFGbdjmSqI4go/h4=";
-      };
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "notify-6.1.1" = "sha256-5Ft2yvRPi2EaErcGBkF/3Xv6K7ijFGbdjmSqI4go/h4=";
     };
+  };
 
-    env = {
-      YAZI_GEN_COMPLETIONS = true;
-      VERGEN_GIT_SHA = rev;
-      VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
-    };
+  env = {
+    YAZI_GEN_COMPLETIONS = true;
+    VERGEN_GIT_SHA = rev;
+    VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
+  };
 
-    nativeBuildInputs = [
-      installShellFiles
-      imagemagick
-    ];
-    buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Foundation ]);
+  nativeBuildInputs = [
+    installShellFiles
+    imagemagick
+  ];
 
-    postInstall = ''
-      installShellCompletion --cmd yazi \
-        --bash ./yazi-boot/completions/yazi.bash \
-        --fish ./yazi-boot/completions/yazi.fish \
-        --zsh  ./yazi-boot/completions/_yazi
+  buildInputs = [
+    rust-jemalloc-sys
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Foundation ]);
 
-      # Resize logo
-      for RES in 16 24 32 48 64 128 256; do
-        mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-        magick assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
-      done
+  postInstall = ''
+    installShellCompletion --cmd yazi \
+      --bash ./yazi-boot/completions/yazi.bash \
+      --fish ./yazi-boot/completions/yazi.fish \
+      --zsh  ./yazi-boot/completions/_yazi
 
-      mkdir -p $out/share/applications
-      install -m644 assets/yazi.desktop $out/share/applications/
-    '';
+    # Resize logo
+    for RES in 16 24 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
+      magick assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
+    done
 
-    meta = {
-      description = "Blazing fast terminal file manager written in Rust, based on async I/O";
-      homepage = "https://github.com/sxyazi/yazi";
-      license = lib.licenses.mit;
-      mainProgram = "yazi";
-    };
-  }
+    mkdir -p $out/share/applications
+    install -m644 assets/yazi.desktop $out/share/applications/
+  '';
+
+  meta = {
+    description = "Blazing fast terminal file manager written in Rust, based on async I/O";
+    homepage = "https://github.com/sxyazi/yazi";
+    license = lib.licenses.mit;
+    mainProgram = "yazi";
+  };
+}


### PR DESCRIPTION
changes and why:
- drop flake-utils: flake-utils was removed from rust-overlay, so pulling it in only to do something that a function could do seems uneeded
- sync "yazi" to be more in sync with upstream
- add "?" to "constructed" args since the ordinary `callPackage` won't pass these args
- remove the last `rec` this is following upstreams nixpkgs pattern on this pattern
- use `prev.stdenv.system` over `final.system` since users can disable aliases, we also have no need to use the final specifically either so `prev` makes more sense
-`shell.nix` is now constructed via `yazi-unwrapped.nix` meaning all dependencies are transfered, reducing some repetion