### PR TITLE
chore: move common dependencies to workspace Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,24 +93,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -151,7 +151,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.11"
+version = "4.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ae69fbb0833c6fcd5a8d4b8609f108c7ad95fc11e248d853ff2c42a90df26a"
+checksum = "a8670053e87c316345e384ca1f3eba3006fc6355ed8b8a1140d104e109e3df34"
 dependencies = [
  "clap",
 ]
@@ -432,21 +432,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
@@ -465,9 +465,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "compact_str"
@@ -616,7 +616,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -657,7 +657,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -667,7 +667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -913,7 +913,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1135,9 +1135,9 @@ checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1180,14 +1180,14 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1478,7 +1478,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1569,7 +1569,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1849,7 +1849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2151,14 +2151,14 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
  "memchr",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
@@ -2288,7 +2288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2322,7 +2322,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2338,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2389,22 +2389,22 @@ checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2522,7 +2522,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.17"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a44eede9b727419af8095cb2d72fab15487a541f54647ad4414b34096ee4631"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "indexmap",
  "serde",
@@ -2573,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.18"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1490595c74d930da779e944f5ba2ecdf538af67df1a9848cbd156af43c1b7cf0"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
  "serde",
@@ -2615,7 +2615,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2797,7 +2797,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2853,9 +2853,9 @@ checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2894,7 +2894,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -2916,7 +2916,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3015,7 +3015,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3026,7 +3026,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3188,9 +3188,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.16"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -3480,7 +3480,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow        = "1.0.86"
 arc-swap      = "1.7.1"
 base64        = "0.22.1"
 bitflags      = "2.6.0"
-clap          = { version = "4.5.11", features = [ "derive" ] }
+clap          = { version = "4.5.13", features = [ "derive" ] }
 crossterm     = { version = "0.27.0", features = [ "event-stream" ] }
 dirs          = "5.0.1"
 futures       = "0.3.30"
@@ -25,15 +25,13 @@ md-5          = "0.10.6"
 mlua          = { version = "0.9.9", features = [ "lua54", "serialize", "macros", "async" ] }
 parking_lot   = "0.12.3"
 ratatui       = "0.27.0"
-regex         = "1.10.5"
+regex         = "1.10.6"
 scopeguard    = "1.2.0"
 serde         = { version = "1.0.204", features = [ "derive" ] }
-serde_json    = "1.0.121"
+serde_json    = "1.0.122"
 shell-words   = "1.1.0"
 tokio         = { version = "1.39.2", features = [ "full" ] }
 tokio-stream  = "0.1.15"
 tokio-util    = "0.7.11"
+tracing       = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
 unicode-width = "0.1.13"
-
-# Logging
-tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,32 @@ codegen-units = 1
 lto           = true
 panic         = "abort"
 strip         = true
+
+[workspace.dependencies]
+ansi-to-tui   = "=3.1.0"
+anyhow        = "1.0.86"
+arc-swap      = "1.7.1"
+base64        = "0.22.1"
+bitflags      = "2.6.0"
+clap          = { version = "4.5.11", features = [ "derive" ] }
+crossterm     = { version = "0.27.0", features = [ "event-stream", "use-dev-tty" ] }
+dirs          = "5.0.1"
+futures       = "0.3.30"
+globset       = "0.4.14"
+libc          = "0.2.155"
+md-5          = "0.10.6"
+mlua          = { version = "0.9.9", features = [ "lua54", "serialize", "macros", "async" ] }
+parking_lot   = "0.12.3"
+ratatui       = "0.27.0"
+regex         = "1.10.5"
+scopeguard    = "1.2.0"
+serde         = { version = "1.0.204", features = [ "derive" ] }
+serde_json    = "1.0.121"
+shell-words   = "1.1.0"
+tokio         = { version = "1.39.2", features = [ "full" ] }
+tokio-stream  = "0.1.15"
+tokio-util    = "0.7.11"
+unicode-width = "0.1.13"
+
+# Logging
+tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ arc-swap      = "1.7.1"
 base64        = "0.22.1"
 bitflags      = "2.6.0"
 clap          = { version = "4.5.11", features = [ "derive" ] }
-crossterm     = { version = "0.27.0", features = [ "event-stream", "use-dev-tty" ] }
+crossterm     = { version = "0.27.0", features = [ "event-stream" ] }
 dirs          = "5.0.1"
 futures       = "0.3.30"
 globset       = "0.4.14"

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -26,9 +26,7 @@ kamadak-exif = "0.5.5"
 ratatui      = { workspace = true }
 scopeguard   = { workspace = true }
 tokio        = { workspace = true }
-
-# Logging
-tracing = { workspace = true }
+tracing      = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 crossterm = { workspace = true, features = [ "use-dev-tty" ] }

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -13,22 +13,22 @@ yazi-config = { path = "../yazi-config", version = "0.3.0" }
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-ansi-to-tui  = "=3.1.0"
-anyhow       = "1.0.86"
-arc-swap     = "1.7.1"
-base64       = "0.22.1"
+ansi-to-tui  = { workspace = true }
+anyhow       = { workspace = true }
+arc-swap     = { workspace = true }
+base64       = { workspace = true }
 color_quant  = "1.1.0"
-crossterm    = "0.27.0"
-futures      = "0.3.30"
+crossterm    = { workspace = true }
+futures      = { workspace = true }
 image        = "0.25.2"
 imagesize    = "0.13.0"
 kamadak-exif = "0.5.5"
-ratatui      = "0.27.0"
-scopeguard   = "1.2.0"
-tokio        = { version = "1.39.2", features = [ "full" ] }
+ratatui      = { workspace = true }
+scopeguard   = { workspace = true }
+tokio        = { workspace = true }
 
 # Logging
-tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
+tracing = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "use-dev-tty" ] }
+crossterm = { workspace = true }

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -31,4 +31,4 @@ tokio        = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }

--- a/yazi-boot/Cargo.toml
+++ b/yazi-boot/Cargo.toml
@@ -9,17 +9,17 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-regex        = "1.10.5"
+regex        = { workspace = true }
 yazi-adapter = { path = "../yazi-adapter", version = "0.3.0" }
 yazi-config  = { path = "../yazi-config", version = "0.3.0" }
 yazi-shared  = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-clap  = { version = "4.5.11", features = [ "derive" ] }
-serde = { version = "1.0.204", features = [ "derive" ] }
+clap  = { workspace = true }
+serde = { workspace = true }
 
 [build-dependencies]
-clap                  = { version = "4.5.11", features = [ "derive" ] }
+clap                  = { workspace = true }
 clap_complete         = "4.5.11"
 clap_complete_fig     = "4.5.2"
 clap_complete_nushell = "4.5.3"

--- a/yazi-boot/Cargo.toml
+++ b/yazi-boot/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true }
 
 [build-dependencies]
 clap                  = { workspace = true }
-clap_complete         = "4.5.11"
+clap_complete         = "4.5.12"
 clap_complete_fig     = "4.5.2"
 clap_complete_nushell = "4.5.3"
 vergen-gitcl          = { version = "1.0.0", features = [ "build" ] }

--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -35,7 +35,7 @@ serde_json            = { workspace = true }
 vergen-gitcl          = { version = "1.0.0", features = [ "build" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }
 
 [[bin]]
 name = "ya"

--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -14,28 +14,28 @@ yazi-dds    = { path = "../yazi-dds", version = "0.3.0" }
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow     = "1.0.86"
-clap       = { version = "4.5.11", features = [ "derive" ] }
-crossterm  = "0.27.0"
-md-5       = "0.10.6"
-serde_json = "1.0.121"
-tokio      = { version = "1.39.2", features = [ "full" ] }
+anyhow     = { workspace = true }
+clap       = { workspace = true }
+crossterm  = { workspace = true }
+md-5       = { workspace = true }
+serde_json = { workspace = true }
+tokio      = { workspace = true }
 toml_edit  = "0.22.18"
 
 [build-dependencies]
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External build dependencies
-anyhow                = "1.0.86"
-clap                  = { version = "4.5.11", features = [ "derive" ] }
+anyhow                = { workspace = true }
+clap                  = { workspace = true }
 clap_complete         = "4.5.11"
 clap_complete_fig     = "4.5.2"
 clap_complete_nushell = "4.5.3"
-serde_json            = "1.0.121"
+serde_json            = { workspace = true }
 vergen-gitcl          = { version = "1.0.0", features = [ "build" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "use-dev-tty" ] }
+crossterm = { workspace = true }
 
 [[bin]]
 name = "ya"

--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -20,7 +20,7 @@ crossterm  = { workspace = true }
 md-5       = { workspace = true }
 serde_json = { workspace = true }
 tokio      = { workspace = true }
-toml_edit  = "0.22.18"
+toml_edit  = "0.22.20"
 
 [build-dependencies]
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
@@ -28,7 +28,7 @@ yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 # External build dependencies
 anyhow                = { workspace = true }
 clap                  = { workspace = true }
-clap_complete         = "4.5.11"
+clap_complete         = "4.5.12"
 clap_complete_fig     = "4.5.2"
 clap_complete_nushell = "4.5.3"
 serde_json            = { workspace = true }

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -17,11 +17,11 @@ arc-swap  = { workspace = true }
 bitflags  = { workspace = true }
 crossterm = { workspace = true }
 globset   = { workspace = true }
-indexmap  = "2.2.6"
+indexmap  = "2.3.0"
 ratatui   = { workspace = true }
 regex     = { workspace = true }
 serde     = { workspace = true }
-toml      = { version = "0.8.17", features = [ "preserve_order" ] }
+toml      = { version = "0.8.19", features = [ "preserve_order" ] }
 validator = { version = "0.18.1", features = [ "derive" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -12,17 +12,17 @@ repository  = "https://github.com/sxyazi/yazi"
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow    = "1.0.86"
-arc-swap  = "1.7.1"
-bitflags  = "2.6.0"
-crossterm = "0.27.0"
-globset   = "0.4.14"
+anyhow    = { workspace = true }
+arc-swap  = { workspace = true }
+bitflags  = { workspace = true }
+crossterm = { workspace = true }
+globset   = { workspace = true }
 indexmap  = "2.2.6"
-ratatui   = "0.27.0"
-regex     = "1.10.5"
-serde     = { version = "1.0.204", features = [ "derive" ] }
+ratatui   = { workspace = true }
+regex     = { workspace = true }
+serde     = { workspace = true }
 toml      = { version = "0.8.17", features = [ "preserve_order" ] }
 validator = { version = "0.18.1", features = [ "derive" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "use-dev-tty" ] }
+crossterm = { workspace = true }

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -25,4 +25,4 @@ toml      = { version = "0.8.17", features = [ "preserve_order" ] }
 validator = { version = "0.18.1", features = [ "derive" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -28,7 +28,7 @@ ueberzug_offset = [ 0, 0, 0, 0 ]
 
 [opener]
 edit = [
-	{ run = '${EDITOR:=vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
+	{ run = '${EDITOR:-vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
 	{ run = 'code %*',    orphan = true, desc = "code",           for = "windows" },
 	{ run = 'code -w %*', block = true,  desc = "code (block)",   for = "windows" },
 ]

--- a/yazi-core/Cargo.toml
+++ b/yazi-core/Cargo.toml
@@ -43,4 +43,4 @@ tracing = { workspace = true }
 libc = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }

--- a/yazi-core/Cargo.toml
+++ b/yazi-core/Cargo.toml
@@ -34,10 +34,8 @@ shell-words   = { workspace = true }
 tokio         = { workspace = true }
 tokio-stream  = { workspace = true }
 tokio-util    = { workspace = true }
+tracing       = { workspace = true }
 unicode-width = { workspace = true }
-
-# Logging
-tracing = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }

--- a/yazi-core/Cargo.toml
+++ b/yazi-core/Cargo.toml
@@ -20,27 +20,27 @@ yazi-scheduler = { path = "../yazi-scheduler", version = "0.3.0" }
 yazi-shared    = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow        = "1.0.86"
-bitflags      = "2.6.0"
-crossterm     = "0.27.0"
-dirs          = "5.0.1"
-futures       = "0.3.30"
+anyhow        = { workspace = true }
+bitflags      = { workspace = true }
+crossterm     = { workspace = true }
+dirs          = { workspace = true }
+futures       = { workspace = true }
 notify        = { git = "https://github.com/notify-rs/notify.git", rev = "96dec74316a93bed6eec9db177b233e6e017275e", default-features = false, features = [ "macos_fsevent" ] }
-parking_lot   = "0.12.3"
-ratatui       = "0.27.0"
-scopeguard    = "1.2.0"
-serde         = "1.0.204"
-shell-words   = "1.1.0"
-tokio         = { version = "1.39.2", features = [ "full" ] }
-tokio-stream  = "0.1.15"
-tokio-util    = "0.7.11"
-unicode-width = "0.1.13"
+parking_lot   = { workspace = true }
+ratatui       = { workspace = true }
+scopeguard    = { workspace = true }
+serde         = { workspace = true }
+shell-words   = { workspace = true }
+tokio         = { workspace = true }
+tokio-stream  = { workspace = true }
+tokio-util    = { workspace = true }
+unicode-width = { workspace = true }
 
 # Logging
-tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
+tracing = { workspace = true }
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.155"
+libc = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "use-dev-tty" ] }
+crossterm = { workspace = true }

--- a/yazi-dds/Cargo.toml
+++ b/yazi-dds/Cargo.toml
@@ -17,17 +17,17 @@ yazi-boot   = { path = "../yazi-boot", version = "0.3.0" }
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow       = "1.0.86"
-mlua         = { version = "0.9.9", features = [ "lua54" ] }
-parking_lot  = "0.12.3"
-serde        = { version = "1.0.204", features = [ "derive" ] }
-serde_json   = "1.0.121"
-tokio        = { version = "1.39.2", features = [ "full" ] }
-tokio-stream = "0.1.15"
-tokio-util   = "0.7.11"
+anyhow       = { workspace = true }
+mlua         = { workspace = true }
+parking_lot  = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+tokio        = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util   = { workspace = true }
 
 # Logging
-tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
+tracing = { workspace = true }
 
 [build-dependencies]
 vergen-gitcl = { version = "1.0.0", features = [ "build" ] }

--- a/yazi-dds/Cargo.toml
+++ b/yazi-dds/Cargo.toml
@@ -25,9 +25,7 @@ serde_json   = { workspace = true }
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util   = { workspace = true }
-
-# Logging
-tracing = { workspace = true }
+tracing      = { workspace = true }
 
 [build-dependencies]
 vergen-gitcl = { version = "1.0.0", features = [ "build" ] }

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -24,29 +24,29 @@ yazi-proxy   = { path = "../yazi-proxy", version = "0.3.0" }
 yazi-shared  = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow       = "1.0.86"
+anyhow       = { workspace = true }
 better-panic = "0.3.0"
-crossterm    = { version = "0.27.0", features = [ "event-stream" ] }
+crossterm    = { workspace = true }
 fdlimit      = "0.3.0"
-futures      = "0.3.30"
-mlua         = { version = "0.9.9", features = [ "lua54" ] }
-ratatui      = "0.27.0"
-scopeguard   = "1.2.0"
+futures      = { workspace = true }
+mlua         = { workspace = true }
+ratatui      = { workspace = true }
+scopeguard   = { workspace = true }
 syntect      = { version = "5.2.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }
-tokio        = { version = "1.39.2", features = [ "full" ] }
-tokio-stream = "0.1.15"
+tokio        = { workspace = true }
+tokio-stream = { workspace = true }
 
 # Logging
-tracing            = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
+tracing            = { workspace = true }
 tracing-appender   = "0.2.3"
 tracing-subscriber = "0.3.18"
 
 [target."cfg(unix)".dependencies]
-libc              = "0.2.155"
+libc              = { workspace = true }
 signal-hook-tokio = { version = "0.3.1", features = [ "futures-v0_3" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "event-stream", "use-dev-tty" ] }
+crossterm = { workspace = true }
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
 tikv-jemallocator = "0.6.0"

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -46,7 +46,7 @@ libc              = { workspace = true }
 signal-hook-tokio = { version = "0.3.1", features = [ "futures-v0_3" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
 tikv-jemallocator = "0.6.0"

--- a/yazi-fs/Cargo.toml
+++ b/yazi-fs/Cargo.toml
@@ -14,8 +14,8 @@ yazi-proxy  = { path = "../yazi-proxy", version = "0.3.0" }
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow  = "1.0.86"
-futures = "0.3.30"
-ratatui = "0.27.0"
-regex   = "1.10.5"
-tokio   = { version = "1.39.2", features = [ "full" ] }
+anyhow  = { workspace = true }
+futures = { workspace = true }
+ratatui = { workspace = true }
+regex   = { workspace = true }
+tokio   = { workspace = true }

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -36,11 +36,9 @@ syntect       = { version = "5.2.0", default-features = false, features = [ "par
 tokio         = { workspace = true }
 tokio-stream  = { workspace = true }
 tokio-util    = { workspace = true }
+tracing       = { workspace = true }
 unicode-width = { workspace = true }
 yazi-prebuild = "0.1.2"
-
-# Logging
-tracing = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 uzers = "0.12.0"

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -21,26 +21,26 @@ yazi-proxy   = { path = "../yazi-proxy", version = "0.3.0" }
 yazi-shared  = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-ansi-to-tui   = "=3.1.0"
-anyhow        = "1.0.86"
-base64        = "0.22.1"
-crossterm     = "0.27.0"
-futures       = "0.3.30"
-globset       = "0.4.14"
-md-5          = "0.10.6"
-mlua          = { version = "0.9.9", features = [ "lua54", "serialize", "macros", "async" ] }
-parking_lot   = "0.12.3"
-ratatui       = "0.27.0"
-shell-words   = "1.1.0"
+ansi-to-tui   = { workspace = true }
+anyhow        = { workspace = true }
+base64        = { workspace = true }
+crossterm     = { workspace = true }
+futures       = { workspace = true }
+globset       = { workspace = true }
+md-5          = { workspace = true }
+mlua          = { workspace = true }
+parking_lot   = { workspace = true }
+ratatui       = { workspace = true }
+shell-words   = { workspace = true }
 syntect       = { version = "5.2.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }
-tokio         = { version = "1.39.2", features = [ "full" ] }
-tokio-stream  = "0.1.15"
-tokio-util    = "0.7.11"
-unicode-width = "0.1.13"
+tokio         = { workspace = true }
+tokio-stream  = { workspace = true }
+tokio-util    = { workspace = true }
+unicode-width = { workspace = true }
 yazi-prebuild = "0.1.2"
 
 # Logging
-tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
+tracing = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 uzers = "0.12.0"
@@ -49,4 +49,4 @@ uzers = "0.12.0"
 clipboard-win = "5.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "use-dev-tty" ] }
+crossterm = { workspace = true }

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -49,4 +49,4 @@ uzers = "0.12.0"
 clipboard-win = "5.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }

--- a/yazi-proxy/Cargo.toml
+++ b/yazi-proxy/Cargo.toml
@@ -17,6 +17,6 @@ yazi-config = { path = "../yazi-config", version = "0.3.0" }
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow = "1.0.86"
-mlua   = { version = "0.9.9", features = [ "lua54" ] }
-tokio  = { version = "1.39.2", features = [ "full" ] }
+anyhow = { workspace = true }
+mlua   = { workspace = true }
+tokio  = { workspace = true }

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -22,9 +22,7 @@ futures                = { workspace = true }
 parking_lot            = { workspace = true }
 scopeguard             = { workspace = true }
 tokio                  = { workspace = true }
-
-# Logging
-tracing = { workspace = true }
+tracing                = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -16,18 +16,18 @@ yazi-proxy  = { path = "../yazi-proxy", version = "0.3.0" }
 yazi-shared = { path = "../yazi-shared", version = "0.3.0" }
 
 # External dependencies
-anyhow                 = "1.0.86"
+anyhow                 = { workspace = true }
 async-priority-channel = "0.2.0"
-futures                = "0.3.30"
-parking_lot            = "0.12.3"
-scopeguard             = "1.2.0"
-tokio                  = { version = "1.39.2", features = [ "full" ] }
+futures                = { workspace = true }
+parking_lot            = { workspace = true }
+scopeguard             = { workspace = true }
+tokio                  = { workspace = true }
 
 # Logging
-tracing = { version = "0.1.40", features = [ "max_level_debug", "release_max_level_warn" ] }
+tracing = { workspace = true }
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.155"
+libc = { workspace = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 trash = "5.0.0"

--- a/yazi-shared/Cargo.toml
+++ b/yazi-shared/Cargo.toml
@@ -10,22 +10,22 @@ repository   = "https://github.com/sxyazi/yazi"
 rust-version = "1.78.0"
 
 [dependencies]
-anyhow           = "1.0.86"
-bitflags         = "2.6.0"
-crossterm        = "0.27.0"
-dirs             = "5.0.1"
-futures          = "0.3.30"
-libc             = "0.2.155"
-parking_lot      = "0.12.3"
+anyhow           = { workspace = true }
+bitflags         = { workspace = true }
+crossterm        = { workspace = true }
+dirs             = { workspace = true }
+futures          = { workspace = true }
+libc             = { workspace = true }
+parking_lot      = { workspace = true }
 percent-encoding = "2.3.1"
-ratatui          = "0.27.0"
-regex            = "1.10.5"
-serde            = { version = "1.0.204", features = [ "derive" ] }
-shell-words      = "1.1.0"
-tokio            = { version = "1.39.2", features = [ "full" ] }
+ratatui          = { workspace = true }
+regex            = { workspace = true }
+serde            = { workspace = true }
+shell-words      = { workspace = true }
+tokio            = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = [ "Win32_Storage_FileSystem", "Win32_UI_Shell" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { version = "0.27.0", features = [ "use-dev-tty" ] }
+crossterm = { workspace = true }

--- a/yazi-shared/Cargo.toml
+++ b/yazi-shared/Cargo.toml
@@ -28,4 +28,4 @@ tokio            = { workspace = true }
 windows-sys = { version = "0.59.0", features = [ "Win32_Storage_FileSystem", "Win32_UI_Shell" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = [ "use-dev-tty" ] }


### PR DESCRIPTION
It's easier to keep versions in sync across the entire workspace this way.