### PR TITLE
feat: Add automatic nightly builds to the Github Actions workflow

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 */8 * * *"
 
 jobs:
   build-unix:
@@ -147,7 +147,7 @@ jobs:
             yazi-*.zip
             yazi-*.snap
           generate_release_notes: true
-  
+
   nightly:
     permissions:
       contents: write
@@ -159,11 +159,9 @@ jobs:
           merge-multiple: true
 
       - run: |
-          GITHUB_SHA_SHORT=${GITHUB_SHA:0:8}
-          UTC_DATE=$(date -u +"%Y-%m-%d %H:%M")
-          echo 'RELEASE_NOTE<<EOF' >> $GITHUB_ENV
-          echo "From commit: ${GITHUB_SHA_SHORT}" >> $GITHUB_ENV
-          echo "Generated on: ${UTC_DATE} UTC" >> $GITHUB_ENV
+          echo 'NIGHTLY_BODY<<EOF' >> $GITHUB_ENV
+          echo "From commit: ${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          echo "Generated on: $(date -u +"%Y-%m-%d %H:%M") UTC" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Nightly
@@ -175,5 +173,4 @@ jobs:
           files: |
             yazi-*.zip
             yazi-*.snap
-          generate_release_notes: true
-          body: ${{ env.RELEASE_NOTE }}
+          body: ${{ env.NIGHTLY_BODY }}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -158,13 +158,11 @@ jobs:
         with:
           merge-multiple: true
 
-      - run: echo "CURRENT_DATE=$(date -u +"%Y%m%d-%H%M")" >> $GITHUB_ENV
-
       - name: Nightly
         uses: softprops/action-gh-release@v1
         if: github.event_name == 'schedule'
         with:
-          tag_name: "yazi-nightly-${{ env.CURRENT_DATE }}"
+          tag_name: "nightly"
           prerelease: true
           files: |
             yazi-*.zip

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -158,6 +158,14 @@ jobs:
         with:
           merge-multiple: true
 
+      - run: |
+          GITHUB_SHA_SHORT=${GITHUB_SHA:0:8}
+          UTC_DATE=$(date -u +"%Y-%m-%d %H:%M")
+          echo 'RELEASE_NOTE<<EOF' >> $GITHUB_ENV
+          echo "From commit: ${GITHUB_SHA_SHORT}" >> $GITHUB_ENV
+          echo "Generated on: ${UTC_DATE} UTC" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: Nightly
         uses: softprops/action-gh-release@v1
         if: github.event_name == 'schedule'
@@ -168,3 +176,4 @@ jobs:
             yazi-*.zip
             yazi-*.snap
           generate_release_notes: true
+          body: ${{ env.RELEASE_NOTE }}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '24 14 * * *'
 
 jobs:
   # build-unix:

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -4,9 +4,11 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+    # !TODO: remove the following line before merging
+    branches:
+      - ci-nightly-builds
   schedule:
     - cron: '28 12 * * *'
-  workflow_dispatch:
 
 jobs:
   # build-unix:
@@ -174,7 +176,8 @@ jobs:
 
       - name: Nightly
         uses: softprops/action-gh-release@v1
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        # !TODO: uncomment the following line before merging
+        # if: github.event_name == 'schedule'
         with:
           tag_name: "yazi-nightly-${{ env.CURRENT_DATE }}"
           prerelease: true

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -4,169 +4,155 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-    # !TODO: remove the following line before merging
-    branches:
-      - ci-nightly-builds
   schedule:
-    - cron: '28 12 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
-  # build-unix:
-    # strategy:
-      # matrix:
-        # include:
-          # - os: ubuntu-latest
-            # target: x86_64-unknown-linux-gnu
-          # - os: ubuntu-latest
-            # target: aarch64-unknown-linux-gnu
-          # - os: macos-latest
-            # target: x86_64-apple-darwin
-          # - os: macos-latest
-            # target: aarch64-apple-darwin
-    # runs-on: ${{ matrix.os }}
-    # steps:
-      # - uses: actions/checkout@v4
-
-      # - name: Install gcc-aarch64-linux-gnu
-        # if: matrix.target == 'aarch64-unknown-linux-gnu'
-        # run: |
-          # sudo apt-get update && sudo apt-get install -yq gcc-aarch64-linux-gnu
-          # echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
-          # echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-
-      # - name: Build
-        # run: ./scripts/build.sh ${{ matrix.target }}
-
-      # - name: Upload artifact
-        # uses: actions/upload-artifact@v4
-        # with:
-          # name: yazi-${{ matrix.target }}.zip
-          # path: yazi-${{ matrix.target }}.zip
-
-  # build-windows:
-    # strategy:
-      # matrix:
-        # include:
-          # - os: windows-latest
-            # target: x86_64-pc-windows-msvc
-          # - os: windows-latest
-            # target: aarch64-pc-windows-msvc
-    # runs-on: ${{ matrix.os }}
-    # steps:
-      # - uses: actions/checkout@v4
-
-      # - name: Setup Rust toolchain
-        # run: rustup toolchain install stable --profile minimal
-
-      # - name: Add target
-        # run: rustup target add ${{ matrix.target }}
-
-      # - name: Build
-        # env:
-          # YAZI_GEN_COMPLETIONS: true
-        # run: |
-          # cargo build -p yazi-cli --release --locked --target ${{ matrix.target }}
-          # cargo build -p yazi-fm --release --locked --target ${{ matrix.target }}
-
-      # - name: Pack artifact
-        # if: matrix.os == 'windows-latest'
-        # env:
-          # TARGET_NAME: yazi-${{ matrix.target }}
-        # run: |
-          # New-Item -ItemType Directory -Path ${env:TARGET_NAME}
-          # Copy-Item -Path "target\${{ matrix.target }}\release\ya.exe" -Destination ${env:TARGET_NAME}
-          # Copy-Item -Path "target\${{ matrix.target }}\release\yazi.exe" -Destination ${env:TARGET_NAME}
-          # Copy-Item -Path "yazi-boot\completions" -Destination ${env:TARGET_NAME} -Recurse
-          # Copy-Item -Path "README.md", "LICENSE" -Destination ${env:TARGET_NAME}
-          # Compress-Archive -Path ${env:TARGET_NAME} -DestinationPath "${env:TARGET_NAME}.zip"
-
-      # - name: Upload artifact
-        # uses: actions/upload-artifact@v4
-        # with:
-          # name: yazi-${{ matrix.target }}.zip
-          # path: yazi-${{ matrix.target }}.zip
-
-  # build-musl:
-    # runs-on: ubuntu-latest
-    # strategy:
-      # matrix:
-        # include:
-          # - target: x86_64-unknown-linux-musl
-            # image: rust-musl-cross:x86_64-musl
-          # - target: aarch64-unknown-linux-musl
-            # image: rust-musl-cross:aarch64-musl
-    # container:
-      # image: docker://ghcr.io/rust-cross/${{ matrix.image }}
-    # steps:
-      # - uses: actions/checkout@v4
-
-      # - name: Build
-        # run: ./scripts/build.sh ${{ matrix.target }}
-
-      # - name: Upload artifact
-        # uses: actions/upload-artifact@v4
-        # with:
-          # name: yazi-${{ matrix.target }}.zip
-          # path: yazi-${{ matrix.target }}.zip
-
-  # build-snap:
-    # strategy:
-      # matrix:
-        # include:
-          # - os: ubuntu-latest
-            # target: x86_64-unknown-linux-gnu
-    # runs-on: ${{ matrix.os }}
-    # steps:
-      # - uses: actions/checkout@v4
-
-      # - name: Build snap
-        # uses: snapcore/action-build@v1
-
-      # - name: Build
-        # run: mv yazi_*.snap yazi-${{ matrix.target }}.snap
-
-      # - name: Upload artifact
-        # uses: actions/upload-artifact@v4
-        # with:
-          # name: yazi-${{ matrix.target }}.snap
-          # path: yazi-${{ matrix.target }}.snap
-
-  # draft:
-    # permissions:
-      # contents: write
-    # runs-on: ubuntu-latest
-    # needs: [build-unix, build-windows, build-musl, build-snap]
-    # steps:
-      # - uses: actions/download-artifact@v4
-        # with:
-          # merge-multiple: true
-
-      # - name: Draft
-        # uses: softprops/action-gh-release@v1
-        # if: startsWith(github.ref, 'refs/tags/')
-        # with:
-          # draft: true
-          # files: |
-            # yazi-*.zip
-            # yazi-*.snap
-          # generate_release_notes: true
-  
-  dummmy:
-    runs-on: ubuntu-latest
+  build-unix:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
     steps:
-      - run: echo "Hello, nightly!" > yazi-dummy.zip
-      - uses: actions/upload-artifact@v4
-        with:
-          name: yazi-dummy.zip
-          path: yazi-dummy.zip
+      - uses: actions/checkout@v4
 
+      - name: Install gcc-aarch64-linux-gnu
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update && sudo apt-get install -yq gcc-aarch64-linux-gnu
+          echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Build
+        run: ./scripts/build.sh ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yazi-${{ matrix.target }}.zip
+          path: yazi-${{ matrix.target }}.zip
+
+  build-windows:
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        env:
+          YAZI_GEN_COMPLETIONS: true
+        run: |
+          cargo build -p yazi-cli --release --locked --target ${{ matrix.target }}
+          cargo build -p yazi-fm --release --locked --target ${{ matrix.target }}
+
+      - name: Pack artifact
+        if: matrix.os == 'windows-latest'
+        env:
+          TARGET_NAME: yazi-${{ matrix.target }}
+        run: |
+          New-Item -ItemType Directory -Path ${env:TARGET_NAME}
+          Copy-Item -Path "target\${{ matrix.target }}\release\ya.exe" -Destination ${env:TARGET_NAME}
+          Copy-Item -Path "target\${{ matrix.target }}\release\yazi.exe" -Destination ${env:TARGET_NAME}
+          Copy-Item -Path "yazi-boot\completions" -Destination ${env:TARGET_NAME} -Recurse
+          Copy-Item -Path "README.md", "LICENSE" -Destination ${env:TARGET_NAME}
+          Compress-Archive -Path ${env:TARGET_NAME} -DestinationPath "${env:TARGET_NAME}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yazi-${{ matrix.target }}.zip
+          path: yazi-${{ matrix.target }}.zip
+
+  build-musl:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            image: rust-musl-cross:x86_64-musl
+          - target: aarch64-unknown-linux-musl
+            image: rust-musl-cross:aarch64-musl
+    container:
+      image: docker://ghcr.io/rust-cross/${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: ./scripts/build.sh ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yazi-${{ matrix.target }}.zip
+          path: yazi-${{ matrix.target }}.zip
+
+  build-snap:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+
+      - name: Build
+        run: mv yazi_*.snap yazi-${{ matrix.target }}.snap
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yazi-${{ matrix.target }}.snap
+          path: yazi-${{ matrix.target }}.snap
+
+  draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [build-unix, build-windows, build-musl, build-snap]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Draft
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          files: |
+            yazi-*.zip
+            yazi-*.snap
+          generate_release_notes: true
+  
   nightly:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    # !TODO: uncomment the following line before merging
-    # needs: [build-unix, build-windows, build-musl, build-snap]
-    needs: [dummmy]
+    needs: [build-unix, build-windows, build-musl, build-snap]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -176,8 +162,7 @@ jobs:
 
       - name: Nightly
         uses: softprops/action-gh-release@v1
-        # !TODO: uncomment the following line before merging
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         with:
           tag_name: "yazi-nightly-${{ env.CURRENT_DATE }}"
           prerelease: true

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -4,143 +4,179 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
-  build-unix:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
-            target: aarch64-apple-darwin
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
+  # build-unix:
+    # strategy:
+      # matrix:
+        # include:
+          # - os: ubuntu-latest
+            # target: x86_64-unknown-linux-gnu
+          # - os: ubuntu-latest
+            # target: aarch64-unknown-linux-gnu
+          # - os: macos-latest
+            # target: x86_64-apple-darwin
+          # - os: macos-latest
+            # target: aarch64-apple-darwin
+    # runs-on: ${{ matrix.os }}
+    # steps:
+      # - uses: actions/checkout@v4
 
-      - name: Install gcc-aarch64-linux-gnu
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update && sudo apt-get install -yq gcc-aarch64-linux-gnu
-          echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      # - name: Install gcc-aarch64-linux-gnu
+        # if: matrix.target == 'aarch64-unknown-linux-gnu'
+        # run: |
+          # sudo apt-get update && sudo apt-get install -yq gcc-aarch64-linux-gnu
+          # echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+          # echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - name: Build
-        run: ./scripts/build.sh ${{ matrix.target }}
+      # - name: Build
+        # run: ./scripts/build.sh ${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: yazi-${{ matrix.target }}.zip
-          path: yazi-${{ matrix.target }}.zip
+      # - name: Upload artifact
+        # uses: actions/upload-artifact@v4
+        # with:
+          # name: yazi-${{ matrix.target }}.zip
+          # path: yazi-${{ matrix.target }}.zip
 
-  build-windows:
-    strategy:
-      matrix:
-        include:
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
+  # build-windows:
+    # strategy:
+      # matrix:
+        # include:
+          # - os: windows-latest
+            # target: x86_64-pc-windows-msvc
+          # - os: windows-latest
+            # target: aarch64-pc-windows-msvc
+    # runs-on: ${{ matrix.os }}
+    # steps:
+      # - uses: actions/checkout@v4
 
-      - name: Setup Rust toolchain
-        run: rustup toolchain install stable --profile minimal
+      # - name: Setup Rust toolchain
+        # run: rustup toolchain install stable --profile minimal
 
-      - name: Add target
-        run: rustup target add ${{ matrix.target }}
+      # - name: Add target
+        # run: rustup target add ${{ matrix.target }}
 
-      - name: Build
-        env:
-          YAZI_GEN_COMPLETIONS: true
-        run: |
-          cargo build -p yazi-cli --release --locked --target ${{ matrix.target }}
-          cargo build -p yazi-fm --release --locked --target ${{ matrix.target }}
+      # - name: Build
+        # env:
+          # YAZI_GEN_COMPLETIONS: true
+        # run: |
+          # cargo build -p yazi-cli --release --locked --target ${{ matrix.target }}
+          # cargo build -p yazi-fm --release --locked --target ${{ matrix.target }}
 
-      - name: Pack artifact
-        if: matrix.os == 'windows-latest'
-        env:
-          TARGET_NAME: yazi-${{ matrix.target }}
-        run: |
-          New-Item -ItemType Directory -Path ${env:TARGET_NAME}
-          Copy-Item -Path "target\${{ matrix.target }}\release\ya.exe" -Destination ${env:TARGET_NAME}
-          Copy-Item -Path "target\${{ matrix.target }}\release\yazi.exe" -Destination ${env:TARGET_NAME}
-          Copy-Item -Path "yazi-boot\completions" -Destination ${env:TARGET_NAME} -Recurse
-          Copy-Item -Path "README.md", "LICENSE" -Destination ${env:TARGET_NAME}
-          Compress-Archive -Path ${env:TARGET_NAME} -DestinationPath "${env:TARGET_NAME}.zip"
+      # - name: Pack artifact
+        # if: matrix.os == 'windows-latest'
+        # env:
+          # TARGET_NAME: yazi-${{ matrix.target }}
+        # run: |
+          # New-Item -ItemType Directory -Path ${env:TARGET_NAME}
+          # Copy-Item -Path "target\${{ matrix.target }}\release\ya.exe" -Destination ${env:TARGET_NAME}
+          # Copy-Item -Path "target\${{ matrix.target }}\release\yazi.exe" -Destination ${env:TARGET_NAME}
+          # Copy-Item -Path "yazi-boot\completions" -Destination ${env:TARGET_NAME} -Recurse
+          # Copy-Item -Path "README.md", "LICENSE" -Destination ${env:TARGET_NAME}
+          # Compress-Archive -Path ${env:TARGET_NAME} -DestinationPath "${env:TARGET_NAME}.zip"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: yazi-${{ matrix.target }}.zip
-          path: yazi-${{ matrix.target }}.zip
+      # - name: Upload artifact
+        # uses: actions/upload-artifact@v4
+        # with:
+          # name: yazi-${{ matrix.target }}.zip
+          # path: yazi-${{ matrix.target }}.zip
 
-  build-musl:
+  # build-musl:
+    # runs-on: ubuntu-latest
+    # strategy:
+      # matrix:
+        # include:
+          # - target: x86_64-unknown-linux-musl
+            # image: rust-musl-cross:x86_64-musl
+          # - target: aarch64-unknown-linux-musl
+            # image: rust-musl-cross:aarch64-musl
+    # container:
+      # image: docker://ghcr.io/rust-cross/${{ matrix.image }}
+    # steps:
+      # - uses: actions/checkout@v4
+
+      # - name: Build
+        # run: ./scripts/build.sh ${{ matrix.target }}
+
+      # - name: Upload artifact
+        # uses: actions/upload-artifact@v4
+        # with:
+          # name: yazi-${{ matrix.target }}.zip
+          # path: yazi-${{ matrix.target }}.zip
+
+  # build-snap:
+    # strategy:
+      # matrix:
+        # include:
+          # - os: ubuntu-latest
+            # target: x86_64-unknown-linux-gnu
+    # runs-on: ${{ matrix.os }}
+    # steps:
+      # - uses: actions/checkout@v4
+
+      # - name: Build snap
+        # uses: snapcore/action-build@v1
+
+      # - name: Build
+        # run: mv yazi_*.snap yazi-${{ matrix.target }}.snap
+
+      # - name: Upload artifact
+        # uses: actions/upload-artifact@v4
+        # with:
+          # name: yazi-${{ matrix.target }}.snap
+          # path: yazi-${{ matrix.target }}.snap
+
+  # draft:
+    # permissions:
+      # contents: write
+    # runs-on: ubuntu-latest
+    # needs: [build-unix, build-windows, build-musl, build-snap]
+    # steps:
+      # - uses: actions/download-artifact@v4
+        # with:
+          # merge-multiple: true
+
+      # - name: Draft
+        # uses: softprops/action-gh-release@v1
+        # if: startsWith(github.ref, 'refs/tags/')
+        # with:
+          # draft: true
+          # files: |
+            # yazi-*.zip
+            # yazi-*.snap
+          # generate_release_notes: true
+  
+  dummmy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-musl
-            image: rust-musl-cross:x86_64-musl
-          - target: aarch64-unknown-linux-musl
-            image: rust-musl-cross:aarch64-musl
-    container:
-      image: docker://ghcr.io/rust-cross/${{ matrix.image }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Build
-        run: ./scripts/build.sh ${{ matrix.target }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - run: echo "Hello, nightly!" > yazi-dummy.zip
+      - uses: actions/upload-artifact@v4
         with:
-          name: yazi-${{ matrix.target }}.zip
-          path: yazi-${{ matrix.target }}.zip
+          name: yazi-dummy.zip
+          path: yazi-dummy.zip
 
-  build-snap:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build snap
-        uses: snapcore/action-build@v1
-
-      - name: Build
-        run: mv yazi_*.snap yazi-${{ matrix.target }}.snap
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: yazi-${{ matrix.target }}.snap
-          path: yazi-${{ matrix.target }}.snap
-
-  draft:
+  nightly:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [build-unix, build-windows, build-musl, build-snap]
+    # !TODO: uncomment the following line before merging
+    # needs: [build-unix, build-windows, build-musl, build-snap]
+    needs: [dummmy]
     steps:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
 
-      - name: Draft
+      - run: echo "CURRENT_DATE=$(date -u +"%Y%m%d-%H%M")" >> $GITHUB_ENV
+
+      - name: Nightly
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'schedule'
         with:
-          draft: true
+          tag_name: "yazi-nightly-${{ env.CURRENT_DATE }}"
+          prerelease: true
           files: |
             yazi-*.zip
             yazi-*.snap

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -6,6 +6,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
   schedule:
     - cron: '28 12 * * *'
+  workflow_dispatch:
 
 jobs:
   # build-unix:
@@ -173,7 +174,7 @@ jobs:
 
       - name: Nightly
         uses: softprops/action-gh-release@v1
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         with:
           tag_name: "yazi-nightly-${{ env.CURRENT_DATE }}"
           prerelease: true

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   schedule:
-    - cron: '24 14 * * *'
+    - cron: '28 12 * * *'
 
 jobs:
   # build-unix:


### PR DESCRIPTION
Named after and hopefully resolving #1382

Changes include:
- workflow running at a cron schedule (12:00 AM / 00:00 UTC)
- workflow scheduled by cron runs `nightly` job, generating a pre-release

Nightly build name is `yazi-nightly-<timestamp>`. Flow tested with dummy artifact created:
https://github.com/uznog/yazi/actions/runs/10215675482

And here's the resulting pre-release: https://github.com/uznog/yazi/releases/tag/yazi-nightly-20240802-1236