### PR TITLE
fix: precache for images with alpha

### DIFF
--- a/yazi-adapter/src/image.rs
+++ b/yazi-adapter/src/image.rs
@@ -31,7 +31,7 @@ impl Image {
 			}
 
 			img = Self::rotate(img, orientation);
-			if !matches!(img, DynamicImage::ImageRgb8(_) | DynamicImage::ImageRgba8(_)) {
+			if !matches!(img, DynamicImage::ImageRgb8(_)) {
 				img = DynamicImage::ImageRgb8(img.into_rgb8());
 			}
 


### PR DESCRIPTION
Fixes #1383.

Image precache uses jpeg which does not support alpha channel, and the latest version of the image crate removed the silent drop. (See [this issue](https://github.com/image-rs/image/issues/2211)).