### PR TITLE
feat: add `cursor` option to the `shell` command

### DIFF
--- a/yazi-core/src/tab/commands/shell.rs
+++ b/yazi-core/src/tab/commands/shell.rs
@@ -61,7 +61,8 @@ Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` wi
 
 		tokio::spawn(async move {
 			if !opt.confirm || opt.run.is_empty() {
-				let mut result = InputProxy::show(InputCfg::shell(opt.block).with_value(opt.run).with_cursor(cursor));
+				let mut result =
+					InputProxy::show(InputCfg::shell(opt.block).with_value(opt.run).with_cursor(cursor));
 				match result.recv().await {
 					Some(Ok(e)) => opt.run = e,
 					_ => return,

--- a/yazi-proxy/src/app.rs
+++ b/yazi-proxy/src/app.rs
@@ -26,11 +26,11 @@ impl AppProxy {
 	}
 
 	#[inline]
-	pub fn notify_warn(title: &str, content: &str) {
+	pub fn notify_warn(title: &str, content: impl ToString) {
 		emit!(Call(
 			Cmd::new("notify").with_any("option", NotifyOpt {
 				title:   title.to_owned(),
-				content: content.to_owned(),
+				content: content.to_string(),
 				level:   NotifyLevel::Warn,
 				timeout: Duration::from_secs(5),
 			}),
@@ -39,11 +39,11 @@ impl AppProxy {
 	}
 
 	#[inline]
-	pub fn notify_error(title: &str, content: &str) {
+	pub fn notify_error(title: &str, content: impl ToString) {
 		emit!(Call(
 			Cmd::new("notify").with_any("option", NotifyOpt {
 				title:   title.to_owned(),
-				content: content.to_owned(),
+				content: content.to_string(),
 				level:   NotifyLevel::Error,
 				timeout: Duration::from_secs(10),
 			}),


### PR DESCRIPTION
Add a `cursor` option to `shell` command, similar to `rename`.
This allows user to define keymaps with cursor set to generic place, so that they don't have to manually move the cursor every time. When the option is unspecified the behavior is same as before (at the end).
Some examples:
```
[manager]
prepend_keymap = [
  # cursor at end, same as before
  { on = [ ":" ], run = 'shell --block --interactive "vim $@"' },
  # cursor at start, user can input command directly, e.g. vim
  { on = [ ":" ], run = 'shell --block --interactive --cursor=start "$@"' },
  # cursor after 7th char (command), user can input flags directly.
  { on = [ ":" ], run = 'shell --block --interactive --cursor=7 "command $@"' },
]
```

`--cursor=start` is equivalent to `--cursor=0`. I added it here because it is supported by rename already. There could be some extra variants like `after_first`, `before_last` if necessary. `--cursor=<usize>` is sufficient for most cases.