### PR TITLE
feat: switch to kitty unicode placeholders for Ghostty image previewing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -29,16 +29,7 @@ body:
     attributes:
       label: "`yazi --debug` output"
       description: Please run `yazi --debug` and paste the debug information here.
-      value: |
-        <details>
-
-        ```sh
-        ##### ↓↓↓ Paste the output here: ↓↓↓ #####
-
-
-        ```
-
-        </details>
+      render: Shell
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -8,16 +8,7 @@ body:
     attributes:
       label: "`yazi --debug` output"
       description: Please run `yazi --debug` and paste the debug information here.
-      value: |
-        <details>
-
-        ```sh
-        ##### ↓↓↓ Paste the output here: ↓↓↓ #####
-
-
-        ```
-
-        </details>
+      render: Shell
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265
 | WezTerm           | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |
 | Mintty (Git Bash) | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |
 | foot              | [Sixel graphics format](https://www.vt100.net/docs/vt3xx-gp/chapter14.html)                           | ✅ Built-in                                                    |
-| Ghostty           | [Kitty old protocol](https://github.com/sxyazi/yazi/blob/main/yazi-adapter/src/kitty_old.rs)          | ✅ Built-in                                                    |
+| Ghostty           | [Kitty unicode placeholders](https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders) | ✅ Built-in                                                    |
 | Black Box         | [Sixel graphics format](https://www.vt100.net/docs/vt3xx-gp/chapter14.html)                           | ✅ Built-in                                                    |
 | VSCode            | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |
 | Tabby             | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |

--- a/yazi-adapter/src/adapter.rs
+++ b/yazi-adapter/src/adapter.rs
@@ -58,8 +58,8 @@ impl Adapter {
 	pub fn image_erase(self, area: Rect) -> Result<()> {
 		match self {
 			Self::Kitty => Kitty::image_erase(area),
-			Self::Iterm2 => Iterm2::image_erase(area),
 			Self::KittyOld => KittyOld::image_erase(area),
+			Self::Iterm2 => Iterm2::image_erase(area),
 			Self::Sixel => Sixel::image_erase(area),
 			Self::X11 | Self::Wayland => Ueberzug::image_erase(area),
 			Self::Chafa => Chafa::image_erase(area),

--- a/yazi-adapter/src/emulator.rs
+++ b/yazi-adapter/src/emulator.rs
@@ -37,7 +37,7 @@ impl Emulator {
 			Self::Iterm2 => vec![Adapter::Iterm2, Adapter::Sixel],
 			Self::WezTerm => vec![Adapter::Iterm2, Adapter::Sixel],
 			Self::Foot => vec![Adapter::Sixel],
-			Self::Ghostty => vec![Adapter::KittyOld],
+			Self::Ghostty => vec![Adapter::Kitty],
 			Self::BlackBox => vec![Adapter::Sixel],
 			Self::VSCode => vec![Adapter::Iterm2, Adapter::Sixel],
 			Self::Tabby => vec![Adapter::Iterm2, Adapter::Sixel],

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr, time::{SystemTime, UNIX_EPOCH}};
+use std::{borrow::Cow, path::PathBuf, str::FromStr, time::{SystemTime, UNIX_EPOCH}};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -28,6 +28,22 @@ impl Preview {
 	pub fn tmpfile(&self, prefix: &str) -> PathBuf {
 		let time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
 		self.cache_dir.join(format!("{prefix}-{}", time.as_nanos() / 1000))
+	}
+
+	#[inline]
+	pub fn indent(&self) -> Cow<'static, str> {
+		match self.tab_size {
+			0 => Cow::Borrowed(""),
+			1 => Cow::Borrowed(" "),
+			2 => Cow::Borrowed("  "),
+			3 => Cow::Borrowed("   "),
+			4 => Cow::Borrowed("    "),
+			5 => Cow::Borrowed("     "),
+			6 => Cow::Borrowed("      "),
+			7 => Cow::Borrowed("       "),
+			8 => Cow::Borrowed("        "),
+			n => Cow::Owned(" ".repeat(n as usize)),
+		}
 	}
 }
 

--- a/yazi-fm/src/input/input.rs
+++ b/yazi-fm/src/input/input.rs
@@ -25,7 +25,7 @@ impl<'a> Input<'a> {
 		if let Some(syntax) = syntaxes.find_syntax_by_name("Bourne Again Shell (bash)") {
 			let mut h = HighlightLines::new(syntax, theme);
 			let regions = h.highlight_line(self.cx.input.value(), syntaxes)?;
-			return Ok(Highlighter::to_line_widget(regions, &" ".repeat(PREVIEW.tab_size as usize)));
+			return Ok(Highlighter::to_line_widget(regions, &PREVIEW.indent()));
 		}
 		bail!("Failed to find syntax")
 	}

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -34,15 +34,13 @@ function Status:style()
 end
 
 function Status:mode()
-	local mode = tostring(self._tab.mode):upper()
-	if mode == "UNSET" then
-		mode = "UN-SET"
-	end
+	local mode = tostring(self._tab.mode):sub(1, 3):upper()
 
 	local style = self:style()
 	return ui.Line {
 		ui.Span(THEME.status.separator_open):fg(style.bg),
 		ui.Span(" " .. mode .. " "):style(style),
+		ui.Span(THEME.status.separator_close):fg(style.bg):bg(THEME.status.separator_style.fg),
 	}
 end
 
@@ -106,11 +104,11 @@ function Status:percentage()
 	end
 
 	if percent == 0 then
-		percent = "  Top "
+		percent = " Top "
 	elseif percent == 100 then
-		percent = "  Bot "
+		percent = " Bot "
 	else
-		percent = string.format(" %3d%% ", percent)
+		percent = string.format(" %2d%% ", percent)
 	end
 
 	local style = self:style()
@@ -126,6 +124,7 @@ function Status:position()
 
 	local style = self:style()
 	return ui.Line {
+		ui.Span(THEME.status.separator_open):fg(style.bg):bg(THEME.status.separator_style.fg),
 		ui.Span(string.format(" %2d/%-2d ", cursor + 1, length)):style(style),
 		ui.Span(THEME.status.separator_close):fg(style.bg),
 	}


### PR DESCRIPTION
Ghostty now supports [kitty unicode placeholders](https://github.com/ghostty-org/ghostty/pull/2015), it's the first terminal I know of besides kitty itself to implement this feature. Much respect!