### PR TITLE
fix: 7zip shows different error messages for RAR and ZIP files

### DIFF
--- a/yazi-core/src/manager/commands/hover.rs
+++ b/yazi-core/src/manager/commands/hover.rs
@@ -28,7 +28,7 @@ impl Manager {
 
 		// Hover on the file
 		render!(self.current_or_mut(opt.tab).repos(opt.url.as_ref()));
-		if opt.url.zip(self.current().hovered()).is_some_and(|(u, f)| u == f.url) {
+		if opt.url.zip(self.current_or(opt.tab).hovered()).is_some_and(|(u, f)| u == f.url) {
 			// `hover(Some)` occurs after user actions, such as create, rename, reveal, etc.
 			// At this point, it's intuitive to track the location of this file regardless.
 			self.current_or_mut(opt.tab).tracing = true;

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -137,6 +137,6 @@ function M:list_files(args, skip, limit)
 	return files, i, code
 end
 
-function M:is_encrypted(s) return s:find(". Wrong password?", 1, true) end
+function M:is_encrypted(s) return s:find(" Wrong password", 1, true) end
 
 return M


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/1465

Also fixes https://github.com/sxyazi/yazi/issues/1466