### PR TITLE
feat: new `tab` DDS event on tab switch

### DIFF
--- a/yazi-core/src/manager/commands/tab_switch.rs
+++ b/yazi-core/src/manager/commands/tab_switch.rs
@@ -1,4 +1,3 @@
-use yazi_dds::Pubsub;
 use yazi_shared::{event::{Cmd, Data}, render};
 
 use crate::manager::Tabs;
@@ -29,8 +28,5 @@ impl Tabs {
 
 		self.set_idx(idx);
 		render!();
-
-		// Publish through DDS
-		Pubsub::pub_from_tab_switch(self.active().idx);
 	}
 }

--- a/yazi-core/src/manager/commands/tab_switch.rs
+++ b/yazi-core/src/manager/commands/tab_switch.rs
@@ -1,3 +1,4 @@
+use yazi_dds::Pubsub;
 use yazi_shared::{event::{Cmd, Data}, render};
 
 use crate::manager::Tabs;
@@ -28,5 +29,8 @@ impl Tabs {
 
 		self.set_idx(idx);
 		render!();
+
+		// Publish through DDS
+		Pubsub::pub_from_tab_switch(self.active().idx);
 	}
 }

--- a/yazi-core/src/manager/tabs.rs
+++ b/yazi-core/src/manager/tabs.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use yazi_boot::BOOT;
+use yazi_dds::Pubsub;
 use yazi_proxy::ManagerProxy;
 use yazi_shared::fs::Url;
 
@@ -47,7 +48,7 @@ impl Tabs {
 			return;
 		}
 
-		// Reset the preview of the previous active tab
+		// Reset the preview of the last active tab
 		if let Some(active) = self.items.get_mut(self.cursor) {
 			active.preview.reset_image();
 		}
@@ -55,6 +56,7 @@ impl Tabs {
 		self.cursor = idx;
 		ManagerProxy::refresh();
 		ManagerProxy::peek(true);
+		Pubsub::pub_from_tab(idx);
 	}
 }
 

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use mlua::{ExternalResult, IntoLua, Lua, Value};
 use serde::Serialize;
 
-use super::{BodyBulk, BodyBye, BodyCd, BodyCustom, BodyDelete, BodyHey, BodyHi, BodyHover, BodyMove, BodyRename, BodyTrash, BodyYank};
+use super::{BodyBulk, BodyBye, BodyCd, BodyCustom, BodyDelete, BodyHey, BodyHi, BodyHover, BodyMove, BodyRename, BodyTabSwitch, BodyTrash, BodyYank};
 use crate::Payload;
 
 #[derive(Debug, Serialize)]
@@ -13,6 +13,7 @@ pub enum Body<'a> {
 	Bye(BodyBye),
 	Cd(BodyCd<'a>),
 	Hover(BodyHover<'a>),
+	TabSwitch(BodyTabSwitch),
 	Rename(BodyRename<'a>),
 	Bulk(BodyBulk<'a>),
 	Yank(BodyYank<'a>),
@@ -30,6 +31,7 @@ impl Body<'static> {
 			"bye" => Self::Bye(serde_json::from_str(body)?),
 			"cd" => Self::Cd(serde_json::from_str(body)?),
 			"hover" => Self::Hover(serde_json::from_str(body)?),
+			"tab-switch" => Self::TabSwitch(serde_json::from_str(body)?),
 			"rename" => Self::Rename(serde_json::from_str(body)?),
 			"bulk" => Self::Bulk(serde_json::from_str(body)?),
 			"@yank" => Self::Yank(serde_json::from_str(body)?),
@@ -53,6 +55,7 @@ impl Body<'static> {
 				| "bye"
 				| "cd"
 				| "hover"
+				| "tab-switch"
 				| "rename"
 				| "bulk"
 				| "@yank"
@@ -84,6 +87,7 @@ impl<'a> Body<'a> {
 			Self::Bye(_) => "bye",
 			Self::Cd(_) => "cd",
 			Self::Hover(_) => "hover",
+			Self::TabSwitch(_) => "tab-switch",
 			Self::Rename(_) => "rename",
 			Self::Bulk(_) => "bulk",
 			Self::Yank(_) => "@yank",
@@ -111,6 +115,7 @@ impl IntoLua<'_> for Body<'static> {
 			Self::Bye(b) => b.into_lua(lua),
 			Self::Cd(b) => b.into_lua(lua),
 			Self::Hover(b) => b.into_lua(lua),
+			Self::TabSwitch(b) => b.into_lua(lua),
 			Self::Rename(b) => b.into_lua(lua),
 			Self::Bulk(b) => b.into_lua(lua),
 			Self::Yank(b) => b.into_lua(lua),

--- a/yazi-dds/src/body/body.rs
+++ b/yazi-dds/src/body/body.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use mlua::{ExternalResult, IntoLua, Lua, Value};
 use serde::Serialize;
 
-use super::{BodyBulk, BodyBye, BodyCd, BodyCustom, BodyDelete, BodyHey, BodyHi, BodyHover, BodyMove, BodyRename, BodyTabSwitch, BodyTrash, BodyYank};
+use super::{BodyBulk, BodyBye, BodyCd, BodyCustom, BodyDelete, BodyHey, BodyHi, BodyHover, BodyMove, BodyRename, BodyTab, BodyTrash, BodyYank};
 use crate::Payload;
 
 #[derive(Debug, Serialize)]
@@ -13,7 +13,7 @@ pub enum Body<'a> {
 	Bye(BodyBye),
 	Cd(BodyCd<'a>),
 	Hover(BodyHover<'a>),
-	TabSwitch(BodyTabSwitch),
+	Tab(BodyTab),
 	Rename(BodyRename<'a>),
 	Bulk(BodyBulk<'a>),
 	Yank(BodyYank<'a>),
@@ -31,7 +31,7 @@ impl Body<'static> {
 			"bye" => Self::Bye(serde_json::from_str(body)?),
 			"cd" => Self::Cd(serde_json::from_str(body)?),
 			"hover" => Self::Hover(serde_json::from_str(body)?),
-			"tab-switch" => Self::TabSwitch(serde_json::from_str(body)?),
+			"tab" => Self::Tab(serde_json::from_str(body)?),
 			"rename" => Self::Rename(serde_json::from_str(body)?),
 			"bulk" => Self::Bulk(serde_json::from_str(body)?),
 			"@yank" => Self::Yank(serde_json::from_str(body)?),
@@ -55,7 +55,7 @@ impl Body<'static> {
 				| "bye"
 				| "cd"
 				| "hover"
-				| "tab-switch"
+				| "tab"
 				| "rename"
 				| "bulk"
 				| "@yank"
@@ -87,7 +87,7 @@ impl<'a> Body<'a> {
 			Self::Bye(_) => "bye",
 			Self::Cd(_) => "cd",
 			Self::Hover(_) => "hover",
-			Self::TabSwitch(_) => "tab-switch",
+			Self::Tab(_) => "tab",
 			Self::Rename(_) => "rename",
 			Self::Bulk(_) => "bulk",
 			Self::Yank(_) => "@yank",
@@ -115,7 +115,7 @@ impl IntoLua<'_> for Body<'static> {
 			Self::Bye(b) => b.into_lua(lua),
 			Self::Cd(b) => b.into_lua(lua),
 			Self::Hover(b) => b.into_lua(lua),
-			Self::TabSwitch(b) => b.into_lua(lua),
+			Self::Tab(b) => b.into_lua(lua),
 			Self::Rename(b) => b.into_lua(lua),
 			Self::Bulk(b) => b.into_lua(lua),
 			Self::Yank(b) => b.into_lua(lua),

--- a/yazi-dds/src/body/mod.rs
+++ b/yazi-dds/src/body/mod.rs
@@ -11,6 +11,7 @@ mod hi;
 mod hover;
 mod move_;
 mod rename;
+mod tab;
 mod trash;
 mod yank;
 
@@ -25,5 +26,6 @@ pub use hi::*;
 pub use hover::*;
 pub use move_::*;
 pub use rename::*;
+pub use tab::*;
 pub use trash::*;
 pub use yank::*;

--- a/yazi-dds/src/body/tab.rs
+++ b/yazi-dds/src/body/tab.rs
@@ -1,0 +1,30 @@
+use mlua::{IntoLua, Lua, Value};
+use serde::{Deserialize, Serialize};
+
+use super::Body;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BodyTabSwitch {
+	/// The index of the tab
+	pub tab: usize,
+}
+
+impl<'a> BodyTabSwitch {
+	#[inline]
+	pub fn borrowed(tab: usize) -> Body<'a> { Self { tab }.into() }
+}
+
+impl BodyTabSwitch {
+	#[inline]
+	pub fn dummy(tab: usize) -> Body<'static> { Self { tab }.into() }
+}
+
+impl<'a> From<BodyTabSwitch> for Body<'a> {
+	fn from(value: BodyTabSwitch) -> Self { Self::TabSwitch(value) }
+}
+
+impl IntoLua<'_> for BodyTabSwitch {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		lua.create_table_from([("tab", self.tab)])?.into_lua(lua)
+	}
+}

--- a/yazi-dds/src/body/tab.rs
+++ b/yazi-dds/src/body/tab.rs
@@ -4,27 +4,21 @@ use serde::{Deserialize, Serialize};
 use super::Body;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct BodyTabSwitch {
-	/// The index of the tab
-	pub tab: usize,
+pub struct BodyTab {
+	pub idx: usize,
 }
 
-impl<'a> BodyTabSwitch {
+impl BodyTab {
 	#[inline]
-	pub fn borrowed(tab: usize) -> Body<'a> { Self { tab }.into() }
+	pub fn owned(idx: usize) -> Body<'static> { Self { idx }.into() }
 }
 
-impl BodyTabSwitch {
-	#[inline]
-	pub fn dummy(tab: usize) -> Body<'static> { Self { tab }.into() }
+impl<'a> From<BodyTab> for Body<'a> {
+	fn from(value: BodyTab) -> Self { Self::Tab(value) }
 }
 
-impl<'a> From<BodyTabSwitch> for Body<'a> {
-	fn from(value: BodyTabSwitch) -> Self { Self::TabSwitch(value) }
-}
-
-impl IntoLua<'_> for BodyTabSwitch {
+impl IntoLua<'_> for BodyTab {
 	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
-		lua.create_table_from([("tab", self.tab)])?.into_lua(lua)
+		lua.create_table_from([("idx", self.idx)])?.into_lua(lua)
 	}
 }

--- a/yazi-dds/src/payload.rs
+++ b/yazi-dds/src/payload.rs
@@ -82,6 +82,7 @@ impl Display for Payload<'_> {
 			Body::Bye(b) => serde_json::to_string(b),
 			Body::Cd(b) => serde_json::to_string(b),
 			Body::Hover(b) => serde_json::to_string(b),
+			Body::TabSwitch(b) => serde_json::to_string(b),
 			Body::Rename(b) => serde_json::to_string(b),
 			Body::Bulk(b) => serde_json::to_string(b),
 			Body::Yank(b) => serde_json::to_string(b),

--- a/yazi-dds/src/payload.rs
+++ b/yazi-dds/src/payload.rs
@@ -82,7 +82,7 @@ impl Display for Payload<'_> {
 			Body::Bye(b) => serde_json::to_string(b),
 			Body::Cd(b) => serde_json::to_string(b),
 			Body::Hover(b) => serde_json::to_string(b),
-			Body::TabSwitch(b) => serde_json::to_string(b),
+			Body::Tab(b) => serde_json::to_string(b),
 			Body::Rename(b) => serde_json::to_string(b),
 			Body::Bulk(b) => serde_json::to_string(b),
 			Body::Yank(b) => serde_json::to_string(b),

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -5,7 +5,7 @@ use parking_lot::RwLock;
 use yazi_boot::BOOT;
 use yazi_shared::{fs::Url, RoCell};
 
-use crate::{body::{Body, BodyBulk, BodyCd, BodyDelete, BodyHi, BodyHover, BodyMove, BodyMoveItem, BodyRename, BodyTrash, BodyYank}, Client, ID, PEERS};
+use crate::{body::{Body, BodyBulk, BodyCd, BodyDelete, BodyHi, BodyHover, BodyMove, BodyMoveItem, BodyRename, BodyTabSwitch, BodyTrash, BodyYank}, Client, ID, PEERS};
 
 pub static LOCAL: RoCell<RwLock<HashMap<String, HashMap<String, Function<'static>>>>> =
 	RoCell::new();
@@ -109,6 +109,18 @@ impl Pubsub {
 		}
 		if BOOT.local_events.contains("hover") {
 			BodyHover::borrowed(tab, url).with_receiver(*ID).flush();
+		}
+	}
+
+	pub fn pub_from_tab_switch(tab: usize) {
+		if LOCAL.read().contains_key("tab-switch") {
+			Self::pub_(BodyTabSwitch::dummy(tab));
+		}
+		if PEERS.read().values().any(|p| p.able("tab-switch")) {
+			Client::push(BodyTabSwitch::borrowed(tab));
+		}
+		if BOOT.local_events.contains("tab-switch") {
+			BodyTabSwitch::borrowed(tab).with_receiver(*ID).flush();
 		}
 	}
 

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -5,7 +5,7 @@ use parking_lot::RwLock;
 use yazi_boot::BOOT;
 use yazi_shared::{fs::Url, RoCell};
 
-use crate::{body::{Body, BodyBulk, BodyCd, BodyDelete, BodyHi, BodyHover, BodyMove, BodyMoveItem, BodyRename, BodyTabSwitch, BodyTrash, BodyYank}, Client, ID, PEERS};
+use crate::{body::{Body, BodyBulk, BodyCd, BodyDelete, BodyHi, BodyHover, BodyMove, BodyMoveItem, BodyRename, BodyTab, BodyTrash, BodyYank}, Client, ID, PEERS};
 
 pub static LOCAL: RoCell<RwLock<HashMap<String, HashMap<String, Function<'static>>>>> =
 	RoCell::new();
@@ -112,15 +112,15 @@ impl Pubsub {
 		}
 	}
 
-	pub fn pub_from_tab_switch(tab: usize) {
-		if LOCAL.read().contains_key("tab-switch") {
-			Self::pub_(BodyTabSwitch::dummy(tab));
+	pub fn pub_from_tab(idx: usize) {
+		if LOCAL.read().contains_key("tab") {
+			Self::pub_(BodyTab::owned(idx));
 		}
-		if PEERS.read().values().any(|p| p.able("tab-switch")) {
-			Client::push(BodyTabSwitch::borrowed(tab));
+		if PEERS.read().values().any(|p| p.able("tab")) {
+			Client::push(BodyTab::owned(idx));
 		}
-		if BOOT.local_events.contains("tab-switch") {
-			BodyTabSwitch::borrowed(tab).with_receiver(*ID).flush();
+		if BOOT.local_events.contains("tab") {
+			BodyTab::owned(idx).with_receiver(*ID).flush();
 		}
 	}
 


### PR DESCRIPTION
This is a simple suggestion on how https://github.com/sxyazi/yazi/issues/1396 could be solved - it simply sends the index of the tab that was switched to in yazi.

Example:

```js
$ ya sub tab-switch
tab-switch,0,1723480172088356,{"tab":1}
tab-switch,0,1723480172088356,{"tab":0}
```

Some observations for your consideration:
- the index in this implementation is currently 0-based while yazi displays tabs as 1-based (1-9). This seems to be what is happening inside yazi, but I'm not sure if this is okay or not.
- other tab commands seem to behave as expected (switch to tab, switch to next/previous tab, move tab, close tab all work without issues)

Closes https://github.com/sxyazi/yazi/issues/1396