### PR TITLE
feat: add `--dir` option to `create` command

### DIFF
--- a/yazi-core/src/manager/commands/create.rs
+++ b/yazi-core/src/manager/commands/create.rs
@@ -4,22 +4,17 @@ use anyhow::Result;
 use tokio::fs;
 use yazi_config::popup::InputCfg;
 use yazi_proxy::{InputProxy, TabProxy, WATCHER};
-use yazi_shared::{
-	event::Cmd,
-	fs::{maybe_exists, ok_or_not_found, symlink_realpath, File, FilesOp, Url},
-};
+use yazi_shared::{event::Cmd, fs::{maybe_exists, ok_or_not_found, symlink_realpath, File, FilesOp, Url}};
 
 use crate::manager::Manager;
 
 pub struct Opt {
 	force: bool,
-	dir: bool,
+	dir:   bool,
 }
 
 impl From<Cmd> for Opt {
-	fn from(c: Cmd) -> Self {
-		Self { force: c.bool("force"), dir: c.bool("dir") }
-	}
+	fn from(c: Cmd) -> Self { Self { force: c.bool("force"), dir: c.bool("dir") } }
 }
 
 impl Manager {

--- a/yazi-core/src/manager/commands/create.rs
+++ b/yazi-core/src/manager/commands/create.rs
@@ -4,16 +4,22 @@ use anyhow::Result;
 use tokio::fs;
 use yazi_config::popup::InputCfg;
 use yazi_proxy::{InputProxy, TabProxy, WATCHER};
-use yazi_shared::{event::Cmd, fs::{maybe_exists, ok_or_not_found, symlink_realpath, File, FilesOp, Url}};
+use yazi_shared::{
+	event::Cmd,
+	fs::{maybe_exists, ok_or_not_found, symlink_realpath, File, FilesOp, Url},
+};
 
 use crate::manager::Manager;
 
 pub struct Opt {
 	force: bool,
+	dir: bool,
 }
 
 impl From<Cmd> for Opt {
-	fn from(c: Cmd) -> Self { Self { force: c.bool("force") } }
+	fn from(c: Cmd) -> Self {
+		Self { force: c.bool("force"), dir: c.bool("dir") }
+	}
 }
 
 impl Manager {
@@ -37,7 +43,7 @@ impl Manager {
 				}
 			}
 
-			Self::create_do(new, name.ends_with('/') || name.ends_with('\\')).await
+			Self::create_do(new, opt.dir || name.ends_with('/') || name.ends_with('\\')).await
 		});
 	}
 

--- a/yazi-core/src/manager/commands/create.rs
+++ b/yazi-core/src/manager/commands/create.rs
@@ -9,12 +9,12 @@ use yazi_shared::{event::Cmd, fs::{maybe_exists, ok_or_not_found, symlink_realpa
 use crate::manager::Manager;
 
 pub struct Opt {
-	force: bool,
 	dir:   bool,
+	force: bool,
 }
 
 impl From<Cmd> for Opt {
-	fn from(c: Cmd) -> Self { Self { force: c.bool("force"), dir: c.bool("dir") } }
+	fn from(c: Cmd) -> Self { Self { dir: c.bool("dir"), force: c.bool("force") } }
 }
 
 impl Manager {


### PR DESCRIPTION
This simple pull request adds a new option to the 'create' command: --dir

With this option 'create' will always create a directory.
This allows you to bind 'create --dir' to a key, so you can easily create directories without having to remember to put / or \ at the end of the name.

Personally it makes sense to me to have a command for this. I very rarely need to create empty files, but I often create directories, and used to have a keybinding for this in ranger. After switching to yazi I very often forget to add the / when I want to make a directory.

I've tested this change on Linux. 'create --dir' now always creates a directory, trailing / is ignored, trailing \ is treated as part of the directory name (which is ok in Linux). Not tested on Windows, because I have no Windows machines :)

Let me know if I've missed something, or if there is a better way to add this functionality.