### PR TITLE
perf: new `image_delay` option debounces image previews to avoid lag caused by terminal image decoding during fast scrolling

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -21,6 +21,7 @@ tab_size        = 2
 max_width       = 600
 max_height      = 900
 cache_dir       = ""
+image_delay     = 30
 image_filter    = "triangle"
 image_quality   = 75
 sixel_fraction  = 15

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -15,6 +15,7 @@ pub struct Preview {
 
 	pub cache_dir: PathBuf,
 
+	pub image_delay:    u8,
 	pub image_filter:   String,
 	pub image_quality:  u8,
 	pub sixel_fraction: u8,
@@ -63,6 +64,8 @@ impl FromStr for Preview {
 
 			cache_dir: Option<String>,
 
+			#[validate(range(min = 0, max = 100))]
+			image_delay:    u8,
 			image_filter:   String,
 			#[validate(range(min = 50, max = 90))]
 			image_quality:  u8,
@@ -87,6 +90,7 @@ impl FromStr for Preview {
 
 			cache_dir,
 
+			image_delay: preview.image_delay,
 			image_filter: preview.image_filter,
 			image_quality: preview.image_quality,
 			sixel_fraction: preview.sixel_fraction,

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -3,15 +3,14 @@ local TEXT = "ABCDEFGHIJKLM\nNOPQRSTUVWXYZ\nabcdefghijklm\nnopqrstuvwxyz\n123456
 local M = {}
 
 function M:peek()
-	local cache = ya.file_cache(self)
-	if not cache then
+	local start, cache = os.clock(), ya.file_cache(self)
+	if not cache or self:preload() ~= 1 then
 		return
 	end
 
-	if self:preload() == 1 then
-		ya.image_show(cache, self.area)
-		ya.preview_widgets(self, {})
-	end
+	ya.sleep(math.max(0, PREVIEW.image_delay / 1000 + start - os.clock()))
+	ya.image_show(cache, self.area)
+	ya.preview_widgets(self, {})
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/image.lua
+++ b/yazi-plugin/preset/plugins/image.lua
@@ -1,11 +1,12 @@
 local M = {}
 
 function M:peek()
-	local url = ya.file_cache(self)
+	local start, url = os.clock(), ya.file_cache(self)
 	if not url or not fs.cha(url) then
 		url = self.file.url
 	end
 
+	ya.sleep(math.max(0, PREVIEW.image_delay / 1000 + start - os.clock()))
 	ya.image_show(url, self.area)
 	ya.preview_widgets(self, {})
 end

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -1,15 +1,14 @@
 local M = {}
 
 function M:peek()
-	local cache = ya.file_cache(self)
-	if not cache then
+	local start, cache = os.clock(), ya.file_cache(self)
+	if not cache or self:preload() ~= 1 then
 		return
 	end
 
-	if self:preload() == 1 then
-		ya.image_show(cache, self.area)
-		ya.preview_widgets(self, {})
-	end
+	ya.sleep(math.max(0, PREVIEW.image_delay / 1000 + start - os.clock()))
+	ya.image_show(cache, self.area)
+	ya.preview_widgets(self, {})
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -1,15 +1,14 @@
 local M = {}
 
 function M:peek()
-	local cache = ya.file_cache(self)
-	if not cache then
+	local start, cache = os.clock(), ya.file_cache(self)
+	if not cache or self:preload() ~= 1 then
 		return
 	end
 
-	if self:preload() == 1 then
-		ya.image_show(cache, self.area)
-		ya.preview_widgets(self, {})
-	end
+	ya.sleep(math.max(0, PREVIEW.image_delay / 1000 + start - os.clock()))
+	ya.image_show(cache, self.area)
+	ya.preview_widgets(self, {})
 end
 
 function M:seek(units)

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -1,15 +1,14 @@
 local M = {}
 
 function M:peek()
-	local cache = ya.file_cache(self)
-	if not cache then
+	local start, cache = os.clock(), ya.file_cache(self)
+	if not cache or self:preload() ~= 1 then
 		return
 	end
 
-	if self:preload() == 1 then
-		ya.image_show(cache, self.area)
-		ya.preview_widgets(self, {})
-	end
+	ya.sleep(math.max(0, PREVIEW.image_delay / 1000 + start - os.clock()))
+	ya.image_show(cache, self.area)
+	ya.preview_widgets(self, {})
 end
 
 function M:seek(units)


### PR DESCRIPTION
I've been working on optimizing Yazi's image preview speed, and with multi-threading, preloading, and a built-in image decoder, it should already be the fastest among all terminal file managers.

However, I noticed some lag during fast scrolling and realized that at this point, the performance bottleneck isn't Yazi itself, but rather the terminal. When users scroll quickly, Yazi processes the images at a very high speed and sends them to the terminal, but the terminal can't keep up with processing them in time, which gives the impression of lag. In reality, it's not Yazi that's lagging, but the terminal.

This PR introduces a new `image_delay` configuration option to address this issue. When previewing images, it will wait at least `image_delay` milliseconds before starting to send the decoded image data to the terminal. 

This gives the terminal a breather and creates the perception that the file list is still scrolling smoothly.

## Before: 


https://github.com/user-attachments/assets/8cf40a08-95b5-44fd-a16b-a1efb70b25f6

## Now:

https://github.com/user-attachments/assets/b5dde838-b700-4fa3-97be-543abff0f4ab

