### PR TITLE
chore: set `MACOSX_DEPLOYMENT_TARGE` to 10.11 to make the binary compatible with old macOS

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ else
 fi
 
 # Build for the target
-cargo build --release --locked --target "$1"
+MACOSX_DEPLOYMENT_TARGE="10.9" cargo build --release --locked --target "$1"
 
 # Create the artifact
 mkdir -p "$ARTIFACT_NAME/completions"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 export ARTIFACT_NAME="yazi-$1"
 export YAZI_GEN_COMPLETIONS=1
-export MACOSX_DEPLOYMENT_TARGE="10.9"
+export MACOSX_DEPLOYMENT_TARGET="10.11"
 
 # Setup Rust toolchain
 if [[ "$1" == *-musl ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export ARTIFACT_NAME="yazi-$1"
 export YAZI_GEN_COMPLETIONS=1
+export MACOSX_DEPLOYMENT_TARGE="10.9"
 
 # Setup Rust toolchain
 if [[ "$1" == *-musl ]]; then
@@ -12,7 +13,7 @@ else
 fi
 
 # Build for the target
-MACOSX_DEPLOYMENT_TARGE="10.9" cargo build --release --locked --target "$1"
+cargo build --release --locked --target "$1"
 
 # Create the artifact
 mkdir -p "$ARTIFACT_NAME/completions"


### PR DESCRIPTION
Fix #1523