### PR TITLE
fix: wrong `debug_assert` in `OrderedFloat` for NaN

### DIFF
--- a/yazi-shared/src/number.rs
+++ b/yazi-shared/src/number.rs
@@ -9,7 +9,7 @@ pub struct OrderedFloat(f64);
 impl OrderedFloat {
 	#[inline]
 	pub fn new(t: f64) -> Self {
-		debug_assert!(t.is_nan());
+		debug_assert!(!t.is_nan());
 		Self(t)
 	}
 


### PR DESCRIPTION
When calling `new` function to create a `OrderedFloat`, it shouldn't allow `NAN` type to pass in, but the issue now only allows `NAN` , which does make much sense for the logic of `OrderedFloat`.

I guess this issue hasn't been detected before is possibly because `OrderedFloat` only works on some edge cases. But anyway, it's better to make the code more robust.