### PR TITLE
feat: make the builtin `code` previewer handle invalid carriage return chars and binary streams better

### DIFF
--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -70,7 +70,7 @@ function Entity:symlink()
 	end
 
 	local to = self._file.link_to
-	return ui.Line(to and { ui.Span(" -> " .. tostring(to)):italic() } or {})
+	return to and ui.Line(" -> " .. tostring(to)):italic() or ui.Line {}
 end
 
 function Entity:render()

--- a/yazi-plugin/preset/plugins/code.lua
+++ b/yazi-plugin/preset/plugins/code.lua
@@ -1,9 +1,13 @@
 local M = {}
 
 function M:peek()
-	local _, bound = ya.preview_code(self)
+	local err, bound = ya.preview_code(self)
 	if bound then
 		ya.manager_emit("peek", { bound, only_if = self.file.url, upper_bound = true })
+	elseif err then
+		ya.preview_widgets(self, {
+			ui.Paragraph(self.area, { ui.Line(err):reverse() }),
+		})
 	end
 end
 

--- a/yazi-plugin/preset/plugins/empty.lua
+++ b/yazi-plugin/preset/plugins/empty.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M:msg(s)
 	local p = ui.Paragraph(self.area, {
-		ui.Line { ui.Span(s):reverse() },
+		ui.Line(s):reverse(),
 	})
 	ya.preview_widgets(self, { p:wrap(ui.Paragraph.WRAP) })
 end

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -53,9 +53,13 @@ function M:seek(units)
 end
 
 function M:fallback_to_builtin()
-	local _, bound = ya.preview_code(self)
+	local err, bound = ya.preview_code(self)
 	if bound then
 		ya.manager_emit("peek", { bound, only_if = self.file.url, upper_bound = true })
+	elseif err then
+		ya.preview_widgets(self, {
+			ui.Paragraph(self.area, { ui.Line(err):reverse() }),
+		})
 	end
 end
 

--- a/yazi-plugin/src/elements/line.rs
+++ b/yazi-plugin/src/elements/line.rs
@@ -82,6 +82,8 @@ impl Line {
 
 impl UserData for Line {
 	fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+		crate::impl_style_shorthands!(methods, 0.style);
+
 		methods.add_function("width", |_, ud: AnyUserData| Ok(ud.borrow_mut::<Self>()?.0.width()));
 		methods.add_function("style", |_, (ud, value): (AnyUserData, Value)| {
 			{

--- a/yazi-plugin/src/elements/span.rs
+++ b/yazi-plugin/src/elements/span.rs
@@ -1,5 +1,4 @@
 use mlua::{AnyUserData, ExternalError, FromLua, Lua, Table, UserData, UserDataMethods, Value};
-use yazi_shared::theme::Color;
 
 use super::Style;
 
@@ -19,54 +18,7 @@ impl Span {
 
 impl UserData for Span {
 	fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
-		methods.add_function("fg", |_, (ud, color): (AnyUserData, String)| {
-			ud.borrow_mut::<Self>()?.0.style.fg = Color::try_from(color).ok().map(Into::into);
-			Ok(ud)
-		});
-		methods.add_function("bg", |_, (ud, color): (AnyUserData, String)| {
-			ud.borrow_mut::<Self>()?.0.style.bg = Color::try_from(color).ok().map(Into::into);
-			Ok(ud)
-		});
-		methods.add_function("bold", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::BOLD;
-			Ok(ud)
-		});
-		methods.add_function("dim", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::DIM;
-			Ok(ud)
-		});
-		methods.add_function("italic", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::ITALIC;
-			Ok(ud)
-		});
-		methods.add_function("underline", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::UNDERLINED;
-			Ok(ud)
-		});
-		methods.add_function("blink", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::SLOW_BLINK;
-			Ok(ud)
-		});
-		methods.add_function("blink_rapid", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::RAPID_BLINK;
-			Ok(ud)
-		});
-		methods.add_function("reverse", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::REVERSED;
-			Ok(ud)
-		});
-		methods.add_function("hidden", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::HIDDEN;
-			Ok(ud)
-		});
-		methods.add_function("crossed", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier |= ratatui::style::Modifier::CROSSED_OUT;
-			Ok(ud)
-		});
-		methods.add_function("reset", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.style.add_modifier = ratatui::style::Modifier::empty();
-			Ok(ud)
-		});
+		crate::impl_style_shorthands!(methods, 0.style);
 
 		methods.add_function("style", |_, (ud, value): (AnyUserData, Value)| {
 			ud.borrow_mut::<Self>()?.0.style = match value {

--- a/yazi-plugin/src/elements/style.rs
+++ b/yazi-plugin/src/elements/style.rs
@@ -40,54 +40,8 @@ impl<'a> TryFrom<Table<'a>> for Style {
 
 impl UserData for Style {
 	fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
-		methods.add_function("fg", |_, (ud, color): (AnyUserData, String)| {
-			ud.borrow_mut::<Self>()?.0.fg = Color::try_from(color).ok().map(Into::into);
-			Ok(ud)
-		});
-		methods.add_function("bg", |_, (ud, color): (AnyUserData, String)| {
-			ud.borrow_mut::<Self>()?.0.bg = Color::try_from(color).ok().map(Into::into);
-			Ok(ud)
-		});
-		methods.add_function("bold", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::BOLD;
-			Ok(ud)
-		});
-		methods.add_function("dim", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::DIM;
-			Ok(ud)
-		});
-		methods.add_function("italic", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::ITALIC;
-			Ok(ud)
-		});
-		methods.add_function("underline", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::UNDERLINED;
-			Ok(ud)
-		});
-		methods.add_function("blink", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::SLOW_BLINK;
-			Ok(ud)
-		});
-		methods.add_function("blink_rapid", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::RAPID_BLINK;
-			Ok(ud)
-		});
-		methods.add_function("reverse", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::REVERSED;
-			Ok(ud)
-		});
-		methods.add_function("hidden", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::HIDDEN;
-			Ok(ud)
-		});
-		methods.add_function("crossed", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier |= ratatui::style::Modifier::CROSSED_OUT;
-			Ok(ud)
-		});
-		methods.add_function("reset", |_, ud: AnyUserData| {
-			ud.borrow_mut::<Self>()?.0.add_modifier = ratatui::style::Modifier::empty();
-			Ok(ud)
-		});
+		crate::impl_style_shorthands!(methods, 0);
+
 		methods.add_function("patch", |_, (ud, value): (AnyUserData, Value)| {
 			{
 				let mut me = ud.borrow_mut::<Self>()?;

--- a/yazi-plugin/src/external/highlighter.rs
+++ b/yazi-plugin/src/external/highlighter.rs
@@ -84,6 +84,14 @@ impl Highlighter {
 				buf.push(b'\n');
 			}
 
+			for b in &mut buf {
+				match *b {
+					b'\0' => return Err("Binary file".into()),
+					b'\r' => *b = b'\n', // '\r' occurs in the middle of a line
+					_ => {}
+				}
+			}
+
 			if i > skip {
 				after.push(String::from_utf8_lossy(&buf).into_owned());
 			} else if !plain {

--- a/yazi-plugin/src/lib.rs
+++ b/yazi-plugin/src/lib.rs
@@ -12,6 +12,7 @@ pub mod fs;
 pub mod isolate;
 pub mod loader;
 mod lua;
+mod macros;
 mod opt;
 pub mod process;
 pub mod pubsub;

--- a/yazi-plugin/src/macros.rs
+++ b/yazi-plugin/src/macros.rs
@@ -1,0 +1,53 @@
+#[macro_export]
+macro_rules! impl_style_shorthands {
+	($methods:ident, $($field:tt).+) => {
+		$methods.add_function("fg", |_, (ud, color): (AnyUserData, String)| {
+			ud.borrow_mut::<Self>()?.$($field).+.fg = yazi_shared::theme::Color::try_from(color).ok().map(Into::into);
+			Ok(ud)
+		});
+		$methods.add_function("bg", |_, (ud, color): (AnyUserData, String)| {
+			ud.borrow_mut::<Self>()?.$($field).+.bg = yazi_shared::theme::Color::try_from(color).ok().map(Into::into);
+			Ok(ud)
+		});
+		$methods.add_function("bold", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::BOLD;
+			Ok(ud)
+		});
+		$methods.add_function("dim", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::DIM;
+			Ok(ud)
+		});
+		$methods.add_function("italic", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::ITALIC;
+			Ok(ud)
+		});
+		$methods.add_function("underline", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::UNDERLINED;
+			Ok(ud)
+		});
+		$methods.add_function("blink", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::SLOW_BLINK;
+			Ok(ud)
+		});
+		$methods.add_function("blink_rapid", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::RAPID_BLINK;
+			Ok(ud)
+		});
+		$methods.add_function("reverse", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::REVERSED;
+			Ok(ud)
+		});
+		$methods.add_function("hidden", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::HIDDEN;
+			Ok(ud)
+		});
+		$methods.add_function("crossed", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier |= ratatui::style::Modifier::CROSSED_OUT;
+			Ok(ud)
+		});
+		$methods.add_function("reset", |_, ud: AnyUserData| {
+			ud.borrow_mut::<Self>()?.$($field).+.add_modifier = ratatui::style::Modifier::empty();
+			Ok(ud)
+		});
+	};
+}

--- a/yazi-shared/src/errors/peek.rs
+++ b/yazi-shared/src/errors/peek.rs
@@ -9,8 +9,8 @@ pub enum PeekError {
 impl Display for PeekError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::Exceed(lines) => write!(f, "Exceed: {lines}"),
-			Self::Unexpected(msg) => write!(f, "Unexpected error: {msg}"),
+			Self::Exceed(lines) => write!(f, "Exceed maximum lines {lines}"),
+			Self::Unexpected(msg) => write!(f, "{msg}"),
 		}
 	}
 }


### PR DESCRIPTION
Invalid `\r` (appearing in the middle of a line and not followed by `\n`) will be replaced with `\n`, and a prompt will be given when using the `code` previewer to preview binary files, see https://github.com/sxyazi/yazi/issues/1546#issuecomment-2307986125.

This PR changes the first return value of `ya.preview_code()` from a boolean to a string. Considering that [only the second return value has been used](https://github.com/search?q=ya.preview_code%28&type=code) in practice for a long time, this change shouldn't have any impact.

Closes https://github.com/sxyazi/yazi/issues/1546