### PR TITLE
fix: open file not work on windows

### DIFF
--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -1,21 +1,50 @@
 local M = {}
 
-function M:peek()
-	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
-	local output, code = Command(cmd):args({ "-bL", tostring(self.file.url) }):stdout(Command.PIPED):output()
+local function detect_os()
+  local os_name
+  if os.getenv('OS') then
+    os_name = os.getenv('OS')
+    if os_name:find('Windows') then
+      return 'Windows'
+    end
+  end
 
-	local p
-	if output then
-		p = ui.Paragraph.parse(self.area, "----- File Type Classification -----\n\n" .. output.stdout)
-	else
-		p = ui.Paragraph(self.area, {
-			ui.Line(string.format("Spawn `%s` command returns %s", cmd, code)),
-		})
-	end
+  local uname_handle = io.popen('uname')
+  if uname_handle then
+    local uname_result = uname_handle:read('*a')
+    uname_handle:close()
+    if uname_result:find('Linux') then
+      return 'Linux'
+    elseif uname_result:find('Darwin') then
+      return 'macOS'
+    end
+  end
 
-	ya.preview_widgets(self, { p:wrap(ui.Paragraph.WRAP) })
+  return 'Unknown'
 end
 
-function M:seek() end
+function M:peek()
+  local cmd = os.getenv('YAZI_FILE_ONE') or 'file'
+  local options = detect_os() == 'Windows' and '-b' or '-bL'
+  local output, code = Command(cmd):args({options, tostring(self.file.url)}):stdout(Command.PIPED):output()
+
+  local p
+  if output then
+    p = ui.Paragraph.parse(self.area, '----- File Type Classification -----\n\n' .. output.stdout)
+  else
+    p =
+      ui.Paragraph(
+      self.area,
+      {
+        ui.Line(string.format('Spawn `%s` command returns %s', cmd, code))
+      }
+    )
+  end
+
+  ya.preview_widgets(self, {p:wrap(ui.Paragraph.WRAP)})
+end
+
+function M:seek()
+end
 
 return M


### PR DESCRIPTION
The `file` command on Windows lacks the `-L (--dereference)` option, and attempting to use it will result in an error.

```
$ file --version
C:\Users\<username>\Scoop\apps\file\current\file.exe-5.45
magic file from %%WIN32_RESOURCE%%
```

```
$ file --help
Usage: file [OPTION...] [FILE...]
Determine type of FILEs.

      --help                 display this help and exit
  -v, --version              output version information and exit
  -m, --magic-file LIST      use LIST as a colon-separated list of magic
                               number files
  -z, --uncompress           try to look inside compressed files
  -Z, --uncompress-noreport  only print the contents of compressed files
  -b, --brief                do not prepend filenames to output lines
  -c, --checking-printout    print the parsed form of the magic file, use in
                               conjunction with -m to debug a new magic file
                               before installing it
  -e, --exclude TEST         exclude TEST from the list of test to be
                               performed for file. Valid tests are:
                               apptype, ascii, cdf, compress, csv, elf,
                               encoding, soft, tar, json, simh,
                               text, tokens
      --exclude-quiet TEST   like exclude, but ignore unknown tests
  -f, --files-from FILE      read the filenames to be examined from FILE
  -F, --separator STRING     use string as separator instead of `:'
  -i, --mime                 output MIME type strings (--mime-type and
                               --mime-encoding)
      --apple                output the Apple CREATOR/TYPE
      --extension            output a slash-separated list of extensions
      --mime-type            output the MIME type
      --mime-encoding        output the MIME encoding
  -k, --keep-going           don't stop at the first match
  -l, --list                 list magic strength
  -n, --no-buffer            do not buffer output
  -N, --no-pad               do not pad output
  -0, --print0               terminate filenames with ASCII NUL
  -P, --parameter            set file engine parameter limits
                                   bytes 7340032 max bytes to look inside file
                               elf_notes     256 max ELF notes processed
                               elf_phnum    2048 max ELF prog sections processed
                               elf_shnum   32768 max ELF sections processed
                               elf_shsize 134217728 max ELF section size
                                encoding   65536 max bytes to scan for encoding
                                   indir      50 recursion limit for indirection
                                    name      50 use limit for name/use magic
                                   regex    8192 length limit for REGEX searches
  -r, --raw                  don't translate unprintable chars to \ooo
  -s, --special-files        treat special (block/char devices) files as
                             ordinary ones
  -S, --no-sandbox           disable system call sandboxing
  -C, --compile              compile file specified by -m
  -d, --debug                print debugging messages

Report bugs to https://bugs.astron.com/
```