### PR TITLE
feat: ensure that `Entity` and `Linemode` have consistent space padding

### DIFF
--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -1,24 +1,27 @@
 Entity = {
 	_inc = 1000,
 	_children = {
-		{ "icon", id = 1, order = 1000 },
-		{ "prefix", id = 2, order = 2000 },
-		{ "highlights", id = 3, order = 3000 },
-		{ "found", id = 4, order = 4000 },
-		{ "symlink", id = 5, order = 5000 },
+		{ "space", id = 1, order = 1000 },
+		{ "icon", id = 2, order = 2000 },
+		{ "prefix", id = 3, order = 3000 },
+		{ "highlights", id = 4, order = 4000 },
+		{ "found", id = 5, order = 5000 },
+		{ "symlink", id = 6, order = 6000 },
 	},
 }
 
 function Entity:new(file) return setmetatable({ _file = file }, { __index = self }) end
+
+function Entity:space() return ui.Line(" ") end
 
 function Entity:icon()
 	local icon = self._file:icon()
 	if not icon then
 		return ui.Line("")
 	elseif self._file:is_hovered() then
-		return ui.Line(" " .. icon.text .. " ")
+		return ui.Line(icon.text .. " ")
 	else
-		return ui.Line(" " .. icon.text .. " "):style(icon.style)
+		return ui.Line(icon.text .. " "):style(icon.style)
 	end
 end
 

--- a/yazi-plugin/preset/components/linemode.lua
+++ b/yazi-plugin/preset/components/linemode.lua
@@ -14,14 +14,10 @@ function Linemode:solo()
 	end
 
 	if not self[mode] then
-		return ui.Line(" " .. mode .. " ")
+		return ui.Line(mode)
 	end
 
-	return ui.Line {
-		ui.Span(" "),
-		self[mode](self),
-		ui.Span(" "),
-	}
+	return ui.Line { self[mode](self) }
 end
 
 function Linemode:size()
@@ -63,6 +59,9 @@ function Linemode:render()
 	local lines = {}
 	for _, c in ipairs(self._children) do
 		lines[#lines + 1] = (type(c[1]) == "string" and self[c[1]] or c[1])(self)
+		if lines[#lines] and lines[#lines]:width() > 0 then
+    			lines[#lines + 1] = ui.Line { ui.Span(" ") }
+		end
 	end
 	return ui.Line(lines)
 end

--- a/yazi-plugin/preset/components/linemode.lua
+++ b/yazi-plugin/preset/components/linemode.lua
@@ -2,22 +2,23 @@ Linemode = {
 	_inc = 1000,
 	_children = {
 		{ "solo", id = 1, order = 1000 },
+		{ "space", id = 2, order = 2000 },
 	},
 }
 
 function Linemode:new(file) return setmetatable({ _file = file }, { __index = self }) end
 
+function Linemode:space() return ui.Line(" ") end
+
 function Linemode:solo()
 	local mode = cx.active.conf.linemode
 	if mode == "none" or mode == "solo" then
 		return ui.Line("")
+	elseif self[mode] then
+		return ui.Line { ui.Span(" "), self[mode](self) }
+	else
+		return ui.Line(" " .. mode)
 	end
-
-	if not self[mode] then
-		return ui.Line(mode)
-	end
-
-	return ui.Line { self[mode](self) }
 end
 
 function Linemode:size()
@@ -59,9 +60,6 @@ function Linemode:render()
 	local lines = {}
 	for _, c in ipairs(self._children) do
 		lines[#lines + 1] = (type(c[1]) == "string" and self[c[1]] or c[1])(self)
-		if lines[#lines] and lines[#lines]:width() > 0 then
-    			lines[#lines + 1] = ui.Line { ui.Span(" ") }
-		end
 	end
 	return ui.Line(lines)
 end


### PR DESCRIPTION
For now the spacing of linemodes is a wild west. This change brings some uniformity - every linemode entry is followed by a space. This also means that every plugin linemode should only return text, without padding of spaces, just like builtin linemodes do.

Another path would be to add spacing parameters to children, so user can decided if certain linemodes should be padded with spaces or not.