### PR TITLE
feat: make the builtin `extract` plugin support compressed tarballs (`*.tar.gz`, `*.tar.bz2`, etc.)

### DIFF
--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -53,6 +53,17 @@ function M:seek(units)
 	end
 end
 
+function M:spawn_tar(args)
+	local command = "tar"
+
+	local stdout = args[1] == "l" and Command.PIPED or Command.NULL
+	local child, code = Command(command):args(args):stdout(stdout):stderr(Command.PIPED):spawn()
+	if not child then
+		return nil, "Failed to spawn, error code: " .. tostring(code)
+	end
+	return child, nil
+end
+
 function M:spawn_7z(args)
 	local last_error = nil
 	local try = function(name)

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -54,10 +54,8 @@ function M:seek(units)
 end
 
 function M:spawn_tar(args)
-	local command = "tar"
-
 	local stdout = args[1] == "l" and Command.PIPED or Command.NULL
-	local child, code = Command(command):args(args):stdout(stdout):stderr(Command.PIPED):spawn()
+	local child, code = Command("tar"):args(args):stdout(stdout):stderr(Command.PIPED):spawn()
 	if not child then
 		return nil, "Failed to spawn, error code: " .. tostring(code)
 	end

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -54,7 +54,7 @@ function M:seek(units)
 end
 
 function M:spawn_tar(args)
-	local stdout = args[1] == "l" and Command.PIPED or Command.NULL
+	local stdout = args[1] and args[1]:sub(0, 2) == "-t" and Command.PIPED or Command.NULL
 	local child, code = Command("tar"):args(args):stdout(stdout):stderr(Command.PIPED):spawn()
 	if not child then
 		return nil, "Failed to spawn, error code: " .. tostring(code)

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -53,15 +53,6 @@ function M:seek(units)
 	end
 end
 
-function M:spawn_tar(args)
-	local stdout = args[1] and args[1]:sub(0, 2) == "-t" and Command.PIPED or Command.NULL
-	local child, code = Command("tar"):args(args):stdout(stdout):stderr(Command.PIPED):spawn()
-	if not child then
-		return nil, "Failed to spawn, error code: " .. tostring(code)
-	end
-	return child, nil
-end
-
 function M:spawn_7z(args)
 	local last_error = nil
 	local try = function(name)
@@ -188,5 +179,7 @@ function M:list_meta(args)
 end
 
 function M:is_encrypted(s) return s:find(" Wrong password", 1, true) end
+
+function M:is_tar(url) return require("archive"):list_meta { "-p", tostring(url) } == "tar" end
 
 return M

--- a/yazi-plugin/src/fs/fs.rs
+++ b/yazi-plugin/src/fs/fs.rs
@@ -3,12 +3,7 @@ use mlua::{ExternalError, ExternalResult, IntoLuaMulti, Lua, Table, Value};
 use tokio::fs;
 use yazi_shared::fs::remove_dir_clean;
 
-use crate::{
-	bindings::Cast,
-	cha::Cha,
-	file::File,
-	url::{Url, UrlRef},
-};
+use crate::{bindings::Cast, cha::Cha, file::File, url::{Url, UrlRef}};
 
 pub fn install(lua: &Lua) -> mlua::Result<()> {
 	lua.globals().raw_set(

--- a/yazi-plugin/src/fs/fs.rs
+++ b/yazi-plugin/src/fs/fs.rs
@@ -53,21 +53,6 @@ pub fn install(lua: &Lua) -> mlua::Result<()> {
 				})?,
 			),
 			(
-				"create",
-				lua.create_async_function(|lua, (type_, url): (mlua::String, UrlRef)| async move {
-					let result = match type_.to_str()? {
-						"file" => fs::File::create(&*url).await.map(|_| ()),
-						"dir" => fs::create_dir(&*url).await,
-						_ => Err("Creation type must be 'file', 'dir'".into_lua_err())?,
-					};
-
-					match result {
-						Ok(_) => (true, Value::Nil).into_lua_multi(lua),
-						Err(e) => (false, e.raw_os_error()).into_lua_multi(lua),
-					}
-				})?,
-			),
-			(
 				"read_dir",
 				lua.create_async_function(|lua, (dir, options): (UrlRef, Table)| async move {
 					let glob = if let Ok(s) = options.raw_get::<_, mlua::String>("glob") {


### PR DESCRIPTION
Close [#1548](https://github.com/sxyazi/yazi/issues/1548).

Description:
 * Add `spawn_tar` function and `is_tar_compatible` function
   - Create `spawn_tar` function to run command with `tar -xaf` to unzip file to tmp directory
   - Create `is_tar_compatible` function to tell if a zip file can be extracted with `tar` command
 * Add `os.excute()` line to make sure the tmp dir exists because `tar` command will not automatically create that dir, unlike `7z`
 * Refactor the logic in the `try()` function to if the zip file can be unzipped with tar and no password required, use `tar`, otherwise use `7z` instead