### PR TITLE
feat: support contour terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265
 | [VSCode](https://github.com/microsoft/vscode)                               | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |
 | [Tabby](https://github.com/Eugeny/tabby)                                    | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |
 | [Hyper](https://github.com/vercel/hyper)                                    | [Inline images protocol](https://iterm2.com/documentation-images.html)                                | ✅ Built-in                                                    |
+| [Contour](https://github.com/contour-terminal/contour)                      | [Sixel graphics format](https://www.vt100.net/docs/vt3xx-gp/chapter14.html)                           | ✅ Built-in                                                    |
 | X11 / Wayland                                                               | Window system protocol                                                                                | ☑️ [Überzug++](https://github.com/jstkdng/ueberzugpp) required |
 | Fallback                                                                    | [ASCII art (Unicode block)](https://en.wikipedia.org/wiki/ASCII_art)                                  | ☑️ [Chafa](https://hpjansson.org/chafa/) required              |
 

--- a/yazi-adapter/src/emulator.rs
+++ b/yazi-adapter/src/emulator.rs
@@ -69,7 +69,6 @@ impl Emulator {
 			("WT_Session", Self::Microsoft),
 			("VSCODE_INJECTION", Self::VSCode),
 			("TABBY_CONFIG_DIRECTORY", Self::Tabby),
-			("TERMINAL_NAME", Self::Contour),
 		];
 		match vars.into_iter().find(|v| env_exists(v.0)) {
 			Some(var) => return var.1,

--- a/yazi-adapter/src/emulator.rs
+++ b/yazi-adapter/src/emulator.rs
@@ -24,6 +24,7 @@ pub enum Emulator {
 	Tabby,
 	Hyper,
 	Mintty,
+	Contour,
 	Neovim,
 	Apple,
 	Urxvt,
@@ -45,6 +46,7 @@ impl Emulator {
 			Self::Tabby => vec![Adapter::Iterm2, Adapter::Sixel],
 			Self::Hyper => vec![Adapter::Iterm2, Adapter::Sixel],
 			Self::Mintty => vec![Adapter::Iterm2],
+			Self::Contour => vec![Adapter::Sixel],
 			Self::Neovim => vec![],
 			Self::Apple => vec![],
 			Self::Urxvt => vec![],
@@ -67,6 +69,7 @@ impl Emulator {
 			("WT_Session", Self::Microsoft),
 			("VSCODE_INJECTION", Self::VSCode),
 			("TABBY_CONFIG_DIRECTORY", Self::Tabby),
+			("TERMINAL_NAME", Self::Contour),
 		];
 		match vars.into_iter().find(|v| env_exists(v.0)) {
 			Some(var) => return var.1,
@@ -92,6 +95,7 @@ impl Emulator {
 			"foot-extra" => return Self::Foot,
 			"xterm-ghostty" => return Self::Ghostty,
 			"rxvt-unicode-256color" => return Self::Urxvt,
+			"contour" => return Self::Contour,
 			_ => warn!("[Adapter] Unknown TERM: {term}"),
 		}
 
@@ -138,6 +142,7 @@ impl Emulator {
 			("WezTerm", Self::WezTerm),
 			("foot", Self::Foot),
 			("ghostty", Self::Ghostty),
+			("contour", Self::Contour),
 		];
 
 		for (name, emulator) in names.iter() {


### PR DESCRIPTION
Contour is a modern C++ TE. See https://github.com/contour-terminal/contour

But there's a tearing(?) problem in the image preview, and I'm not sure if it's a Contour issue or a Yazi issue.
My workaround is to disable the status line:
```yml
# in `.config/contour/contour.yml`
status_line:
    # Either none or indicator.
    display: none
```
![图片](https://github.com/user-attachments/assets/b7ff0e06-5454-4979-bf2c-6bb9361f60b3)
