### PR TITLE
feat: add `dict_merge()` function

### DIFF
--- a/yazi-plugin/preset/ya.lua
+++ b/yazi-plugin/preset/ya.lua
@@ -21,7 +21,12 @@ function ya.list_merge(a, b)
 	return a
 end
 
-function ya.basename(s) return s:gsub("(.*[/\\])(.*)", "%2") end
+function ya.dict_merge(a, b)
+	for k, v in pairs(b) do
+		a[k] = v
+	end
+	return a
+end
 
 function ya.readable_size(size)
 	local units = { "B", "K", "M", "G", "T", "P", "E", "Z", "Y", "R", "Q" }


### PR DESCRIPTION
This PR also removes `ya.basename` because it has [never been used](https://github.com/search?q=ya.basename&type=code) or documented, and the `Url` userdata has added a `name()` method, which is a better way to achieve the same functionality without relying on a regular expression.