### PR TITLE
fix: set `allow-passthrough` always to `all` instead of `on` to prevent overriding a user setting with a higher priority `all`

### DIFF
--- a/yazi-adapter/src/lib.rs
+++ b/yazi-adapter/src/lib.rs
@@ -47,7 +47,7 @@ pub fn init() {
 
 	if *TMUX {
 		_ = std::process::Command::new("tmux")
-			.args(["set", "-p", "allow-passthrough", "on"])
+			.args(["set", "-p", "allow-passthrough", "all"])
 			.stdin(std::process::Stdio::null())
 			.stdout(std::process::Stdio::null())
 			.stderr(std::process::Stdio::null())


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/1624

Set `allow-passthrough` always to `all` instead of `on` to prevent overriding a user setting with a higher priority `all`.

It might be worth considering adding detection for user-defined values and moving this to a separate thread to avoid impacting Yazi's startup speed in the future, as this would involve one additional tmux process call.