### PR TITLE
feat: change input title when using `create --dir`

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -139,7 +139,7 @@ cd_origin = "top-center"
 cd_offset = [ 0, 2, 50, 3 ]
 
 # create
-create_title  = "Create:"
+create_title  = [ "Create:", "Create (dir):" ]
 create_origin = "top-center"
 create_offset = [ 0, 2, 50, 3 ]
 

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -83,5 +83,15 @@ Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` wi
 		}
 	}
 
+	// TODO: Remove when deprecated
+	if matches!(INPUT.create_title, popup::CreateTitle::One(_)) {
+		println!(
+			r#"WARNING: `create_title` config now takes two different values to account for the `--dir` flag.
+Example:
+[input]
+create_title = ["Create:", "Create (dir):"]"#
+		);
+	}
+
 	Ok(())
 }

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -83,13 +83,13 @@ Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` wi
 		}
 	}
 
-	// TODO: Remove when deprecated
-	if matches!(INPUT.create_title, popup::CreateTitle::One(_)) {
+	// TODO: Remove in v0.3.6
+	if matches!(INPUT.create_title, popup::InputCreateTitle::One(_)) {
 		println!(
-			r#"WARNING: `create_title` config now takes two different values to account for the `--dir` flag.
-Example:
-[input]
-create_title = ["Create:", "Create (dir):"]"#
+			r#"WARNING: The `create_title` under `[input]` now accepts an array instead of a string to support different titles for `create` and `create --dir` command.
+
+Please change `create_title = "Create:"` to `create_title = ["Create:", "Create (dir):"]` in your yazi.toml.
+"#
 		);
 	}
 

--- a/yazi-config/src/popup/input.rs
+++ b/yazi-config/src/popup/input.rs
@@ -14,7 +14,7 @@ pub struct Input {
 	pub cd_offset: Offset,
 
 	// create
-	pub create_title:  String,
+	pub create_title:  [String; 2],
 	pub create_origin: Origin,
 	pub create_offset: Offset,
 

--- a/yazi-config/src/popup/input.rs
+++ b/yazi-config/src/popup/input.rs
@@ -5,6 +5,13 @@ use serde::Deserialize;
 use super::{Offset, Origin};
 
 #[derive(Deserialize)]
+#[serde(untagged)]
+pub enum CreateTitle {
+	One(String),
+	Two([String; 2]),
+}
+
+#[derive(Deserialize)]
 pub struct Input {
 	pub cursor_blink: bool,
 
@@ -14,7 +21,7 @@ pub struct Input {
 	pub cd_offset: Offset,
 
 	// create
-	pub create_title:  [String; 2],
+	pub create_title:  CreateTitle,
 	pub create_origin: Origin,
 	pub create_offset: Offset,
 

--- a/yazi-config/src/popup/input.rs
+++ b/yazi-config/src/popup/input.rs
@@ -5,13 +5,6 @@ use serde::Deserialize;
 use super::{Offset, Origin};
 
 #[derive(Deserialize)]
-#[serde(untagged)]
-pub enum CreateTitle {
-	One(String),
-	Two([String; 2]),
-}
-
-#[derive(Deserialize)]
 pub struct Input {
 	pub cursor_blink: bool,
 
@@ -21,7 +14,7 @@ pub struct Input {
 	pub cd_offset: Offset,
 
 	// create
-	pub create_title:  CreateTitle,
+	pub create_title:  InputCreateTitle,
 	pub create_origin: Origin,
 	pub create_offset: Offset,
 
@@ -65,5 +58,22 @@ impl FromStr for Input {
 		}
 
 		Ok(toml::from_str::<Outer>(s)?.input)
+	}
+}
+
+// TODO: Remove in v0.3.6
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum InputCreateTitle {
+	One(String),
+	Two([String; 2]),
+}
+
+impl InputCreateTitle {
+	pub fn as_array(&self) -> [&str; 2] {
+		match self {
+			Self::One(s) => [s, "Create (dir):"],
+			Self::Two(a) => [&a[0], &a[1]],
+		}
 	}
 }

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -41,12 +41,8 @@ impl InputCfg {
 	}
 
 	pub fn create(dir: bool) -> Self {
-		let title = match &INPUT.create_title {
-			super::CreateTitle::One(single_title) => single_title.to_owned(),
-			super::CreateTitle::Two(titles) => titles[dir as usize].to_owned(),
-		};
 		Self {
-			title,
+			title: INPUT.create_title.as_array()[dir as usize].to_owned(),
 			position: Position::new(INPUT.create_origin, INPUT.create_offset),
 			..Default::default()
 		}

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -40,9 +40,9 @@ impl InputCfg {
 		}
 	}
 
-	pub fn create() -> Self {
+	pub fn create(dir: bool) -> Self {
 		Self {
-			title: INPUT.create_title.to_owned(),
+			title: INPUT.create_title[dir as usize].to_owned(),
 			position: Position::new(INPUT.create_origin, INPUT.create_offset),
 			..Default::default()
 		}

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -41,8 +41,12 @@ impl InputCfg {
 	}
 
 	pub fn create(dir: bool) -> Self {
+		let title = match &INPUT.create_title {
+			super::CreateTitle::One(single_title) => single_title.to_owned(),
+			super::CreateTitle::Two(titles) => titles[dir as usize].to_owned(),
+		};
 		Self {
-			title: INPUT.create_title[dir as usize].to_owned(),
+			title,
 			position: Position::new(INPUT.create_origin, INPUT.create_offset),
 			..Default::default()
 		}

--- a/yazi-core/src/manager/commands/create.rs
+++ b/yazi-core/src/manager/commands/create.rs
@@ -22,7 +22,7 @@ impl Manager {
 		let opt = opt.into() as Opt;
 		let cwd = self.cwd().to_owned();
 		tokio::spawn(async move {
-			let mut result = InputProxy::show(InputCfg::create());
+			let mut result = InputProxy::show(InputCfg::create(opt.dir));
 			let Some(Ok(name)) = result.recv().await else {
 				return Ok(());
 			};


### PR DESCRIPTION
When using `create` the title will rename the same (`Create:`), but when using the new `--dir` option, it will show `Create (dir):` to show that it is different in the input prompt.