### PR TITLE
change create_title on preset yazi.toml from sequence to string

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -139,7 +139,7 @@ cd_origin = "top-center"
 cd_offset = [ 0, 2, 50, 3 ]
 
 # create
-create_title  = [ "Create:", "Create (dir):" ]
+create_title  = "Create:"
 create_origin = "top-center"
 create_offset = [ 0, 2, 50, 3 ]
 


### PR DESCRIPTION
Utilizing yazi-config/preset/yazi.toml as it is now would prevent yazi to execute. As yazi does not create the config files at first launch (as well as the docs points to the presets on the repo), users trying the presets as template would not get it to work. 
As the same function is used to create both file and directory (the description of the create function is "Create a file (ends with / for directories)" ), create_title is expected to be a string, not a sequence.

As a remider, create_title is used as "interface text" when creating a new file/folder.