### PR TITLE
fix: `magick` previewer for multi-layered image files with `-flatten` argument

### DIFF
--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -23,6 +23,7 @@ function M:preload()
 		"-density",
 		"200",
 		tostring(self.file.url),
+		"-flatten",
 		"-resize",
 		string.format("%dx%d^", PREVIEW.max_width, PREVIEW.max_height),
 		"-quality",


### PR DESCRIPTION
As the title describes it, this is an easy fix in order for the previewer to work for `xcf` and other files which handle layers. It should work as normal for non-layered files.