### PR TITLE
fix: `enter` and `leave` commands should treat the search results as regular entities

### DIFF
--- a/yazi-core/src/manager/commands/peek.rs
+++ b/yazi-core/src/manager/commands/peek.rs
@@ -1,4 +1,4 @@
-use yazi_shared::{event::{Cmd, Data}, fs::Url, render};
+use yazi_shared::{event::{Cmd, Data}, fs::Url};
 
 use crate::manager::Manager;
 

--- a/yazi-core/src/manager/commands/seek.rs
+++ b/yazi-core/src/manager/commands/seek.rs
@@ -1,6 +1,6 @@
 use yazi_config::PLUGIN;
 use yazi_plugin::isolate;
-use yazi_shared::{MIME_DIR, event::{Cmd, Data}, render};
+use yazi_shared::{MIME_DIR, event::{Cmd, Data}};
 
 use crate::manager::Manager;
 

--- a/yazi-core/src/manager/commands/tab_create.rs
+++ b/yazi-core/src/manager/commands/tab_create.rs
@@ -42,11 +42,11 @@ impl Tabs {
 		} else if let Some(h) = self.active().current.hovered() {
 			tab.conf = self.active().conf.clone();
 			tab.apply_files_attrs();
-			tab.reveal(h.url_owned());
+			tab.reveal(h.url.to_regular());
 		} else {
 			tab.conf = self.active().conf.clone();
 			tab.apply_files_attrs();
-			tab.cd(self.active().cwd().to_owned());
+			tab.cd(self.active().cwd().to_regular());
 		}
 
 		self.items.insert(self.cursor + 1, tab);

--- a/yazi-core/src/tab/commands/enter.rs
+++ b/yazi-core/src/tab/commands/enter.rs
@@ -4,6 +4,6 @@ use crate::tab::Tab;
 
 impl Tab {
 	pub fn enter(&mut self, _: Cmd) {
-		self.current.hovered().filter(|h| h.is_dir()).map(|h| h.url_owned()).map(|u| self.cd(u));
+		self.current.hovered().filter(|h| h.is_dir()).map(|h| h.url.to_regular()).map(|u| self.cd(u));
 	}
 }

--- a/yazi-core/src/tab/commands/leave.rs
+++ b/yazi-core/src/tab/commands/leave.rs
@@ -15,9 +15,9 @@ impl Tab {
 		self
 			.current
 			.hovered()
-			.and_then(|h| h.parent())
+			.and_then(|h| h.url.parent_url())
 			.filter(|u| u != self.cwd())
 			.or_else(|| self.cwd().parent_url())
-			.map(|u| self.cd(u));
+			.map(|u| self.cd(u.into_regular()));
 	}
 }

--- a/yazi-shared/src/fs/file.rs
+++ b/yazi-shared/src/fs/file.rs
@@ -101,7 +101,4 @@ impl File {
 
 	#[inline]
 	pub fn stem(&self) -> Option<&OsStr> { self.url.file_stem() }
-
-	#[inline]
-	pub fn parent(&self) -> Option<Url> { self.url.parent_url() }
 }


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/1683