### PR TITLE
fix: enable texts of `search` related commnds to show in plural form when mutli files are selected.

### DIFF
--- a/yazi-config/preset/keymap.toml
+++ b/yazi-config/preset/keymap.toml
@@ -89,10 +89,10 @@ keymap = [
 	{ on = [ "m", "n" ], run = "linemode none",        desc = "Linemode: none" },
 
 	# Copy
-	{ on = [ "c", "c" ], run = "copy path",             desc = "Copy the file path" },
-	{ on = [ "c", "d" ], run = "copy dirname",          desc = "Copy the directory path" },
-	{ on = [ "c", "f" ], run = "copy filename",         desc = "Copy the filename" },
-	{ on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy the filename without extension" },
+	{ on = [ "c", "c" ], run = "copy path",             desc = "Copy the file path{s}" },
+	{ on = [ "c", "d" ], run = "copy dirname",          desc = "Copy the directory path{s}" },
+	{ on = [ "c", "f" ], run = "copy filename",         desc = "Copy the filename{s}" },
+	{ on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy the filename{s} without extension" },
 
 	# Filter
 	{ on = "f", run = "filter --smart", desc = "Filter files" },

--- a/yazi-config/src/keymap/chord.rs
+++ b/yazi-config/src/keymap/chord.rs
@@ -56,7 +56,7 @@ impl Chord {
 			});
 			let whitespace_re = RE.get_or_init(|| Regex::new(r"\s+").unwrap());
 			match result {
-				Cow::Owned(result) => Cow::Owned(whitespace_re.replace_all(&result, "").into_owned()),
+				Cow::Owned(result) => Cow::Owned(whitespace_re.replace_all(&result, " ").into_owned()),
 				Cow::Borrowed(result) => whitespace_re.replace_all(result, " "),
 			}
 		})

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::str::FromStr;
 
+use keymap::Plurality;
 use yazi_shared::{RoCell, Xdg};
 
 pub mod keymap;
@@ -68,7 +69,7 @@ pub fn init() -> anyhow::Result<()> {
 				continue;
 			}
 			if !r.bool("confirm") && !r.bool("interactive") {
-				let s = format!("`{}` ({})", c.on(), c.desc_or_run());
+				let s = format!("`{}` ({})", c.on(), c.desc_or_run(Plurality::default()));
 				eprintln!(
 					r#"WARNING: In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with either `--interactive` or `--confirm`.
 

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -16,10 +16,6 @@ impl From<Cmd> for Opt {
 impl Tab {
 	pub fn copy(&mut self, opt: impl Into<Opt>) {
 		let opt = opt.into() as Opt;
-		if !self.try_escape_visual() {
-			return;
-		}
-
 		let mut s = OsString::new();
 		let mut it = self.selected_or_hovered(true).peekable();
 		while let Some(u) = it.next() {

--- a/yazi-core/src/which/sorter.rs
+++ b/yazi-core/src/which/sorter.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, mem};
 
-use yazi_config::{WHICH, keymap::ChordCow, which::SortBy};
+use yazi_config::{keymap::{ChordCow, Plurality}, which::SortBy, WHICH};
 use yazi_shared::{Transliterator, natsort};
 
 #[derive(Clone, Copy, PartialEq)]
@@ -35,7 +35,7 @@ impl WhichSorter {
 			entities.push(match self.by {
 				SortBy::None => unreachable!(),
 				SortBy::Key => Cow::Owned(ctrl.on()),
-				SortBy::Desc => ctrl.desc_or_run(),
+				SortBy::Desc => ctrl.desc_or_run(Plurality::Plural),
 			});
 		}
 

--- a/yazi-core/src/which/sorter.rs
+++ b/yazi-core/src/which/sorter.rs
@@ -35,7 +35,7 @@ impl WhichSorter {
 			entities.push(match self.by {
 				SortBy::None => unreachable!(),
 				SortBy::Key => Cow::Owned(ctrl.on()),
-				SortBy::Desc => ctrl.desc_or_run(Plurality::Plural),
+				SortBy::Desc => ctrl.desc_or_run(Plurality::default()),
 			});
 		}
 

--- a/yazi-fm/src/help/bindings.rs
+++ b/yazi-fm/src/help/bindings.rs
@@ -1,5 +1,5 @@
 use ratatui::{buffer::Buffer, layout::{self, Constraint, Rect}, widgets::{List, ListItem, Widget}};
-use yazi_config::THEME;
+use yazi_config::{keymap::Plurality, THEME};
 
 use crate::Ctx;
 
@@ -29,7 +29,7 @@ impl Widget for Bindings<'_> {
 		// Desc
 		let col3: Vec<_> = bindings
 			.iter()
-			.map(|c| ListItem::new(c.desc().unwrap_or("-".into())).style(THEME.help.desc))
+			.map(|c| ListItem::new(c.desc(Plurality::default()).unwrap_or("-".into())).style(THEME.help.desc))
 			.collect();
 
 		let chunks = layout::Layout::horizontal([

--- a/yazi-fm/src/router.rs
+++ b/yazi-fm/src/router.rs
@@ -1,3 +1,4 @@
+use crossterm::event::KeyCode;
 use yazi_config::{KEYMAP, keymap::{Chord, Key}};
 use yazi_shared::{Layer, emit};
 
@@ -50,6 +51,13 @@ impl<'a> Router<'a> {
 			}
 
 			if on.len() > 1 {
+				//for `copy` hotkeys starting with 'c', we need to escape visual mode first so that the `Which` UI can check how many files
+				// are selected to decide using plural or singular on command names.
+				if key.code == KeyCode::Char('c') {
+					if !self.app.cx.manager.active_mut().try_escape_visual() {
+						return false;
+					}
+				}
 				self.app.cx.which.show_with(key, layer);
 			} else {
 				emit!(Seq(ctrl.to_seq(), layer));

--- a/yazi-fm/src/which/cand.rs
+++ b/yazi-fm/src/which/cand.rs
@@ -4,10 +4,11 @@ use yazi_config::{keymap::{Chord, Plurality}, THEME};
 pub(super) struct Cand<'a> {
 	cand:  &'a Chord,
 	times: usize,
+	selected: usize,
 }
 
 impl<'a> Cand<'a> {
-	pub(super) fn new(cand: &'a Chord, times: usize) -> Self { Self { times, cand } }
+	pub(super) fn new(cand: &'a Chord, times: usize, selected: usize) -> Self { Self { times, cand, selected } }
 
 	fn keys(&self) -> Vec<String> {
 		self.cand.on[self.times..].iter().map(ToString::to_string).collect()
@@ -32,7 +33,7 @@ impl Widget for Cand<'_> {
 		spans.push(Span::styled(&THEME.which.separator, THEME.which.separator_style));
 
 		// Description
-		spans.push(Span::styled(self.cand.desc_or_run(Plurality::Plural), THEME.which.desc));
+		spans.push(Span::styled(self.cand.desc_or_run(if self.selected > 1 { Plurality::Plural } else { Plurality::Singular }), THEME.which.desc));
 
 		Line::from(spans).render(area, buf);
 	}

--- a/yazi-fm/src/which/cand.rs
+++ b/yazi-fm/src/which/cand.rs
@@ -1,5 +1,5 @@
 use ratatui::{buffer::Buffer, layout::Rect, text::{Line, Span}, widgets::Widget};
-use yazi_config::{THEME, keymap::Chord};
+use yazi_config::{keymap::{Chord, Plurality}, THEME};
 
 pub(super) struct Cand<'a> {
 	cand:  &'a Chord,
@@ -32,7 +32,7 @@ impl Widget for Cand<'_> {
 		spans.push(Span::styled(&THEME.which.separator, THEME.which.separator_style));
 
 		// Description
-		spans.push(Span::styled(self.cand.desc_or_run(), THEME.which.desc));
+		spans.push(Span::styled(self.cand.desc_or_run(Plurality::Plural), THEME.which.desc));
 
 		Line::from(spans).render(area, buf);
 	}

--- a/yazi-fm/src/which/layout.rs
+++ b/yazi-fm/src/which/layout.rs
@@ -48,14 +48,13 @@ impl Widget for Which<'_> {
 
 		yazi_plugin::elements::Clear::default().render(area, buf);
 		Block::new().style(THEME.which.mask).render(area, buf);
-
+		let selected = self.cx.manager.selected_or_hovered(false).count();
 		for y in 0..area.height {
 			for (x, chunk) in chunks.iter().enumerate() {
 				let Some(cand) = which.cands.get(y as usize * cols + x) else {
 					break;
 				};
-
-				Cand::new(cand, which.times).render(Rect { y: chunk.y + y + 1, height: 1, ..*chunk }, buf);
+				Cand::new(cand, which.times, selected).render(Rect { y: chunk.y + y + 1, height: 1, ..*chunk }, buf);
 			}
 		}
 	}


### PR DESCRIPTION
## Issue Addressed

Previously, when pressing the `c` key, the text displayed was always in singular form, even when multiple files were selected:

```
Copy the file path
Copy the directory path
Copy the filename
```

## Solution

After this fix, when multiple files are selected and the `c` key is pressed, the nouns are converted to plural form:

```
Copy the file paths
Copy the directory paths
Copy the filenames
```

The original singular form is maintained if only one file is selected (or hovered).

## Implementation Details

1. Enabled the `desc` text field in `keymap.toml` to support formats like `wol{ves|f}` or `name{s}`, accommodating both regular and irregular plural forms.

2. The new system works as follows:
   a. Matches content inside `{}` and splits it.
   b. For plural form: Uses the first element of the split to replace the whole `{}`.
      Example: `wol{ves|f}` => `wolves`, `name{s}` => `names`
   c. For singular form: 
      - Uses the second element of the split if available.
      - If no second element (no `|`), removes the entire `{}`.
      Example: `name{s}` => `name`, `wol{ves|f}` => `wolf`

3. Updated the logic to call `selected_or_hovered` in advance  when the `c` key is pressed, ensuring accurate capture of selected file count in the `Which` window.

4. For the `Help` window, the default plural form is used to display help information.

## Additional Notes
I'd be much appericiated if you can provide me any feedback. To be honest, this PR is slightly more complicated than I initially though, But it helps me know lots more cool features of this project.
