### PR TITLE
feat: reuse the `code` previewer seeking behavior for `json`, `archive`, and `empty`

### DIFF
--- a/yazi-core/src/manager/commands/rename.rs
+++ b/yazi-core/src/manager/commands/rename.rs
@@ -105,10 +105,10 @@ impl Manager {
 
 		let ext = url.extension();
 		match by {
-			"stem" => ext.map_or_else(String::new, |s| format!(".{}", s.to_string_lossy().into_owned())),
+			"stem" => ext.map_or_else(String::new, |s| format!(".{}", s.to_string_lossy())),
 			"ext" if ext.is_some() => format!("{}.", url.file_stem().unwrap().to_string_lossy()),
 			"dot_ext" if ext.is_some() => url.file_stem().unwrap().to_string_lossy().into_owned(),
-			_ => url.file_name().map_or_else(String::new, |s| s.to_string_lossy().into_owned()),
+			_ => url.name().to_string_lossy().into_owned(),
 		}
 	}
 }

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -26,7 +26,7 @@ impl Tab {
 			s.push(match opt.type_.as_str() {
 				"path" => u.as_os_str(),
 				"dirname" => u.parent().map_or(OsStr::new(""), |p| p.as_os_str()),
-				"filename" => u.file_name().unwrap_or(OsStr::new("")),
+				"filename" => u.name(),
 				"name_without_ext" => u.file_stem().unwrap_or(OsStr::new("")),
 				_ => return,
 			});

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -42,16 +42,7 @@ function M:peek()
 	end
 end
 
-function M:seek(units)
-	local h = cx.active.current.hovered
-	if h and h.url == self.file.url then
-		local step = math.floor(units * self.area.h / 10)
-		ya.manager_emit("peek", {
-			math.max(0, cx.active.preview.skip + step),
-			only_if = self.file.url,
-		})
-	end
-end
+function M:seek(units) require("code").seek(self, units) end
 
 function M.spawn_7z(args)
 	local last_error = nil

--- a/yazi-plugin/preset/plugins/empty.lua
+++ b/yazi-plugin/preset/plugins/empty.lua
@@ -35,15 +35,6 @@ function M:peek()
 	end
 end
 
-function M:seek(units)
-	local h = cx.active.current.hovered
-	if h and h.url == self.file.url then
-		local step = math.floor(units * self.area.h / 10)
-		ya.manager_emit("peek", {
-			math.max(0, cx.active.preview.skip + step),
-			only_if = self.file.url,
-		})
-	end
-end
+function M:seek(units) require("code").seek(self, units) end
 
 return M

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -41,15 +41,6 @@ function M:peek()
 	end
 end
 
-function M:seek(units)
-	local h = cx.active.current.hovered
-	if h and h.url == self.file.url then
-		local step = math.floor(units * self.area.h / 10)
-		ya.manager_emit("peek", {
-			math.max(0, cx.active.preview.skip + step),
-			only_if = self.file.url,
-		})
-	end
-end
+function M:seek(units) require("code").seek(self, units) end
 
 return M

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -104,8 +104,7 @@ impl Scheduler {
 	}
 
 	pub fn file_copy(&self, from: Url, mut to: Url, force: bool, follow: bool) {
-		let name = format!("Copy {:?} to {:?}", from, to);
-		let id = self.ongoing.lock().add(TaskKind::User, name);
+		let id = self.ongoing.lock().add(TaskKind::User, format!("Copy {from} to {to}"));
 
 		if to.starts_with(&from) && to != from {
 			self.new_and_fail(id, "Cannot copy directory into itself").ok();
@@ -122,8 +121,7 @@ impl Scheduler {
 	}
 
 	pub fn file_link(&self, from: Url, mut to: Url, relative: bool, force: bool) {
-		let name = format!("Link {from:?} to {to:?}");
-		let id = self.ongoing.lock().add(TaskKind::User, name);
+		let id = self.ongoing.lock().add(TaskKind::User, format!("Link {from} to {to}"));
 
 		let file = self.file.clone();
 		self.send_micro(id, LOW, async move {
@@ -137,8 +135,7 @@ impl Scheduler {
 	}
 
 	pub fn file_hardlink(&self, from: Url, mut to: Url, force: bool, follow: bool) {
-		let name = format!("Hardlink {:?} to {:?}", from, to);
-		let id = self.ongoing.lock().add(TaskKind::User, name);
+		let id = self.ongoing.lock().add(TaskKind::User, format!("Hardlink {from} to {to}"));
 
 		if to.starts_with(&from) && to != from {
 			self.new_and_fail(id, "Cannot hardlink directory into itself").ok();
@@ -156,7 +153,7 @@ impl Scheduler {
 
 	pub fn file_delete(&self, target: Url) {
 		let mut ongoing = self.ongoing.lock();
-		let id = ongoing.add(TaskKind::User, format!("Delete {:?}", target));
+		let id = ongoing.add(TaskKind::User, format!("Delete {target}"));
 
 		ongoing.hooks.insert(id, {
 			let target = target.clone();
@@ -185,7 +182,7 @@ impl Scheduler {
 
 	pub fn file_trash(&self, target: Url) {
 		let mut ongoing = self.ongoing.lock();
-		let id = ongoing.add(TaskKind::User, format!("Trash {:?}", target));
+		let id = ongoing.add(TaskKind::User, format!("Trash {target}"));
 
 		ongoing.hooks.insert(id, {
 			let target = target.clone();
@@ -258,7 +255,7 @@ impl Scheduler {
 		let mut ongoing = self.ongoing.lock();
 
 		for target in targets {
-			let id = ongoing.add(TaskKind::Preload, format!("Calculate the size of {:?}", target));
+			let id = ongoing.add(TaskKind::Preload, format!("Calculate the size of {target}"));
 			let target = target.clone();
 			let throttle = throttle.clone();
 
@@ -435,7 +432,7 @@ impl Scheduler {
 			async move {
 				if let Err(e) = f.await {
 					prog.send(TaskProg::New(id, 0)).ok();
-					prog.send(TaskProg::Fail(id, format!("Task initialization failed:\n{e}"))).ok();
+					prog.send(TaskProg::Fail(id, format!("Task initialization failed:\n{e:?}"))).ok();
 				}
 			}
 			.boxed(),


### PR DESCRIPTION
This PR makes implementing https://github.com/sxyazi/yazi/issues/1328#issuecomment-2379689321 easier — these `seek`ing behaviors are consistent, we just use the `code`'s `seek` method uniformly, so as long as the user rewrites the `code`'s, the other previewers will just work.