### PR TITLE
fix create_title (yazi-config/preset/yazi.toml)

### DIFF
--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -139,7 +139,7 @@ cd_origin = "top-center"
 cd_offset = [ 0, 2, 50, 3 ]
 
 # create
-create_title  = [ "Create:", "Create (dir):" ]
+create_title  = "Create:"
 create_origin = "top-center"
 create_offset = [ 0, 2, 50, 3 ]
 


### PR DESCRIPTION
When I copied yazi-config/preset/yazi.toml to ~/.config/yazi/yazi.toml, the following error occurred:

```
Error: TOML parse error at line 253, column 16
    |
253 | create_title = ["Create:", "Create (dir):"]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
invalid type: sequence, expected a string
```

It seems toml parse error, but there is the comment ```TODO: Remove in v0.3.6``` in source-code, so I have only updated the toml file to resolve this error for now.