### PR TITLE
feat: `yazi --debug` supports detecting whether `tmux` is built with `--enable-sixel`

### DIFF
--- a/yazi-adapter/src/lib.rs
+++ b/yazi-adapter/src/lib.rs
@@ -8,6 +8,7 @@ mod iip;
 mod image;
 mod kgp;
 mod kgp_old;
+mod mux;
 mod sixel;
 mod ueberzug;
 
@@ -18,6 +19,7 @@ pub use emulator::*;
 use iip::*;
 use kgp::*;
 use kgp_old::*;
+pub use mux::*;
 use sixel::*;
 use ueberzug::*;
 use yazi_shared::{RoCell, env_exists, in_wsl};
@@ -62,17 +64,4 @@ pub fn init() {
 
 	ADAPTOR.init(Adapter::matches());
 	ADAPTOR.start();
-}
-
-pub fn tcsi(s: &str) -> std::borrow::Cow<str> {
-	if *TMUX {
-		std::borrow::Cow::Owned(format!(
-			"{}{}{}",
-			*START,
-			s.trim_start_matches('\x1b').replace('\x1b', *ESCAPE),
-			*CLOSE
-		))
-	} else {
-		std::borrow::Cow::Borrowed(s)
-	}
 }

--- a/yazi-adapter/src/mux.rs
+++ b/yazi-adapter/src/mux.rs
@@ -1,0 +1,56 @@
+use crate::{CLOSE, ESCAPE, START, TMUX};
+
+pub struct Mux;
+
+impl Mux {
+	pub fn csi(s: &str) -> std::borrow::Cow<str> {
+		if *TMUX {
+			std::borrow::Cow::Owned(format!(
+				"{}{}{}",
+				*START,
+				s.trim_start_matches('\x1b').replace('\x1b', *ESCAPE),
+				*CLOSE
+			))
+		} else {
+			std::borrow::Cow::Borrowed(s)
+		}
+	}
+
+	pub fn tmux_sixel_flag() -> &'static str {
+		let stdout = std::process::Command::new("tmux")
+			.args(["-LwU0dju1is5", "-f/dev/null", "start", ";", "display", "-p", "#{sixel_support}"])
+			.output()
+			.ok()
+			.and_then(|o| String::from_utf8(o.stdout).ok())
+			.unwrap_or_default();
+
+		match stdout.trim() {
+			"1" => "Supported",
+			"0" => "Unsupported",
+			_ => "Unknown",
+		}
+	}
+
+	pub(super) fn term_program() -> (Option<String>, Option<String>) {
+		let (mut term, mut program) = (None, None);
+		if !*TMUX {
+			return (term, program);
+		}
+		let Ok(output) = std::process::Command::new("tmux").arg("show-environment").output() else {
+			return (term, program);
+		};
+		for line in String::from_utf8_lossy(&output.stdout).lines() {
+			if let Some((k, v)) = line.trim().split_once('=') {
+				match k {
+					"TERM" => term = Some(v.to_owned()),
+					"TERM_PROGRAM" => program = Some(v.to_owned()),
+					_ => continue,
+				}
+			}
+			if term.is_some() && program.is_some() {
+				break;
+			}
+		}
+		(term, program)
+	}
+}

--- a/yazi-boot/src/actions/debug.rs
+++ b/yazi-boot/src/actions/debug.rs
@@ -1,6 +1,7 @@
 use std::{env, ffi::OsStr, fmt::Write};
 
 use regex::Regex;
+use yazi_adapter::Mux;
 use yazi_shared::Xdg;
 
 use super::Actions;
@@ -51,14 +52,24 @@ impl Actions {
 		writeln!(s, "\nText Opener")?;
 		writeln!(
 			s,
-			"    default: {:?}",
+			"    default     : {:?}",
 			yazi_config::OPEN.openers("f75a.txt", "text/plain").and_then(|a| a.first().cloned())
 		)?;
-		writeln!(s, "    block  : {:?}", yazi_config::OPEN.block_opener("bulk.txt", "text/plain"))?;
+		writeln!(
+			s,
+			"    block-create: {:?}",
+			yazi_config::OPEN.block_opener("bulk-create.txt", "text/plain")
+		)?;
+		writeln!(
+			s,
+			"    block-rename: {:?}",
+			yazi_config::OPEN.block_opener("bulk-rename.txt", "text/plain")
+		)?;
 
 		writeln!(s, "\nMultiplexers")?;
 		writeln!(s, "    TMUX               : {:?}", *yazi_adapter::TMUX)?;
 		writeln!(s, "    tmux version       : {}", Self::process_output("tmux", "-V"))?;
+		writeln!(s, "    tmux build flags   : enable-sixel={}", Mux::tmux_sixel_flag())?;
 		writeln!(s, "    ZELLIJ_SESSION_NAME: {:?}", env::var_os("ZELLIJ_SESSION_NAME"))?;
 		writeln!(s, "    Zellij version     : {}", Self::process_output("zellij", "--version"))?;
 

--- a/yazi-core/src/manager/commands/bulk_rename.rs
+++ b/yazi-core/src/manager/commands/bulk_rename.rs
@@ -12,7 +12,7 @@ use crate::manager::Manager;
 
 impl Manager {
 	pub(super) fn bulk_rename(&self) {
-		let Some(opener) = OPEN.block_opener("bulk.txt", "text/plain") else {
+		let Some(opener) = OPEN.block_opener("bulk-rename.txt", "text/plain") else {
 			return AppProxy::notify_warn("Bulk rename", "No text opener found");
 		};
 

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use crossterm::{event::{DisableBracketedPaste, EnableBracketedPaste, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags}, execute, queue, style::Print, terminal::{EnterAlternateScreen, LeaveAlternateScreen, SetTitle, disable_raw_mode, enable_raw_mode}};
 use cursor::RestoreCursor;
 use ratatui::{CompletedFrame, Frame, Terminal, backend::CrosstermBackend, buffer::Buffer, layout::Rect};
-use yazi_adapter::{Emulator, tcsi};
+use yazi_adapter::{Emulator, Mux};
 use yazi_config::{INPUT, MANAGER};
 
 static CSI_U: AtomicBool = AtomicBool::new(false);
@@ -28,9 +28,9 @@ impl Term {
 		enable_raw_mode()?;
 		execute!(
 			BufWriter::new(stderr()),
-			Print(tcsi("\x1b[?12$p")),      // Request cursor blink status (DECSET)
-			Print(tcsi("\x1bP$q q\x1b\\")), // Request cursor shape (DECRQM)
-			Print(tcsi("\x1b[?u\x1b[c")),   // Request keyboard enhancement flags (CSI u)
+			Print(Mux::csi("\x1b[?12$p")), // Request cursor blink status (DECSET)
+			Print(Mux::csi("\x1bP$q q\x1b\\")), // Request cursor shape (DECRQM)
+			Print(Mux::csi("\x1b[?u\x1b[c")), // Request keyboard enhancement flags (CSI u)
 			EnterAlternateScreen,
 			EnableBracketedPaste,
 			mouse::SetMouse(true),


### PR DESCRIPTION
A Yazi side implementation of https://github.com/tmux/tmux/issues/4177

---

This PR also changes the `bulk.txt` filename to `bulk-rename.txt` used in bulk renaming, in preparation for the future `bulk-create.txt`. 

This will impect the ["Specify a different editor for bulk renaming" tip](https://yazi-rs.github.io/docs/tips#bulk-editor), but considering it was added just 4 days ago in https://github.com/yazi-rs/yazi-rs.github.io/commit/1c1671b9cdbf4d09b0aa958a5441a44d200af8e9, the impact should be reasonably small, and it will be updated accordingly.

