### PR TITLE
feat!: decouple `ui.List`, `ui.Bar`, `ui.Border`, and `ui.Gauge` from coordinates

### DIFF
--- a/yazi-plugin/preset/components/current.lua
+++ b/yazi-plugin/preset/components/current.lua
@@ -11,15 +11,15 @@ function Current:new(area, tab)
 end
 
 function Current:empty()
-	local line
+	local text
 	if self._folder.files.filter then
-		line = ui.Line("No filter results")
+		text = ui.Text("No filter results")
 	else
-		line = ui.Line(self._folder.stage.is_loading and "Loading..." or "No items")
+		text = ui.Text(self._folder.stage.is_loading and "Loading..." or "No items")
 	end
 
 	return {
-		ui.Text(line):area(self._area):align(ui.Text.CENTER),
+		text:area(self._area):align(ui.Text.CENTER),
 	}
 end
 
@@ -31,8 +31,8 @@ function Current:render()
 
 	local entities, linemodes = {}, {}
 	for _, f in ipairs(files) do
-		linemodes[#linemodes + 1] = Linemode:new(f):render()
 		entities[#entities + 1] = Entity:new(f):render()
+		linemodes[#linemodes + 1] = Linemode:new(f):render()
 	end
 
 	return {

--- a/yazi-plugin/preset/components/header.lua
+++ b/yazi-plugin/preset/components/header.lua
@@ -95,6 +95,7 @@ function Header:render()
 	self._right_width = right:width()
 
 	local left = self:children_render(self.LEFT)
+
 	return {
 		ui.Text(left):area(self._area),
 		ui.Text(right):area(self._area):align(ui.Text.RIGHT),

--- a/yazi-plugin/preset/components/marker.lua
+++ b/yazi-plugin/preset/components/marker.lua
@@ -29,7 +29,7 @@ function Marker:render()
 			w = 1,
 			h = math.min(1 + last[2] - last[1], self._area.y + self._area.h - y),
 		}
-		elements[#elements + 1] = ui.Bar(rect, ui.Bar.LEFT):style(last[3])
+		elements[#elements + 1] = ui.Bar(ui.Bar.LEFT):area(rect):style(last[3])
 	end
 
 	local last = { 0, 0, nil } -- start, end, style

--- a/yazi-plugin/preset/components/progress.lua
+++ b/yazi-plugin/preset/components/progress.lua
@@ -21,7 +21,7 @@ function Progress:partial_render()
 		return { ui.Text {} }
 	end
 
-	local gauge = ui.Gauge(self._area)
+	local gauge = ui.Gauge():area(self._area)
 	if progress.fail == 0 then
 		gauge = gauge:gauge_style(THEME.status.progress_normal)
 	else

--- a/yazi-plugin/preset/components/rail.lua
+++ b/yazi-plugin/preset/components/rail.lua
@@ -11,8 +11,8 @@ end
 
 function Rail:build()
 	self._base = {
-		ui.Bar(self._chunks[1], ui.Bar.RIGHT):symbol(THEME.manager.border_symbol):style(THEME.manager.border_style),
-		ui.Bar(self._chunks[3], ui.Bar.LEFT):symbol(THEME.manager.border_symbol):style(THEME.manager.border_style),
+		ui.Bar(ui.Bar.RIGHT):area(self._chunks[1]):symbol(THEME.manager.border_symbol):style(THEME.manager.border_style),
+		ui.Bar(ui.Bar.LEFT):area(self._chunks[3]):symbol(THEME.manager.border_symbol):style(THEME.manager.border_style),
 	}
 	self._children = {
 		Marker:new(self._chunks[1], self._tab.parent),

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -132,8 +132,10 @@ end
 
 function Status:render()
 	local left = self:children_render(self.LEFT)
+
 	local right = self:children_render(self.RIGHT)
 	local right_width = right:width()
+
 	return {
 		ui.Text(left):area(self._area),
 		ui.Text(right):area(self._area):align(ui.Text.RIGHT),

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -7,9 +7,7 @@ function M:peek()
 	local files, bound, code = self.list_files({ "-p", tostring(self.file.url) }, self.skip, limit)
 	if code ~= 0 then
 		return ya.preview_widgets(self, {
-			ui.Text(
-				ui.Line(code == 2 and "File list in this archive is encrypted" or "Spawn `7z` and `7zz` both commands failed")
-			)
+			ui.Text(code == 2 and "File list in this archive is encrypted" or "Spawn `7z` and `7zz` both commands failed")
 				:area(self.area),
 		})
 	end
@@ -27,9 +25,9 @@ function M:peek()
 		end
 
 		if f.size > 0 then
-			sizes[#sizes + 1] = ui.Line(string.format(" %s ", ya.readable_size(f.size)))
+			sizes[#sizes + 1] = string.format(" %s ", ya.readable_size(f.size))
 		else
-			sizes[#sizes + 1] = ui.Line("")
+			sizes[#sizes + 1] = ""
 		end
 	end
 

--- a/yazi-plugin/preset/plugins/code.lua
+++ b/yazi-plugin/preset/plugins/code.lua
@@ -6,7 +6,7 @@ function M:peek()
 		ya.manager_emit("peek", { bound, only_if = self.file.url, upper_bound = true })
 	elseif err and not err:find("cancelled", 1, true) then
 		ya.preview_widgets(self, {
-			ui.Text(ui.Line(err):reverse()):area(self.area),
+			ui.Text(err):area(self.area):reverse(),
 		})
 	end
 end

--- a/yazi-plugin/preset/plugins/empty.lua
+++ b/yazi-plugin/preset/plugins/empty.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M:msg(s) ya.preview_widgets(self, { ui.Text(ui.Line(s):reverse()):area(self.area):wrap(ui.Text.WRAP) }) end
+function M:msg(s) ya.preview_widgets(self, { ui.Text(s):area(self.area):reverse():wrap(ui.Text.WRAP) }) end
 
 function M:peek()
 	local path = tostring(self.file.url)

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -4,14 +4,14 @@ function M:peek()
 	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
 	local output, code = Command(cmd):args({ "-bL", tostring(self.file.url) }):stdout(Command.PIPED):output()
 
-	local p
+	local text
 	if output then
-		p = ui.Text.parse("----- File Type Classification -----\n\n" .. output.stdout):area(self.area)
+		text = ui.Text.parse("----- File Type Classification -----\n\n" .. output.stdout)
 	else
-		p = ui.Text(string.format("Spawn `%s` command returns %s", cmd, code)):area(self.area)
+		text = ui.Text(string.format("Spawn `%s` command returns %s", cmd, code))
 	end
 
-	ya.preview_widgets(self, { p:wrap(ui.Text.WRAP) })
+	ya.preview_widgets(self, { text:area(self.area):wrap(ui.Text.WRAP) })
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/folder.lua
+++ b/yazi-plugin/preset/plugins/folder.lua
@@ -13,7 +13,7 @@ function M:peek()
 
 	if #folder.files == 0 then
 		return ya.preview_widgets(self, {
-			ui.Text(ui.Line(folder.stage.is_loading and "Loading..." or "No items")):area(self.area):align(ui.Text.CENTER),
+			ui.Text(folder.stage.is_loading and "Loading..." or "No items"):area(self.area):align(ui.Text.CENTER),
 		})
 	end
 

--- a/yazi-plugin/src/elements/bar.rs
+++ b/yazi-plugin/src/elements/bar.rs
@@ -3,7 +3,7 @@ use ratatui::widgets::Borders;
 
 use super::{Rect, Renderable};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Bar {
 	area: Rect,
 
@@ -14,14 +14,8 @@ pub struct Bar {
 
 impl Bar {
 	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {
-		let new = lua.create_function(|_, (_, area, direction): (Table, Rect, u8)| {
-			Ok(Self {
-				area,
-
-				direction: Borders::from_bits_truncate(direction),
-				symbol: Default::default(),
-				style: Default::default(),
-			})
+		let new = lua.create_function(|_, (_, direction): (Table, u8)| {
+			Ok(Self { direction: Borders::from_bits_truncate(direction), ..Default::default() })
 		})?;
 
 		let bar = lua.create_table_from([

--- a/yazi-plugin/src/elements/border.rs
+++ b/yazi-plugin/src/elements/border.rs
@@ -22,9 +22,8 @@ pub struct Border {
 
 impl Border {
 	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {
-		let new = lua.create_function(|_, (_, area, position): (Table, Rect, u8)| {
+		let new = lua.create_function(|_, (_, position): (Table, u8)| {
 			Ok(Border {
-				area,
 				position: ratatui::widgets::Borders::from_bits_truncate(position),
 				..Default::default()
 			})

--- a/yazi-plugin/src/elements/constraint.rs
+++ b/yazi-plugin/src/elements/constraint.rs
@@ -1,42 +1,11 @@
 use mlua::{FromLua, Lua, Table, UserData};
 
-#[derive(Clone, Copy, FromLua)]
+#[derive(Clone, Copy, Default, FromLua)]
 pub struct Constraint(pub(super) ratatui::layout::Constraint);
 
 impl Constraint {
-	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {
-		let constraint = lua.create_table_from([
-			(
-				"Min",
-				lua.create_function(|_, n: u16| Ok(Constraint(ratatui::layout::Constraint::Min(n))))?,
-			),
-			(
-				"Max",
-				lua.create_function(|_, n: u16| Ok(Constraint(ratatui::layout::Constraint::Max(n))))?,
-			),
-			(
-				"Length",
-				lua.create_function(|_, n: u16| Ok(Constraint(ratatui::layout::Constraint::Length(n))))?,
-			),
-			(
-				"Percentage",
-				lua.create_function(|_, n: u16| {
-					Ok(Constraint(ratatui::layout::Constraint::Percentage(n)))
-				})?,
-			),
-			(
-				"Ratio",
-				lua.create_function(|_, (a, b): (u32, u32)| {
-					Ok(Constraint(ratatui::layout::Constraint::Ratio(a, b)))
-				})?,
-			),
-			(
-				"Fill",
-				lua.create_function(|_, n: u16| Ok(Constraint(ratatui::layout::Constraint::Fill(n))))?,
-			),
-		])?;
-
-		ui.raw_set("Constraint", constraint)
+	pub fn install(_: &Lua, ui: &Table) -> mlua::Result<()> {
+		ui.raw_set("Constraint", Constraint::default())
 	}
 }
 
@@ -44,4 +13,15 @@ impl From<Constraint> for ratatui::layout::Constraint {
 	fn from(value: Constraint) -> Self { value.0 }
 }
 
-impl UserData for Constraint {}
+impl UserData for Constraint {
+	fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
+		use ratatui::layout::Constraint as C;
+
+		methods.add_function("Min", |_, n: u16| Ok(Self(C::Min(n))));
+		methods.add_function("Max", |_, n: u16| Ok(Self(C::Max(n))));
+		methods.add_function("Length", |_, n: u16| Ok(Self(C::Length(n))));
+		methods.add_function("Percentage", |_, n: u16| Ok(Self(C::Percentage(n))));
+		methods.add_function("Ratio", |_, (a, b): (u32, u32)| Ok(Self(C::Ratio(a, b))));
+		methods.add_function("Fill", |_, n: u16| Ok(Self(C::Fill(n))));
+	}
+}

--- a/yazi-plugin/src/elements/gauge.rs
+++ b/yazi-plugin/src/elements/gauge.rs
@@ -16,10 +16,7 @@ pub struct Gauge {
 
 impl Gauge {
 	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {
-		ui.raw_set(
-			"Gauge",
-			lua.create_function(|_, area: Rect| Ok(Gauge { area, ..Default::default() }))?,
-		)
+		ui.raw_set("Gauge", lua.create_function(|_, ()| Ok(Gauge::default()))?)
 	}
 }
 

--- a/yazi-plugin/src/elements/span.rs
+++ b/yazi-plugin/src/elements/span.rs
@@ -1,17 +1,32 @@
-use mlua::{FromLua, Lua, Table, UserData, UserDataMethods};
+use mlua::{ExternalError, FromLua, Lua, Table, UserData, UserDataMethods, Value};
 use unicode_width::UnicodeWidthChar;
+
+const EXPECTED: &str = "expected a string or ui.Span";
 
 #[derive(Clone, FromLua)]
 pub struct Span(pub(super) ratatui::text::Span<'static>);
 
 impl Span {
 	pub fn install(lua: &Lua, ui: &Table) -> mlua::Result<()> {
-		ui.raw_set(
-			"Span",
-			lua.create_function(|_, content: mlua::String| {
-				Ok(Self(ratatui::text::Span::raw(content.to_string_lossy().into_owned())))
-			})?,
-		)
+		ui.raw_set("Span", lua.create_function(|_, value: Value| Span::try_from(value))?)
+	}
+}
+
+impl TryFrom<Value<'_>> for Span {
+	type Error = mlua::Error;
+
+	fn try_from(value: Value<'_>) -> Result<Self, Self::Error> {
+		Ok(Self(match value {
+			Value::String(s) => s.to_string_lossy().into_owned().into(),
+			Value::UserData(ud) => {
+				if let Ok(span) = ud.take::<Span>() {
+					span.0
+				} else {
+					Err(EXPECTED.into_lua_err())?
+				}
+			}
+			_ => Err(EXPECTED.into_lua_err())?,
+		}))
 	}
 }
 


### PR DESCRIPTION
Before version 0.4, `ui.List`, `ui.Bar`, `ui.Border`, and `ui.Gauge` required an `area` parameter to specify the element's position in the terminal. While this worked fine in most cases, a few issues arose:

- **Limited flexibility:** These elements could not exist independently without being tied to specific coordinates.  
- **Redundant calculations:** Coordinates had to be computed before constructing the elements, even though the same calculations are done again during rendering, impacting performance.  
- **Inflexibility with dynamic layouts:** It was difficult to apply dynamic coordinates on the Rust side. Whenever the terminal size or layout area changed, a Lua function had to be called to recalculate coordinates, as the `area` needed to be passed from the Lua side.  

This PR removes the `area` parameter from the constructors of these elements, making it optional. 

Now, if Lua needs to explicitly set coordinates, it can use the `:area()` method, allowing these elements to be created without requiring coordinates upfront.

## ⚠️ Breaking changes

**The doc now updated to reflect the API changes in v0.4: https://yazi-rs.github.io/docs/plugins/layout**

```diff
- ui.List(area, items)
+ ui.List(items):area(area)
```

```diff
- ui.Bar(area, ui.Bar.TOP)
+ ui.Bar(ui.Bar.TOP):area(area)
```

```diff
- ui.Border(area, ui.Border.ALL)
+ ui.Border(ui.Border.ALL):area(area)
```

```diff
- ui.Gauge(area)
+ ui.Gauge():area(area)
```