### PR TITLE
Add Command.which(cmd) function to lua interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,6 +3398,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.2.0",
  "uzers",
+ "which",
  "yazi-adapter",
  "yazi-boot",
  "yazi-config",

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -39,6 +39,7 @@ tokio-stream  = { workspace = true }
 tokio-util    = { workspace = true }
 tracing       = { workspace = true }
 unicode-width = { workspace = true }
+which = "6.0.3"
 yazi-prebuild = "0.1.2"
 
 [target."cfg(unix)".dependencies]

--- a/yazi-plugin/src/process/command.rs
+++ b/yazi-plugin/src/process/command.rs
@@ -23,12 +23,17 @@ impl Command {
 			Ok(Self { inner })
 		})?;
 
+		let which = lua.create_function(|_, (program,): (String,)| {
+			Ok(which::which(program).ok().and_then(|path| path.to_str().map(str::to_string)))
+		})?;
+
 		let command = lua.create_table_from([
 			// Stdio
 			("NULL", NULL),
 			("PIPED", PIPED),
 			("INHERIT", INHERIT),
 		])?;
+		command.raw_set("which", which)?;
 
 		command.set_metatable(Some(lua.create_table_from([("__call", new)])?));
 


### PR DESCRIPTION
I added the which function to the global Command table, which simply resolves the path for the command passed as an argument and returns nil if it can't find it.

An example of usage is:
```lua
local bin = Command.which('yazi')
if not bin then
  error('yazi not found')
end
```