### PR TITLE
fix: wrong file list offset squeeze when `scrolloff = 0`

### DIFF
--- a/yazi-fs/src/folder.rs
+++ b/yazi-fs/src/folder.rs
@@ -149,7 +149,7 @@ impl Folder {
 		self.offset = if self.cursor < (self.offset + limit).min(len).saturating_sub(scrolloff) {
 			len.saturating_sub(limit).min(self.offset)
 		} else {
-			len.saturating_sub(limit).min(self.cursor.saturating_sub(limit) + scrolloff)
+			len.saturating_sub(limit).min(self.cursor.saturating_sub(limit) + 1 + scrolloff)
 		};
 
 		old != self.offset


### PR DESCRIPTION
this pr fix:

wrong file list offset squeeze (#1865)