### PR TITLE
feat: new `copy --separator` option to allow specifying the path separator

### DIFF
--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -1,4 +1,7 @@
 use std::ffi::{OsStr, OsString};
+#[cfg(target_os = "windows")]
+use std::path::Component;
+use std::path::Path;
 
 use yazi_plugin::CLIPBOARD;
 use yazi_shared::event::Cmd;
@@ -7,10 +10,13 @@ use crate::tab::Tab;
 
 struct Opt {
 	type_: String,
+	separator: PathSeparator,
 }
 
 impl From<Cmd> for Opt {
-	fn from(mut c: Cmd) -> Self { Self { type_: c.take_first_str().unwrap_or_default() } }
+	fn from(mut c: Cmd) -> Self {
+		Self { type_: c.take_first_str().unwrap_or_default(), separator: PathSeparator::from(&c) }
+	}
 }
 
 impl Tab {
@@ -24,8 +30,8 @@ impl Tab {
 		let mut it = self.selected_or_hovered(true).peekable();
 		while let Some(u) = it.next() {
 			s.push(match opt.type_.as_str() {
-				"path" => u.as_os_str(),
-				"dirname" => u.parent().map_or(OsStr::new(""), |p| p.as_os_str()),
+				"path" => path_to_os_str(u, opt.separator),
+				"dirname" => u.parent().map_or(OsStr::new(""), |p| path_to_os_str(p, opt.separator)),
 				"filename" => u.name(),
 				"name_without_ext" => u.file_stem().unwrap_or(OsStr::new("")),
 				_ => return,
@@ -41,5 +47,105 @@ impl Tab {
 		}
 
 		futures::executor::block_on(CLIPBOARD.set(s));
+	}
+}
+
+#[derive(Default, Clone, Copy)]
+enum PathSeparator {
+	Unix,
+	#[default]
+	Auto,
+}
+
+impl From<&Cmd> for PathSeparator {
+	fn from(c: &Cmd) -> Self {
+		match c.str("separator") {
+			Some("unix") => PathSeparator::Unix,
+			Some("auto") => PathSeparator::Auto,
+			_ => Default::default(),
+		}
+	}
+}
+
+#[cfg(not(target_os = "windows"))]
+fn path_to_os_str(path: &Path, _separator: PathSeparator) -> &OsStr {
+	return path.as_os_str();
+}
+
+#[cfg(target_os = "windows")]
+fn path_to_os_str(path: &Path, separator: PathSeparator) -> &OsStr {
+	if let PathSeparator::Auto = separator {
+		return path.as_os_str();
+	};
+
+	let mut s = OsString::new();
+	for component in path.components() {
+		match component {
+			Component::RootDir => {}
+			Component::CurDir => s.push("."),
+			Component::ParentDir => s.push(".."),
+			Component::Normal(path) => s.push(path),
+			Component::Prefix(prefix) => {
+				// "C:\foo" => [Prefix("C:"), RootDir, Normal(foo)]
+				s.push(prefix.as_os_str());
+				// If we push a "/" below, we will met a RootDir and push a "/"
+				// again resulting in "C://". So we need to skip that.
+				continue;
+			}
+		};
+		s.push("/");
+	}
+
+	return s.as_os_str();
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+
+	use super::*;
+
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn test_path_to_os_str_windows_auto() {
+		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
+		assert_eq!(
+			path_to_os_str(&path, PathSeparator::Auto),
+			"C:\\Users\\JohnDoe\\Downloads\\image.png",
+			"windows-auto",
+		);
+	}
+
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn test_path_to_os_str_windows_unix() {
+		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
+		assert_eq!(
+			path_to_os_str(&path, PathSeparator::Unix),
+			"C:/Users/JohnDow/Downloads/image.png",
+			"windows-unix",
+		);
+	}
+
+	#[cfg(not(target_os = "windows"))]
+	#[test]
+	fn test_path_to_os_str_unix_auto() {
+		let path = PathBuf::from("/home/johndoe/Downloads/image.png");
+		assert_eq!(
+			path_to_os_str(&path, PathSeparator::Auto),
+			"/home/johndoe/Downloads/image.png",
+			"unix-auto"
+		);
+	}
+
+	#[cfg(not(target_os = "windows"))]
+	#[test]
+	fn test_path_to_os_str_unix_unix() {
+		let path = PathBuf::from("/home/johndoe/Downloads/image.png");
+		assert_eq!(
+			path_to_os_str(&path, PathSeparator::Unix),
+			"/home/johndoe/Downloads/image.png",
+			"unix-unix"
+		);
 	}
 }

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -150,7 +150,7 @@ mod tests {
 		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
 		assert_eq!(
 			path_to_os_str(&path, PathSeparator::Unix).to_str(),
-			Some("C:/Users/JohnDow/Downloads/image.png"),
+			Some("C:/Users/JohnDoe/Downloads/image.png"),
 			"windows-unix",
 		);
 	}

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -91,9 +91,11 @@ fn path_to_os_str(path: &Path, _separator: PathSeparator) -> Cow<'_, OsStr> {
 
 #[cfg(windows)]
 fn path_to_os_str(path: &Path, separator: PathSeparator) -> Cow<'_, OsStr> {
+	use yazi_shared::fs::backslash_to_slash;
+
 	match separator {
 		PathSeparator::Auto => Cow::Borrowed(path.as_os_str()),
-		PathSeparator::Unix => match yazi_shared::fs::path::backslash_to_slash(path) {
+		PathSeparator::Unix => match backslash_to_slash(path) {
 			Cow::Borrowed(path) => Cow::Borrowed(path.as_os_str()),
 			Cow::Owned(path) => Cow::Owned(OsString::from(path)),
 		},
@@ -106,7 +108,7 @@ mod tests {
 
 	use super::*;
 
-	#[cfg(target_os = "windows")]
+	#[cfg(windows)]
 	#[test]
 	fn test_path_to_os_str_windows_auto() {
 		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
@@ -117,7 +119,7 @@ mod tests {
 		);
 	}
 
-	#[cfg(target_os = "windows")]
+	#[cfg(windows)]
 	#[test]
 	fn test_path_to_os_str_windows_unix() {
 		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
@@ -128,7 +130,7 @@ mod tests {
 		);
 	}
 
-	#[cfg(not(target_os = "windows"))]
+	#[cfg(unix)]
 	#[test]
 	fn test_path_to_os_str_unix_auto() {
 		let path = PathBuf::from("/home/johndoe/Downloads/image.png");
@@ -139,7 +141,7 @@ mod tests {
 		);
 	}
 
-	#[cfg(not(target_os = "windows"))]
+	#[cfg(unix)]
 	#[test]
 	fn test_path_to_os_str_unix_unix() {
 		let path = PathBuf::from("/home/johndoe/Downloads/image.png");

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::{borrow::Cow, ffi::{OsStr, OsString}, path::Path};
 
 use yazi_plugin::CLIPBOARD;
 use yazi_shared::event::Cmd;
@@ -8,13 +6,16 @@ use yazi_shared::event::Cmd;
 use crate::tab::Tab;
 
 struct Opt {
-	type_: String,
-	separator: PathSeparator,
+	type_:     String,
+	separator: Separator,
 }
 
 impl From<Cmd> for Opt {
 	fn from(mut c: Cmd) -> Self {
-		Self { type_: c.take_first_str().unwrap_or_default(), separator: PathSeparator::from(&c) }
+		Self {
+			type_:     c.take_first_str().unwrap_or_default(),
+			separator: c.str("separator").unwrap_or_default().into(),
+		}
 	}
 }
 
@@ -28,31 +29,13 @@ impl Tab {
 		let mut s = OsString::new();
 		let mut it = self.selected_or_hovered(true).peekable();
 		while let Some(u) = it.next() {
-			match opt.type_.as_str() {
-				"path" => {
-					match path_to_os_str(u, opt.separator) {
-						Cow::Borrowed(p) => s.push(p),
-						Cow::Owned(p) => s.push(&p),
-					};
-				}
-				"dirname" => {
-					if let Some(parent) = u.parent() {
-						match path_to_os_str(parent, opt.separator) {
-							Cow::Borrowed(p) => s.push(p),
-							Cow::Owned(p) => s.push(&p),
-						};
-					}
-				}
-				"filename" => {
-					s.push(u.name());
-				}
-				"name_without_ext" => {
-					if let Some(stem) = u.file_stem() {
-						s.push(stem);
-					}
-				}
+			s.push(match opt.type_.as_str() {
+				"path" => opt.separator.transform(u),
+				"dirname" => opt.separator.transform(u.parent().unwrap_or(Path::new(""))),
+				"filename" => opt.separator.transform(u.name()),
+				"name_without_ext" => opt.separator.transform(u.file_stem().unwrap_or_default()),
 				_ => return,
-			}
+			});
 			if it.peek().is_some() {
 				s.push("\n");
 			}
@@ -67,88 +50,31 @@ impl Tab {
 	}
 }
 
-#[derive(Default, Clone, Copy)]
-enum PathSeparator {
-	Unix,
-	#[default]
+// --- Separator
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Separator {
 	Auto,
+	Unix,
 }
 
-impl From<&Cmd> for PathSeparator {
-	fn from(c: &Cmd) -> Self {
-		match c.str("separator") {
-			Some("unix") => PathSeparator::Unix,
-			Some("auto") => PathSeparator::Auto,
-			_ => Default::default(),
+impl From<&str> for Separator {
+	fn from(value: &str) -> Self {
+		match value {
+			"unix" => Self::Unix,
+			_ => Self::Auto,
 		}
 	}
 }
 
-#[cfg(unix)]
-fn path_to_os_str(path: &Path, _separator: PathSeparator) -> Cow<'_, OsStr> {
-	Cow::Borrowed(path.as_os_str())
-}
-
-#[cfg(windows)]
-fn path_to_os_str(path: &Path, separator: PathSeparator) -> Cow<'_, OsStr> {
-	use yazi_shared::fs::backslash_to_slash;
-
-	match separator {
-		PathSeparator::Auto => Cow::Borrowed(path.as_os_str()),
-		PathSeparator::Unix => match backslash_to_slash(path) {
-			Cow::Borrowed(path) => Cow::Borrowed(path.as_os_str()),
-			Cow::Owned(path) => Cow::Owned(OsString::from(path)),
-		},
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use std::path::PathBuf;
-
-	use super::*;
-
-	#[cfg(windows)]
-	#[test]
-	fn test_path_to_os_str_windows_auto() {
-		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
-		assert_eq!(
-			path_to_os_str(&path, PathSeparator::Auto).to_str(),
-			Some("C:\\Users\\JohnDoe\\Downloads\\image.png"),
-			"windows-auto",
-		);
-	}
-
-	#[cfg(windows)]
-	#[test]
-	fn test_path_to_os_str_windows_unix() {
-		let path = PathBuf::from("C:\\Users\\JohnDoe\\Downloads\\image.png");
-		assert_eq!(
-			path_to_os_str(&path, PathSeparator::Unix).to_str(),
-			Some("C:/Users/JohnDoe/Downloads/image.png"),
-			"windows-unix",
-		);
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn test_path_to_os_str_unix_auto() {
-		let path = PathBuf::from("/home/johndoe/Downloads/image.png");
-		assert_eq!(
-			path_to_os_str(&path, PathSeparator::Auto).to_str(),
-			Some("/home/johndoe/Downloads/image.png"),
-			"unix-auto"
-		);
-	}
-
-	#[cfg(unix)]
-	#[test]
-	fn test_path_to_os_str_unix_unix() {
-		let path = PathBuf::from("/home/johndoe/Downloads/image.png");
-		assert_eq!(
-			path_to_os_str(&path, PathSeparator::Unix).to_str(),
-			Some("/home/johndoe/Downloads/image.png"),
-			"unix-unix"
-		);
+impl Separator {
+	fn transform<T: AsRef<Path> + ?Sized>(self, p: &T) -> Cow<OsStr> {
+		#[cfg(windows)]
+		if self == Self::Unix {
+			return match yazi_shared::fs::backslash_to_slash(p.as_ref()) {
+				Cow::Owned(p) => Cow::Owned(p.into_os_string()),
+				Cow::Borrowed(p) => Cow::Borrowed(p.as_os_str()),
+			};
+		}
+		Cow::Borrowed(p.as_ref().as_os_str())
 	}
 }


### PR DESCRIPTION
resolves #1861 

This PR adds support for choosing the path separator for the copy command between:
- `auto`: uses `/` on Unix-like systems and `\` on Windows
- `unix`: forces forward slashes (`/`) in the path copied to the user's clipboard

## Note

EDIT: The tests in CI passes! So it should be working now. 

I havn't written mcuh cross-platform Rust code, and I'm unsure how to run tests targeted for Windows on my Linux machine 😅. Any advice or extra caution during review would be appreciated.