### PR TITLE
feat: include package revision hash in `ya pack --list`

### DIFF
--- a/yazi-cli/src/package/parser.rs
+++ b/yazi-cli/src/package/parser.rs
@@ -81,9 +81,13 @@ impl Package {
 		println!("{section}s:");
 
 		for dep in deps {
-			if let Some(Value::String(use_)) = dep.as_inline_table().and_then(|t| t.get("use")) {
-				println!("\t{}", use_.value());
-			}
+			let Some(Value::String(use_)) = dep.as_inline_table().and_then(|t| t.get("use")) else {
+				return Ok(());
+			};
+			let Some(Value::String(rev)) = dep.as_inline_table().and_then(|t| t.get("rev")) else {
+				return Ok(());
+			};
+			println!("\t{} ({})", use_.value(), rev.value());
 		}
 		Ok(())
 	}

--- a/yazi-shared/src/event/cmd.rs
+++ b/yazi-shared/src/event/cmd.rs
@@ -57,20 +57,16 @@ impl Cmd {
 	pub fn get(&self, name: &str) -> Option<&Data> { self.args.get(name) }
 
 	#[inline]
-	pub fn str(&self, name: &str) -> Option<&str> { self.args.get(name).and_then(Data::as_str) }
+	pub fn str(&self, name: &str) -> Option<&str> { self.get(name).and_then(Data::as_str) }
 
 	#[inline]
-	pub fn bool(&self, name: &str) -> bool {
-		self.args.get(name).and_then(Data::as_bool).unwrap_or(false)
-	}
+	pub fn bool(&self, name: &str) -> bool { self.maybe_bool(name).unwrap_or(false) }
 
 	#[inline]
-	pub fn maybe_bool(&self, name: &str) -> Option<bool> {
-		self.args.get(name).and_then(Data::as_bool)
-	}
+	pub fn maybe_bool(&self, name: &str) -> Option<bool> { self.get(name).and_then(Data::as_bool) }
 
 	#[inline]
-	pub fn first(&self) -> Option<&Data> { self.args.get("0") }
+	pub fn first(&self) -> Option<&Data> { self.get("0") }
 
 	// --- Take
 	#[inline]
@@ -78,15 +74,15 @@ impl Cmd {
 
 	#[inline]
 	pub fn take_str(&mut self, name: &str) -> Option<String> {
-		if let Some(Data::String(s)) = self.args.remove(name) { Some(s) } else { None }
+		if let Some(Data::String(s)) = self.take(name) { Some(s) } else { None }
 	}
 
 	#[inline]
-	pub fn take_first(&mut self) -> Option<Data> { self.args.remove("0") }
+	pub fn take_first(&mut self) -> Option<Data> { self.take("0") }
 
 	#[inline]
 	pub fn take_first_str(&mut self) -> Option<String> {
-		if let Some(Data::String(s)) = self.args.remove("0") { Some(s) } else { None }
+		if let Some(Data::String(s)) = self.take_first() { Some(s) } else { None }
 	}
 
 	#[inline]


### PR DESCRIPTION
resolves #1881 

When using `ya pack -l`, show commit hash.

Before(don't show commit hash)
```
$ ya pack -l
plugins:
	GrzegorzKozub/mdcat
flavors:
	yazi-rs/flavors:catppuccin-mocha
```

After(show commit hash)
```
$ ya pack -l
plugins:
	GrzegorzKozub/mdcat (78cef96)
flavors:
	yazi-rs/flavors:catppuccin-mocha (d504f70)
```
# Note
This content is specific to my environment, so please don't worry about it.