### PR TITLE
feat: support customizable alignment for image display

### DIFF
--- a/yazi-adapter/src/adapter.rs
+++ b/yazi-adapter/src/adapter.rs
@@ -5,7 +5,7 @@ use ratatui::layout::Rect;
 use tracing::warn;
 use yazi_shared::env_exists;
 
-use crate::{Brand, Emulator, SHOWN, TMUX, WSL, drivers};
+use crate::{Brand, Emulator, Offset, SHOWN, TMUX, WSL, drivers};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Adapter {
@@ -35,18 +35,18 @@ impl Display for Adapter {
 }
 
 impl Adapter {
-	pub async fn image_show(self, path: &Path, max: Rect) -> Result<Rect> {
+	pub async fn image_show(self, path: &Path, max: Rect, offset: Option<Offset>) -> Result<Rect> {
 		if max.is_empty() {
 			return Ok(Rect::default());
 		}
 
 		match self {
-			Self::Kgp => drivers::Kgp::image_show(path, max).await,
-			Self::KgpOld => drivers::KgpOld::image_show(path, max).await,
-			Self::Iip => drivers::Iip::image_show(path, max).await,
-			Self::Sixel => drivers::Sixel::image_show(path, max).await,
-			Self::X11 | Self::Wayland => drivers::Ueberzug::image_show(path, max).await,
-			Self::Chafa => drivers::Chafa::image_show(path, max).await,
+			Self::Kgp => drivers::Kgp::image_show(path, max, offset).await,
+			Self::KgpOld => drivers::KgpOld::image_show(path, max, offset).await,
+			Self::Iip => drivers::Iip::image_show(path, max, offset).await,
+			Self::Sixel => drivers::Sixel::image_show(path, max, offset).await,
+			Self::X11 | Self::Wayland => drivers::Ueberzug::image_show(path, max, offset).await,
+			Self::Chafa => drivers::Chafa::image_show(path, max, offset).await,
 		}
 	}
 

--- a/yazi-adapter/src/drivers/iip.rs
+++ b/yazi-adapter/src/drivers/iip.rs
@@ -7,14 +7,14 @@ use image::{DynamicImage, ExtendedColorType, ImageEncoder, codecs::{jpeg::JpegEn
 use ratatui::layout::Rect;
 use yazi_config::PREVIEW;
 
-use crate::{CLOSE, Emulator, Image, START, adapter::Adapter};
+use crate::{CLOSE, Emulator, Image, Offset, START, adapter::Adapter};
 
 pub(crate) struct Iip;
 
 impl Iip {
-	pub(crate) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+	pub(crate) async fn image_show(path: &Path, max: Rect, offset: Option<Offset>) -> Result<Rect> {
 		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let area = Image::pixel_area((img.width(), img.height()), max, offset);
 		let b = Self::encode(img).await?;
 
 		Adapter::Iip.image_hide()?;

--- a/yazi-adapter/src/drivers/kgp.rs
+++ b/yazi-adapter/src/drivers/kgp.rs
@@ -7,7 +7,7 @@ use crossterm::{cursor::MoveTo, queue};
 use image::DynamicImage;
 use ratatui::layout::Rect;
 
-use crate::{CLOSE, ESCAPE, Emulator, START, adapter::Adapter, image::Image};
+use crate::{CLOSE, ESCAPE, Emulator, Offset, START, adapter::Adapter, image::Image};
 
 static DIACRITICS: [char; 297] = [
 	'\u{0305}',
@@ -312,9 +312,9 @@ static DIACRITICS: [char; 297] = [
 pub(crate) struct Kgp;
 
 impl Kgp {
-	pub(crate) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+	pub(crate) async fn image_show(path: &Path, max: Rect, offset: Option<Offset>) -> Result<Rect> {
 		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let area = Image::pixel_area((img.width(), img.height()), max, offset);
 
 		let b1 = Self::encode(img).await?;
 		let b2 = Self::place(&area)?;

--- a/yazi-adapter/src/drivers/kgp_old.rs
+++ b/yazi-adapter/src/drivers/kgp_old.rs
@@ -6,14 +6,14 @@ use base64::{Engine, engine::general_purpose};
 use image::DynamicImage;
 use ratatui::layout::Rect;
 
-use crate::{CLOSE, ESCAPE, Emulator, Image, START, adapter::Adapter};
+use crate::{CLOSE, ESCAPE, Emulator, Image, Offset, START, adapter::Adapter};
 
 pub(crate) struct KgpOld;
 
 impl KgpOld {
-	pub(crate) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+	pub(crate) async fn image_show(path: &Path, max: Rect, offset: Option<Offset>) -> Result<Rect> {
 		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let area = Image::pixel_area((img.width(), img.height()), max, offset);
 		let b = Self::encode(img).await?;
 
 		Adapter::KgpOld.image_hide()?;

--- a/yazi-adapter/src/drivers/sixel.rs
+++ b/yazi-adapter/src/drivers/sixel.rs
@@ -7,14 +7,14 @@ use image::DynamicImage;
 use ratatui::layout::Rect;
 use yazi_config::PREVIEW;
 
-use crate::{CLOSE, ESCAPE, Emulator, Image, START, adapter::Adapter};
+use crate::{CLOSE, ESCAPE, Emulator, Image, Offset, START, adapter::Adapter};
 
 pub(crate) struct Sixel;
 
 impl Sixel {
-	pub(crate) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
+	pub(crate) async fn image_show(path: &Path, max: Rect, offset: Option<Offset>) -> Result<Rect> {
 		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let area = Image::pixel_area((img.width(), img.height()), max, offset);
 		let b = Self::encode(img).await?;
 
 		Adapter::Sixel.image_hide()?;

--- a/yazi-adapter/src/image.rs
+++ b/yazi-adapter/src/image.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use image::{DynamicImage, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageReader, ImageResult, Limits, codecs::{jpeg::JpegEncoder, png::PngEncoder}, imageops::FilterType, metadata::Orientation};
-use ratatui::layout::Rect;
+use ratatui::layout::{Rect, Size};
 use yazi_config::{PREVIEW, TASKS};
 
-use crate::Dimension;
+use crate::{Dimension, Offset};
 
 pub struct Image;
 
@@ -73,13 +73,15 @@ impl Image {
 			.unwrap_or((PREVIEW.max_width, PREVIEW.max_height))
 	}
 
-	pub(super) fn pixel_area(size: (u32, u32), rect: Rect) -> Rect {
+	pub(super) fn pixel_area(size: (u32, u32), rect: Rect, offset: Option<Offset>) -> Rect {
 		Dimension::ratio()
-			.map(|(r1, r2)| Rect {
-				x:      rect.x,
-				y:      rect.y,
-				width:  (size.0 as f64 / r1).ceil() as u16,
-				height: (size.1 as f64 / r2).ceil() as u16,
+			.map(|(r1, r2)| {
+				let width = (size.0 as f64 / r1).ceil() as u16;
+				let height = (size.1 as f64 / r2).ceil() as u16;
+				let offset = offset.unwrap_or_else(|| {
+					Offset::from((Size { width, height }, Size { width: rect.width, height: rect.height }))
+				});
+				Rect { x: rect.x + offset.x, y: rect.y + offset.y, width, height }
 			})
 			.unwrap_or(rect)
 	}

--- a/yazi-adapter/src/lib.rs
+++ b/yazi-adapter/src/lib.rs
@@ -2,7 +2,7 @@
 
 yazi_macro::mod_pub!(drivers);
 
-yazi_macro::mod_flat!(adapter brand dimension emulator image info mux unknown);
+yazi_macro::mod_flat!(adapter brand dimension emulator image info mux offset unknown);
 
 use yazi_shared::{RoCell, SyncCell, env_exists, in_wsl};
 

--- a/yazi-adapter/src/offset.rs
+++ b/yazi-adapter/src/offset.rs
@@ -1,0 +1,26 @@
+use ratatui::layout::Size;
+use yazi_config::{PREVIEW, preview::{HorizontalAlignment, VerticalAlignment}};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Offset {
+	pub x: u16,
+	pub y: u16,
+}
+
+impl From<(Size, Size)> for Offset {
+	fn from(value: (Size, Size)) -> Self {
+		let inner = value.0;
+		let outer = value.1;
+		let offset_x = match PREVIEW.alignment.horizontal {
+			HorizontalAlignment::Left => 0,
+			HorizontalAlignment::Center => (outer.width - inner.width) / 2,
+			HorizontalAlignment::Right => outer.width - inner.width,
+		};
+		let offset_y = match PREVIEW.alignment.vertical {
+			VerticalAlignment::Top => 0,
+			VerticalAlignment::Center => (outer.height - inner.height) / 2,
+			VerticalAlignment::Bottom => outer.height - inner.height,
+		};
+		Self { x: offset_x, y: offset_y }
+	}
+}

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -3,214 +3,215 @@
 "$schema" = "https://yazi-rs.github.io/schemas/yazi.json"
 
 [manager]
-ratio          = [ 1, 4, 3 ]
-sort_by        = "alphabetical"
+ratio = [1, 4, 3]
+sort_by = "alphabetical"
 sort_sensitive = false
-sort_reverse 	 = false
+sort_reverse = false
 sort_dir_first = true
-sort_translit  = false
-linemode       = "none"
-show_hidden    = false
-show_symlink   = true
-scrolloff      = 5
-mouse_events   = [ "click", "scroll" ]
-title_format   = "Yazi: {cwd}"
+sort_translit = false
+linemode = "none"
+show_hidden = false
+show_symlink = true
+scrolloff = 5
+mouse_events = ["click", "scroll"]
+title_format = "Yazi: {cwd}"
 
 [preview]
-wrap            = "no"
-tab_size        = 2
-max_width       = 600
-max_height      = 900
-cache_dir       = ""
-image_delay     = 30
-image_filter    = "triangle"
-image_quality   = 75
-sixel_fraction  = 15
-ueberzug_scale  = 1
-ueberzug_offset = [ 0, 0, 0, 0 ]
+wrap = "no"
+tab_size = 2
+max_width = 600
+max_height = 900
+alignment = { horizontal = "center", vertical = "top" }
+cache_dir = ""
+image_delay = 30
+image_filter = "triangle"
+image_quality = 75
+sixel_fraction = 15
+ueberzug_scale = 1
+ueberzug_offset = [0, 0, 0, 0]
 
 [opener]
 edit = [
-	{ run = '${EDITOR:-vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
-	{ run = 'code %*',    orphan = true, desc = "code",           for = "windows" },
-	{ run = 'code -w %*', block = true,  desc = "code (block)",   for = "windows" },
+    { run = '${EDITOR:-vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
+    { run = 'code %*', orphan = true, desc = "code", for = "windows" },
+    { run = 'code -w %*', block = true, desc = "code (block)", for = "windows" },
 ]
 open = [
-	{ run = 'xdg-open "$1"',                desc = "Open", for = "linux" },
-	{ run = 'open "$@"',                    desc = "Open", for = "macos" },
-	{ run = 'start "" "%1"', orphan = true, desc = "Open", for = "windows" },
+    { run = 'xdg-open "$1"', desc = "Open", for = "linux" },
+    { run = 'open "$@"', desc = "Open", for = "macos" },
+    { run = 'start "" "%1"', orphan = true, desc = "Open", for = "windows" },
 ]
 reveal = [
-	{ run = 'xdg-open "$(dirname "$1")"',           desc = "Reveal", for = "linux" },
-	{ run = 'open -R "$1"',                         desc = "Reveal", for = "macos" },
-	{ run = 'explorer /select,"%1"', orphan = true, desc = "Reveal", for = "windows" },
-	{ run = '''exiftool "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show EXIF", for = "unix" },
+    { run = 'xdg-open "$(dirname "$1")"', desc = "Reveal", for = "linux" },
+    { run = 'open -R "$1"', desc = "Reveal", for = "macos" },
+    { run = 'explorer /select,"%1"', orphan = true, desc = "Reveal", for = "windows" },
+    { run = '''exiftool "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show EXIF", for = "unix" },
 ]
 extract = [
-	{ run = 'ya pub extract --list "$@"', desc = "Extract here", for = "unix" },
-	{ run = 'ya pub extract --list %*',   desc = "Extract here", for = "windows" },
+    { run = 'ya pub extract --list "$@"', desc = "Extract here", for = "unix" },
+    { run = 'ya pub extract --list %*', desc = "Extract here", for = "windows" },
 ]
 play = [
-	{ run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
-	{ run = 'mpv --force-window %*', orphan = true, for = "windows" },
-	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
+    { run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
+    { run = 'mpv --force-window %*', orphan = true, for = "windows" },
+    { run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
 
 [open]
 rules = [
-	# Folder
-	{ name = "*/", use = [ "edit", "open", "reveal" ] },
-	# Text
-	{ mime = "text/*", use = [ "edit", "reveal" ] },
-	# Image
-	{ mime = "image/*", use = [ "open", "reveal" ] },
-	# Media
-	{ mime = "{audio,video}/*", use = [ "play", "reveal" ] },
-	# Archive
-	{ mime = "application/{,g}zip", use = [ "extract", "reveal" ] },
-	{ mime = "application/{tar,bzip*,7z*,xz,rar}", use = [ "extract", "reveal" ] },
-	# JSON
-	{ mime = "application/{json,ndjson}", use = [ "edit", "reveal" ] },
-	{ mime = "*/javascript", use = [ "edit", "reveal" ] },
-	# Empty file
-	{ mime = "inode/empty", use = [ "edit", "reveal" ] },
-	# Fallback
-	{ name = "*", use = [ "open", "reveal" ] },
+    # Folder
+    { name = "*/", use = ["edit", "open", "reveal"] },
+    # Text
+    { mime = "text/*", use = ["edit", "reveal"] },
+    # Image
+    { mime = "image/*", use = ["open", "reveal"] },
+    # Media
+    { mime = "{audio,video}/*", use = ["play", "reveal"] },
+    # Archive
+    { mime = "application/{,g}zip", use = ["extract", "reveal"] },
+    { mime = "application/{tar,bzip*,7z*,xz,rar}", use = ["extract", "reveal"] },
+    # JSON
+    { mime = "application/{json,ndjson}", use = ["edit", "reveal"] },
+    { mime = "*/javascript", use = ["edit", "reveal"] },
+    # Empty file
+    { mime = "inode/empty", use = ["edit", "reveal"] },
+    # Fallback
+    { name = "*", use = ["open", "reveal"] },
 ]
 
 [tasks]
-micro_workers    = 10
-macro_workers    = 25
-bizarre_retry    = 5
-image_alloc      = 536870912  # 512MB
-image_bound      = [ 0, 0 ]
+micro_workers = 10
+macro_workers = 25
+bizarre_retry = 5
+image_alloc = 536870912  # 512MB
+image_bound = [0, 0]
 suppress_preload = false
 
 [plugin]
 
 fetchers = [
-	# Mimetype
-	{ id = "mime", name = "*", run = "mime", if = "!mime", prio = "high" },
+    # Mimetype
+    { id = "mime", name = "*", run = "mime", if = "!mime", prio = "high" },
 ]
 spotters = [
-	{ name = "*/", run = "folder" },
-	# Code
-	{ mime = "text/*", run = "code" },
-	{ mime = "*/{xml,javascript,wine-extension-ini}", run = "code" },
-	# Image
-	{ mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
-	{ mime = "image/*", run = "image" },
-	# Video
-	{ mime = "video/*", run = "video" },
-	# Fallback
-	{ name = "*", run = "file" },
+    { name = "*/", run = "folder" },
+    # Code
+    { mime = "text/*", run = "code" },
+    { mime = "*/{xml,javascript,wine-extension-ini}", run = "code" },
+    # Image
+    { mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
+    { mime = "image/*", run = "image" },
+    # Video
+    { mime = "video/*", run = "video" },
+    # Fallback
+    { name = "*", run = "file" },
 ]
 preloaders = [
-	# Image
-	{ mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
-	{ mime = "image/*", run = "image" },
-	# Video
-	{ mime = "video/*", run = "video" },
-	# PDF
-	{ mime = "application/pdf", run = "pdf" },
-	# Font
-	{ mime = "font/*", run = "font" },
-	{ mime = "application/ms-opentype", run = "font" },
+    # Image
+    { mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
+    { mime = "image/*", run = "image" },
+    # Video
+    { mime = "video/*", run = "video" },
+    # PDF
+    { mime = "application/pdf", run = "pdf" },
+    # Font
+    { mime = "font/*", run = "font" },
+    { mime = "application/ms-opentype", run = "font" },
 ]
 previewers = [
-	{ name = "*/", run = "folder", sync = true },
-	# Code
-	{ mime = "text/*", run = "code" },
-	{ mime = "*/{xml,javascript,wine-extension-ini}", run = "code" },
-	# JSON
-	{ mime = "application/{json,ndjson}", run = "json" },
-	# Image
-	{ mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
-	{ mime = "image/*", run = "image" },
-	# Video
-	{ mime = "video/*", run = "video" },
-	# PDF
-	{ mime = "application/pdf", run = "pdf" },
-	# Archive
-	{ mime = "application/{,g}zip", run = "archive" },
-	{ mime = "application/{tar,bzip*,7z*,xz,rar,iso9660-image}", run = "archive" },
-	# Font
-	{ mime = "font/*", run = "font" },
-	{ mime = "application/ms-opentype", run = "font" },
-	# Empty file
-	{ mime = "inode/empty", run = "empty" },
-	# Fallback
-	{ name = "*", run = "file" },
+    { name = "*/", run = "folder", sync = true },
+    # Code
+    { mime = "text/*", run = "code" },
+    { mime = "*/{xml,javascript,wine-extension-ini}", run = "code" },
+    # JSON
+    { mime = "application/{json,ndjson}", run = "json" },
+    # Image
+    { mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
+    { mime = "image/*", run = "image" },
+    # Video
+    { mime = "video/*", run = "video" },
+    # PDF
+    { mime = "application/pdf", run = "pdf" },
+    # Archive
+    { mime = "application/{,g}zip", run = "archive" },
+    { mime = "application/{tar,bzip*,7z*,xz,rar,iso9660-image}", run = "archive" },
+    # Font
+    { mime = "font/*", run = "font" },
+    { mime = "application/ms-opentype", run = "font" },
+    # Empty file
+    { mime = "inode/empty", run = "empty" },
+    # Fallback
+    { name = "*", run = "file" },
 ]
 
 [input]
 cursor_blink = false
 
 # cd
-cd_title  = "Change directory:"
+cd_title = "Change directory:"
 cd_origin = "top-center"
-cd_offset = [ 0, 2, 50, 3 ]
+cd_offset = [0, 2, 50, 3]
 
 # create
-create_title  = [ "Create:", "Create (dir):" ]
+create_title = ["Create:", "Create (dir):"]
 create_origin = "top-center"
-create_offset = [ 0, 2, 50, 3 ]
+create_offset = [0, 2, 50, 3]
 
 # rename
-rename_title  = "Rename:"
+rename_title = "Rename:"
 rename_origin = "hovered"
-rename_offset = [ 0, 1, 50, 3 ]
+rename_offset = [0, 1, 50, 3]
 
 # filter
-filter_title  = "Filter:"
+filter_title = "Filter:"
 filter_origin = "top-center"
-filter_offset = [ 0, 2, 50, 3 ]
+filter_offset = [0, 2, 50, 3]
 
 # find
-find_title  = [ "Find next:", "Find previous:" ]
+find_title = ["Find next:", "Find previous:"]
 find_origin = "top-center"
-find_offset = [ 0, 2, 50, 3 ]
+find_offset = [0, 2, 50, 3]
 
 # search
-search_title  = "Search via {n}:"
+search_title = "Search via {n}:"
 search_origin = "top-center"
-search_offset = [ 0, 2, 50, 3 ]
+search_offset = [0, 2, 50, 3]
 
 # shell
-shell_title  = [ "Shell:", "Shell (block):" ]
+shell_title = ["Shell:", "Shell (block):"]
 shell_origin = "top-center"
-shell_offset = [ 0, 2, 50, 3 ]
+shell_offset = [0, 2, 50, 3]
 
 [confirm]
 # trash
-trash_title 	= "Trash {n} selected file{s}?"
-trash_origin	= "center"
-trash_offset	= [ 0, 0, 70, 20 ]
+trash_title = "Trash {n} selected file{s}?"
+trash_origin = "center"
+trash_offset = [0, 0, 70, 20]
 
 # delete
-delete_title 	= "Permanently delete {n} selected file{s}?"
-delete_origin	= "center"
-delete_offset	= [ 0, 0, 70, 20 ]
+delete_title = "Permanently delete {n} selected file{s}?"
+delete_origin = "center"
+delete_offset = [0, 0, 70, 20]
 
 # overwrite
-overwrite_title   = "Overwrite file?"
+overwrite_title = "Overwrite file?"
 overwrite_content = "Will overwrite the following file:"
-overwrite_origin  = "center"
-overwrite_offset  = [ 0, 0, 50, 15 ]
+overwrite_origin = "center"
+overwrite_offset = [0, 0, 50, 15]
 
 # quit
-quit_title   = "Quit?"
+quit_title = "Quit?"
 quit_content = "The following task is still running, are you sure you want to quit?"
-quit_origin  = "center"
-quit_offset  = [ 0, 0, 50, 15 ]
+quit_origin = "center"
+quit_offset = [0, 0, 50, 15]
 
 [pick]
-open_title  = "Open with:"
+open_title = "Open with:"
 open_origin = "hovered"
-open_offset = [ 0, 1, 50, 7 ]
+open_offset = [0, 1, 50, 7]
 
 [which]
-sort_by      	 = "none"
+sort_by = "none"
 sort_sensitive = false
-sort_reverse 	 = false
-sort_translit  = false
+sort_reverse = false
+sort_translit = false

--- a/yazi-config/src/preview/alignment.rs
+++ b/yazi-config/src/preview/alignment.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HorizontalAlignment {
+	Left,
+	#[default]
+	Center,
+	Right,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerticalAlignment {
+	#[default]
+	Top,
+	Center,
+	Bottom,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct Alignment {
+	#[serde(default)]
+	pub horizontal: HorizontalAlignment,
+	#[serde(default)]
+	pub vertical:   VerticalAlignment,
+}

--- a/yazi-config/src/preview/mod.rs
+++ b/yazi-config/src/preview/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(preview wrap);
+yazi_macro::mod_flat!(alignment preview wrap);

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -6,7 +6,7 @@ use validator::Validate;
 use yazi_fs::{Xdg, expand_path};
 use yazi_shared::timestamp_us;
 
-use super::PreviewWrap;
+use super::{Alignment, PreviewWrap};
 
 #[rustfmt::skip]
 const TABS: &[&str] = &["", " ", "  ", "   ", "    ", "     ", "      ", "       ", "        ", "         ", "          ", "           ", "            ", "             ", "              ", "               ", "                "];
@@ -17,6 +17,7 @@ pub struct Preview {
 	pub tab_size:   u8,
 	pub max_width:  u32,
 	pub max_height: u32,
+	pub alignment:  Alignment,
 
 	pub cache_dir: PathBuf,
 
@@ -72,6 +73,8 @@ impl<'de> Deserialize<'de> for Preview {
 			tab_size:   u8,
 			max_width:  u32,
 			max_height: u32,
+			#[serde(default)]
+			alignment:  Alignment,
 
 			cache_dir: Option<String>,
 
@@ -95,6 +98,7 @@ impl<'de> Deserialize<'de> for Preview {
 			tab_size:   preview.tab_size,
 			max_width:  preview.max_width,
 			max_height: preview.max_height,
+			alignment:  preview.alignment,
 
 			cache_dir: preview
 				.cache_dir


### PR DESCRIPTION
This is an attempt to provide a possible solution to #1141.

- Adds configuration options in `yazi.toml` for setting preferred image alignment, which plugin developers can optionally respect.
- Updates plugin defaults to use `PREVIEW.alignment` for aligned image display.
- Ensures backward compatibility for existing plugins.

It appears to work well overall, though some aspects remain unclear:
1. Does the current use of `serde` align with usual practices?
2. Are the new Lua API function consistent with current design philosophy?