### PR TITLE
refactor(adapter): extract `image_area` from `image_show`

### DIFF
--- a/yazi-adapter/src/adapter.rs
+++ b/yazi-adapter/src/adapter.rs
@@ -5,7 +5,7 @@ use ratatui::layout::Rect;
 use tracing::warn;
 use yazi_shared::env_exists;
 
-use super::{Iip, Kgp, KgpOld};
+use super::{Iip, Image, Kgp, KgpOld};
 use crate::{Chafa, Emulator, SHOWN, Sixel, TMUX, Ueberzug, WSL};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -36,6 +36,20 @@ impl Display for Adapter {
 }
 
 impl Adapter {
+	pub async fn image_area(self, path: &Path, max: Rect) -> Result<Rect> {
+		if max.is_empty() {
+			return Ok(Rect::default());
+		}
+
+		match self {
+			Self::Kgp | Self::KgpOld | Self::Iip | Self::Sixel => {
+				Image::image_area(path, max).await.map(|(_img, area)| area)
+			}
+			Self::X11 | Self::Wayland => Ueberzug::image_area(path, max).await,
+			Self::Chafa => Chafa::image_area(path, max).await,
+		}
+	}
+
 	pub async fn image_show(self, path: &Path, max: Rect) -> Result<Rect> {
 		if max.is_empty() {
 			return Ok(Rect::default());

--- a/yazi-adapter/src/iip.rs
+++ b/yazi-adapter/src/iip.rs
@@ -14,8 +14,7 @@ pub(super) struct Iip;
 
 impl Iip {
 	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
-		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let (img, area) = Image::image_area(path, max).await?;
 		let b = Self::encode(img).await?;
 
 		Adapter::Iip.image_hide()?;

--- a/yazi-adapter/src/image.rs
+++ b/yazi-adapter/src/image.rs
@@ -85,6 +85,13 @@ impl Image {
 	}
 
 	#[inline]
+	pub(super) async fn image_area(path: &Path, max: Rect) -> Result<(DynamicImage, Rect)> {
+		let img = Self::downscale(path, max).await?;
+		let area = Self::pixel_area((img.width(), img.height()), max);
+		Ok((img, area))
+	}
+
+	#[inline]
 	fn filter() -> FilterType {
 		match PREVIEW.image_filter.as_str() {
 			"nearest" => FilterType::Nearest,

--- a/yazi-adapter/src/kgp.rs
+++ b/yazi-adapter/src/kgp.rs
@@ -314,8 +314,7 @@ pub(super) struct Kgp;
 
 impl Kgp {
 	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
-		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let (img, area) = Image::image_area(path, max).await?;
 
 		let b1 = Self::encode(img).await?;
 		let b2 = Self::place(&area)?;

--- a/yazi-adapter/src/kgp_old.rs
+++ b/yazi-adapter/src/kgp_old.rs
@@ -13,8 +13,7 @@ pub(super) struct KgpOld;
 
 impl KgpOld {
 	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
-		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let (img, area) = Image::image_area(path, max).await?;
 		let b = Self::encode(img).await?;
 
 		Adapter::KgpOld.image_hide()?;

--- a/yazi-adapter/src/sixel.rs
+++ b/yazi-adapter/src/sixel.rs
@@ -13,8 +13,7 @@ pub(super) struct Sixel;
 
 impl Sixel {
 	pub(super) async fn image_show(path: &Path, max: Rect) -> Result<Rect> {
-		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
+		let (img, area) = Image::image_area(path, max).await?;
 		let b = Self::encode(img).await?;
 
 		Adapter::Sixel.image_hide()?;


### PR DESCRIPTION
Exposing `image_area` separately allows future Lua integration to handle image placement more flexibly, without needing to invoke full rendering. This change promotes modularity and simplifies obtaining image dimensions alone.

This refactor provides the foundation for feature PR #1897, preparing for easier integration.