### PR TITLE
refactor: make error messages more user-friendly

### DIFF
--- a/yazi-adapter/src/ueberzug.rs
+++ b/yazi-adapter/src/ueberzug.rs
@@ -91,7 +91,7 @@ impl Ueberzug {
 			.spawn();
 
 		if let Err(ref e) = result {
-			warn!("ueberzugpp spawning failed: {e}");
+			warn!("Failed to start ueberzugpp: {e}");
 		}
 		Ok(result?)
 	}

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -9,7 +9,7 @@ function M:peek()
 		return ya.preview_widgets(self, {
 			ui.Text(
 				code == 2 and "File list in this archive is encrypted"
-					or "Both `7z` and `7zz` commands failed to run.\nDo you have 7-zip installed?"
+					or "Starting both `7z` and `7zz` failed. Do you have 7-zip installed?"
 			):area(self.area),
 		})
 	end

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -7,8 +7,10 @@ function M:peek()
 	local files, bound, code = self.list_files({ "-p", tostring(self.file.url) }, self.skip, limit)
 	if code ~= 0 then
 		return ya.preview_widgets(self, {
-			ui.Text(code == 2 and "File list in this archive is encrypted" or "Spawn `7z` and `7zz` both commands failed")
-				:area(self.area),
+			ui.Text(
+				code == 2 and "File list in this archive is encrypted"
+					or "Both `7z` and `7zz` commands failed to run.\nDo you have 7-zip installed?"
+			):area(self.area),
 		})
 	end
 
@@ -62,7 +64,7 @@ function M.spawn_7z(args)
 	end
 
 	if not child then
-		return ya.err("spawn `7z` and `7zz` both commands failed, error code: " .. tostring(last_error))
+		return ya.err("Both `7z` and `7zz` failed, error code: " .. tostring(last_error))
 	end
 	return child, last_error
 end

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -64,7 +64,7 @@ function M.spawn_7z(args)
 	end
 
 	if not child then
-		return ya.err("Both `7z` and `7zz` failed, error code: " .. tostring(last_error))
+		return ya.err("Starting both `7z` and `7zz` failed, error code: " .. tostring(last_error))
 	end
 	return child, last_error
 end

--- a/yazi-plugin/preset/plugins/extract.lua
+++ b/yazi-plugin/preset/plugins/extract.lua
@@ -50,7 +50,7 @@ function M:try_with(from, pwd, to)
 	local archive = require("archive")
 	local child, code = archive.spawn_7z { "x", "-aou", "-sccUTF-8", "-p" .. pwd, "-o" .. tostring(tmp), tostring(from) }
 	if not child then
-		fail("Spawn `7z` and `7zz` both commands failed, error code %s", code)
+		fail("Both `7z` and `7zz` commands failed with error code %s.\nDo you have 7-zip installed?", code)
 	end
 
 	local output, err = child:wait_with_output()

--- a/yazi-plugin/preset/plugins/extract.lua
+++ b/yazi-plugin/preset/plugins/extract.lua
@@ -50,7 +50,7 @@ function M:try_with(from, pwd, to)
 	local archive = require("archive")
 	local child, code = archive.spawn_7z { "x", "-aou", "-sccUTF-8", "-p" .. pwd, "-o" .. tostring(tmp), tostring(from) }
 	if not child then
-		fail("Both `7z` and `7zz` commands failed with error code %s.\nDo you have 7-zip installed?", code)
+		fail("Starting both `7z` and `7zz` failed, error code %s. Do you have 7-zip installed?", code)
 	end
 
 	local output, err = child:wait_with_output()

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -8,7 +8,7 @@ function M:peek()
 	if output then
 		text = ui.Text.parse("----- File Type Classification -----\n\n" .. output.stdout)
 	else
-		text = ui.Text(string.format("Spawn `%s` command returns %s", cmd, code))
+		text = ui.Text(string.format("`%s` command returns %s", cmd, code))
 	end
 
 	ya.preview_widgets(self, { text:area(self.area):wrap(ui.Text.WRAP) })

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -8,7 +8,7 @@ function M:peek()
 	if output then
 		text = ui.Text.parse("----- File Type Classification -----\n\n" .. output.stdout)
 	else
-		text = ui.Text(string.format("`%s` command returns %s", cmd, code))
+		text = ui.Text(string.format("Starting `%s` failed with error code %s. Do you have file(1) installed?", cmd, code))
 	end
 
 	ya.preview_widgets(self, { text:area(self.area):wrap(ui.Text.WRAP) })

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -40,7 +40,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("`magick` command returns " .. tostring(code))
+		ya.err(string.format("Starting `magick` failed with error code %s", code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -40,7 +40,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("spawn `magick` command returns " .. tostring(code))
+		ya.err("`magick` command returns " .. tostring(code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/fzf.lua
+++ b/yazi-plugin/preset/plugins/fzf.lua
@@ -10,7 +10,7 @@ local function entry()
 		Command("fzf"):cwd(cwd):stdin(Command.INHERIT):stdout(Command.PIPED):stderr(Command.INHERIT):spawn()
 
 	if not child then
-		return fail("Command `fzf` failed with error code %s. Do you have it installed?", err)
+		return fail("Starting `fzf` failed with error code %s. Do you have it installed?", err)
 	end
 
 	local output, err = child:wait_with_output()

--- a/yazi-plugin/preset/plugins/fzf.lua
+++ b/yazi-plugin/preset/plugins/fzf.lua
@@ -10,7 +10,7 @@ local function entry()
 		Command("fzf"):cwd(cwd):stdin(Command.INHERIT):stdout(Command.PIPED):stderr(Command.INHERIT):spawn()
 
 	if not child then
-		return fail("Spawn `fzf` failed with error code %s. Do you have it installed?", err)
+		return fail("Command `fzf` failed with error code %s. Do you have it installed?", err)
 	end
 
 	local output, err = child:wait_with_output()

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -33,7 +33,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("spawn `magick` command returns " .. tostring(code))
+		ya.err("`magick` command returns " .. tostring(code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -33,7 +33,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("`magick` command returns " .. tostring(code))
+		ya.err(string.format("Starting `magick` failed with error code %s", code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -18,7 +18,7 @@ function M:fetch(job)
 	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
 	local child, code = Command(cmd):args({ "-bL", "--mime-type", "--" }):args(urls):stdout(Command.PIPED):spawn()
 	if not child then
-		ya.err(string.format("Spawn `%s` command returns %s", cmd, code))
+		ya.err(string.format("`%s` command returns %s", cmd, code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -18,7 +18,7 @@ function M:fetch(job)
 	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
 	local child, code = Command(cmd):args({ "-bL", "--mime-type", "--" }):args(urls):stdout(Command.PIPED):spawn()
 	if not child then
-		ya.err(string.format("`%s` command returns %s", cmd, code))
+		ya.err(string.format("Starting `%s` failed with error code %s", cmd, code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -62,7 +62,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("`ffmpeg` command returns " .. tostring(code))
+		ya.err("Starting `ffmpeg` failed with error code " .. tostring(code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -62,7 +62,7 @@ function M:preload()
 	}):spawn()
 
 	if not child then
-		ya.err("Spawn `ffmpeg` process returns " .. tostring(code))
+		ya.err("`ffmpeg` command returns " .. tostring(code))
 		return 0
 	end
 

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -101,7 +101,7 @@ local function entry()
 		:spawn()
 
 	if not child then
-		return fail("Spawn `zoxide` failed with error code %s. Do you have it installed?", err)
+		return fail("Command `zoxide` failed with error code %s. Do you have it installed?", err)
 	end
 
 	local output, err = child:wait_with_output()

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -101,7 +101,7 @@ local function entry()
 		:spawn()
 
 	if not child then
-		return fail("Command `zoxide` failed with error code %s. Do you have it installed?", err)
+		return fail("Starting `zoxide` failed with error code %s. Do you have it installed?", err)
 	end
 
 	local output, err = child:wait_with_output()

--- a/yazi-scheduler/src/process/process.rs
+++ b/yazi-scheduler/src/process/process.rs
@@ -21,7 +21,7 @@ impl Process {
 		let (id, cmd) = (task.id, task.cmd.clone());
 		let result = super::shell(task.into());
 		if let Err(e) = result {
-			AppProxy::notify_warn(&cmd.to_string_lossy(), format!("Failed to spawn process: {e}"));
+			AppProxy::notify_warn(&cmd.to_string_lossy(), format!("Failed to run process: {e}"));
 			return self.succ(id);
 		}
 
@@ -44,7 +44,7 @@ impl Process {
 			Ok(_) => self.succ(id)?,
 			Err(e) => {
 				self.prog.send(TaskProg::New(id, 0))?;
-				self.fail(id, format!("Failed to spawn process: {e}"))?;
+				self.fail(id, format!("Failed to run process: {e}"))?;
 			}
 		}
 

--- a/yazi-scheduler/src/process/process.rs
+++ b/yazi-scheduler/src/process/process.rs
@@ -21,7 +21,7 @@ impl Process {
 		let (id, cmd) = (task.id, task.cmd.clone());
 		let result = super::shell(task.into());
 		if let Err(e) = result {
-			AppProxy::notify_warn(&cmd.to_string_lossy(), format!("Failed to run process: {e}"));
+			AppProxy::notify_warn(&cmd.to_string_lossy(), format!("Failed to start process: {e}"));
 			return self.succ(id);
 		}
 
@@ -44,7 +44,7 @@ impl Process {
 			Ok(_) => self.succ(id)?,
 			Err(e) => {
 				self.prog.send(TaskProg::New(id, 0))?;
-				self.fail(id, format!("Failed to run process: {e}"))?;
+				self.fail(id, format!("Failed to start process: {e}"))?;
 			}
 		}
 


### PR DESCRIPTION
- "Spawn a command/process" is not straightforward for non-technical users. Using "Run a command/process" or "Execute a command/process" in error messages would be better.