### PR TITLE
perf: use rayon to parallelize directory operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,6 +3635,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "ratatui",
+ "rayon",
  "serde",
  "shell-words",
  "tokio",

--- a/yazi-fs/Cargo.toml
+++ b/yazi-fs/Cargo.toml
@@ -21,6 +21,7 @@ futures  = { workspace = true }
 regex    = { workspace = true }
 serde    = { workspace = true }
 tokio    = { workspace = true }
+rayon    = "1.10.0"
 
 [target."cfg(unix)".dependencies]
 libc  = { workspace = true }

--- a/yazi-plugin/src/fs/fs.rs
+++ b/yazi-plugin/src/fs/fs.rs
@@ -81,7 +81,7 @@ fn remove(lua: &Lua) -> mlua::Result<Function> {
 			b"file" => fs::remove_file(&*url).await,
 			b"dir" => fs::remove_dir(&*url).await,
 			b"dir_all" => fs::remove_dir_all(&*url).await,
-			b"dir_clean" => Ok(remove_dir_clean(&url).await),
+			b"dir_clean" => Ok(remove_dir_clean(&url).await?),
 			_ => Err("Removal type must be 'file', 'dir', 'dir_all', or 'dir_clean'".into_lua_err())?,
 		};
 

--- a/yazi-scheduler/src/file/file.rs
+++ b/yazi-scheduler/src/file/file.rs
@@ -318,7 +318,7 @@ impl File {
 
 	pub async fn trash(&self, mut task: FileOpTrash) -> Result<()> {
 		let id = task.id;
-		task.length = calculate_size(&task.target).await;
+		task.length = calculate_size(&task.target).await?;
 
 		self.prog.send(TaskProg::New(id, task.length))?;
 		self.queue(FileOp::Trash(task), LOW).await?;

--- a/yazi-scheduler/src/prework/prework.rs
+++ b/yazi-scheduler/src/prework/prework.rs
@@ -83,7 +83,7 @@ impl Prework {
 				self.prog.send(TaskProg::Adv(task.id, 1, 0))?;
 			}
 			PreworkOp::Size(task) => {
-				let length = calculate_size(&task.target).await;
+				let length = calculate_size(&task.target).await?;
 				task.throttle.done((task.target, length), |buf| {
 					{
 						let mut loading = self.size_loading.write();

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -86,7 +86,7 @@ impl Scheduler {
 			Box::new(move |canceled: bool| {
 				async move {
 					if !canceled {
-						remove_dir_clean(&from).await;
+						let _ = remove_dir_clean(&from).await;
 						Pump::push_move(from, to);
 					}
 					ongoing.lock().try_remove(id, TaskStage::Hooked);

--- a/yazi-shared/Cargo.toml
+++ b/yazi-shared/Cargo.toml
@@ -22,6 +22,7 @@ ratatui          = { workspace = true }
 serde            = { workspace = true }
 shell-words      = { workspace = true }
 tokio            = { workspace = true }
+rayon            = "1.10.0"
 
 [target."cfg(unix)".dependencies]
 libc  = { workspace = true }


### PR DESCRIPTION
- Currently, all directory operations including size calculating, removing and etc, are single-threaded per task. Use `rayon` to parallelize these operations.