### PR TITLE
feat!: extend the available styles for `mode` by separating `mode` from the `separator` styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Yazi (means "duck") is a terminal file manager written in Rust, based on non-blo
 - 📦 **Package Manager**: Install plugins and themes with one command, keeping them up to date, or pin them to a specific version.
 - 🧰 Integration with ripgrep, fd, fzf, zoxide
 - 💫 Vim-like input/pick/confirm/which/notify component, auto-completion for cd paths
-- 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, code, fonts, etc.)
+- 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, code, directories, etc.)
 - 🔄 Bulk Renaming, Visual Mode, File Chooser
 - 🎨 Theme System, Mouse Support, Trash Bin, Custom Layouts, CSI u
 - ... and more!

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Yazi (means "duck") is a terminal file manager written in Rust, based on non-blo
 - 💪 **Powerful Async Task Scheduling and Management**: Provides real-time progress updates, task cancellation, and internal task priority assignment.
 - 🖼️ **Built-in Support for Multiple Image Protocols**: Also integrated with Überzug++ and Chafa, covering almost all terminals.
 - 🌟 **Built-in Code Highlighting and Image Decoding**: Combined with the pre-loading mechanism, greatly accelerates image and normal file loading.
-- 🔌 **Concurrent Plugin System**: UI plugins (rewriting most of the UI), functional plugins, custom previewer/preloader/fetcher; Just some pieces of Lua.
+- 🔌 **Concurrent Plugin System**: UI plugins (rewriting most of the UI), functional plugins, custom previewer/preloader/spotter/fetcher; Just some pieces of Lua.
 - 📡 **Data Distribution Service**: Built on a client-server architecture (no additional server process required), integrated with a Lua-based publish-subscribe model, achieving cross-instance communication and state persistence.
 - 📦 **Package Manager**: Install plugins and themes with one command, keeping them up to date, or pin them to a specific version.
 - 🧰 Integration with ripgrep, fd, fzf, zoxide
 - 💫 Vim-like input/pick/confirm/which/notify component, auto-completion for cd paths
-- 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, directories, code, etc.)
+- 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, code, fonts, etc.)
 - 🔄 Bulk Renaming, Visual Mode, File Chooser
 - 🎨 Theme System, Mouse Support, Trash Bin, Custom Layouts, CSI u
 - ... and more!

--- a/yazi-config/preset/theme+dark.toml
+++ b/yazi-config/preset/theme+dark.toml
@@ -1,5 +1,6 @@
-# `theme+dark.toml` and `theme+light.toml` are additions to `theme.toml` and are considered part of it.
-# If your terminal is in dark mode, `theme+dark.toml` will be applied *after* `theme.toml`; if it's in light mode, then `theme+light.toml` instead.
+# If the user's terminal is in dark mode, Yazi will use the content from `theme-base.toml` + `theme+dark.toml` as the default theme;
+# if it's in light mode, use `theme-base.toml` + `theme+light.toml` instead.
+# Users can always override and adjust the default theme in their own `theme.toml` configuration file.
 "$schema" = "https://yazi-rs.github.io/schemas/theme.json"
 
 # vim:fileencoding=utf-8:foldmethod=marker

--- a/yazi-config/preset/theme+light.toml
+++ b/yazi-config/preset/theme+light.toml
@@ -1,5 +1,6 @@
-# `theme+dark.toml` and `theme+light.toml` are additions to `theme.toml` and are considered part of it.
-# If your terminal is in dark mode, `theme+dark.toml` will be applied *after* `theme.toml`; if it's in light mode, then `theme+light.toml` instead.
+# If the user's terminal is in dark mode, Yazi will use the content from `theme-base.toml` + `theme+dark.toml` as the default theme;
+# if it's in light mode, use `theme-base.toml` + `theme+light.toml` instead.
+# Users can always override and adjust the default theme in their own `theme.toml` configuration file.
 "$schema" = "https://yazi-rs.github.io/schemas/theme.json"
 
 # vim:fileencoding=utf-8:foldmethod=marker

--- a/yazi-config/preset/theme-base.toml
+++ b/yazi-config/preset/theme-base.toml
@@ -82,11 +82,11 @@ progress_normal = { fg = "blue", bg = "black" }
 progress_error  = { fg = "red", bg = "black" }
 
 # Permissions
-permissions_t = { fg = "green" }
-permissions_r = { fg = "yellow" }
-permissions_w = { fg = "red" }
-permissions_x = { fg = "cyan" }
-permissions_s = { fg = "darkgray" }
+perm_sep   = { fg = "darkgray" }
+perm_type  = { fg = "green" }
+perm_read  = { fg = "yellow" }
+perm_write = { fg = "red" }
+perm_exec  = { fg = "cyan" }
 
 # : }}}
 

--- a/yazi-config/preset/theme-base.toml
+++ b/yazi-config/preset/theme-base.toml
@@ -1,5 +1,6 @@
-# A TOML linter such as https://taplo.tamasfe.dev/ can use this schema to validate your config.
-# If you encounter any issues, please make an issue at https://github.com/yazi-rs/schemas.
+# If the user's terminal is in dark mode, Yazi will use the content from `theme-base.toml` + `theme+dark.toml` as the default theme;
+# if it's in light mode, use `theme-base.toml` + `theme+light.toml` instead.
+# Users can always override and adjust the default theme in their own `theme.toml` configuration file.
 "$schema" = "https://yazi-rs.github.io/schemas/theme.json"
 
 # vim:fileencoding=utf-8:foldmethod=marker
@@ -51,17 +52,29 @@ syntect_theme = ""
 # : }}}
 
 
-# : Status {{{
+# : Mode {{{
+
+[mode]
+
+normal_main = { bg = "blue", bold = true }
+normal_alt  = { fg = "blue", bg = "gray" }
+
+# Select mode
+select_main = { bg = "red", bold = true }
+select_alt  = { fg = "red", bg = "gray" }
+
+# Unset mode
+unset_main = { bg = "red", bold = true }
+unset_alt  = { fg = "red", bg = "gray" }
+
+# : }}}
+
+
+# : Status bar {{{
 
 [status]
 separator_open  = ""
 separator_close = ""
-separator_style = { fg = "gray", bg = "gray" }
-
-# Mode
-mode_normal = { bg = "blue", bold = true }
-mode_select = { bg = "red", bold = true }
-mode_unset  = { bg = "red", bold = true }
 
 # Progress
 progress_label  = { bold = true }

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -101,11 +101,11 @@ struct Status {
 	pub progress_error:  Style,
 
 	// Permissions
-	pub permissions_t: Style,
-	pub permissions_r: Style,
-	pub permissions_w: Style,
-	pub permissions_x: Style,
-	pub permissions_s: Style,
+	pub perm_sep:   Style,
+	pub perm_type:  Style,
+	pub perm_read:  Style,
+	pub perm_write: Style,
+	pub perm_exec:  Style,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -11,6 +11,7 @@ use super::{Filetype, Flavor, Icons};
 pub struct Theme {
 	pub flavor:     Flavor,
 	pub manager:    Manager,
+	mode:           Mode,
 	status:         Status,
 	pub input:      Input,
 	pub confirm:    Confirm,
@@ -78,15 +79,21 @@ pub struct Manager {
 }
 
 #[derive(Deserialize, Serialize)]
+struct Mode {
+	pub normal_main: Style,
+	pub normal_alt:  Style,
+
+	pub select_main: Style,
+	pub select_alt:  Style,
+
+	pub unset_main: Style,
+	pub unset_alt:  Style,
+}
+
+#[derive(Deserialize, Serialize)]
 struct Status {
 	pub separator_open:  String,
 	pub separator_close: String,
-	pub separator_style: Style,
-
-	// Mode
-	pub mode_normal: Style,
-	pub mode_select: Style,
-	pub mode_unset:  Style,
 
 	// Progress
 	pub progress_label:  Style,

--- a/yazi-macro/src/asset.rs
+++ b/yazi-macro/src/asset.rs
@@ -50,7 +50,7 @@ macro_rules! theme_preset {
 				".toml"
 			))
 			.expect(concat!("Failed to read 'yazi-config/preset/theme+", $name, ".toml'"));
-			std::borrow::Cow::from(format!("{}\n{append}", &$crate::config_preset!("theme")))
+			std::borrow::Cow::from(format!("{}\n{append}", &$crate::config_preset!("theme-base")))
 		}
 		#[cfg(not(debug_assertions))]
 		{

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -25,12 +25,13 @@ function Status:new(area, tab)
 end
 
 function Status:style()
+	local m = THEME.mode
 	if self._tab.mode.is_select then
-		return THEME.status.mode_select
+		return { main = m.select_main, alt = m.select_alt }
 	elseif self._tab.mode.is_unset then
-		return THEME.status.mode_unset
+		return { main = m.unset_main, alt = m.unset_alt }
 	else
-		return THEME.status.mode_normal
+		return { main = m.normal_main, alt = m.normal_alt }
 	end
 end
 
@@ -39,9 +40,9 @@ function Status:mode()
 
 	local style = self:style()
 	return ui.Line {
-		ui.Span(THEME.status.separator_open):fg(style.bg),
-		ui.Span(" " .. mode .. " "):style(style),
-		ui.Span(THEME.status.separator_close):fg(style.bg):bg(THEME.status.separator_style.fg),
+		ui.Span(THEME.status.separator_open):fg(style.main.bg),
+		ui.Span(" " .. mode .. " "):style(style.main),
+		ui.Span(THEME.status.separator_close):fg(style.main.bg):bg(style.alt.bg),
 	}
 end
 
@@ -53,8 +54,8 @@ function Status:size()
 
 	local style = self:style()
 	return ui.Line {
-		ui.Span(" " .. ya.readable_size(h:size() or h.cha.len) .. " "):fg(style.bg):bg(THEME.status.separator_style.bg),
-		ui.Span(THEME.status.separator_close):fg(THEME.status.separator_style.fg),
+		ui.Span(" " .. ya.readable_size(h:size() or h.cha.len) .. " "):style(style.alt),
+		ui.Span(THEME.status.separator_close):fg(style.alt.bg),
 	}
 end
 
@@ -114,8 +115,8 @@ function Status:percent()
 
 	local style = self:style()
 	return ui.Line {
-		ui.Span(" " .. THEME.status.separator_open):fg(THEME.status.separator_style.fg),
-		ui.Span(percent):fg(style.bg):bg(THEME.status.separator_style.bg),
+		ui.Span(" " .. THEME.status.separator_open):fg(style.alt.bg),
+		ui.Span(percent):style(style.alt),
 	}
 end
 
@@ -125,9 +126,9 @@ function Status:position()
 
 	local style = self:style()
 	return ui.Line {
-		ui.Span(THEME.status.separator_open):fg(style.bg):bg(THEME.status.separator_style.fg),
-		ui.Span(string.format(" %2d/%-2d ", math.min(cursor + 1, length), length)):style(style),
-		ui.Span(THEME.status.separator_close):fg(style.bg),
+		ui.Span(THEME.status.separator_open):fg(style.main.bg):bg(style.alt.bg),
+		ui.Span(string.format(" %2d/%-2d ", math.min(cursor + 1, length), length)):style(style.main),
+		ui.Span(THEME.status.separator_close):fg(style.main.bg),
 	}
 end
 

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -82,15 +82,15 @@ function Status:perm()
 	local spans = {}
 	for i = 1, #perm do
 		local c = perm:sub(i, i)
-		local style = THEME.status.permissions_t
+		local style = THEME.status.perm_type
 		if c == "-" or c == "?" then
-			style = THEME.status.permissions_s
+			style = THEME.status.perm_sep
 		elseif c == "r" then
-			style = THEME.status.permissions_r
+			style = THEME.status.perm_read
 		elseif c == "w" then
-			style = THEME.status.permissions_w
+			style = THEME.status.perm_write
 		elseif c == "x" or c == "s" or c == "S" or c == "t" or c == "T" then
-			style = THEME.status.permissions_x
+			style = THEME.status.perm_exec
 		end
 		spans[i] = ui.Span(c):style(style)
 	end


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/pull/732, https://github.com/sxyazi/yazi/issues/1228

Closes https://github.com/sxyazi/yazi/pull/732, https://github.com/sxyazi/yazi/issues/1228

---

Previously, only a single mode style was supported, which meant the same mode style was used for both the highlight and secondary colors, and the separator style was applied to the secondary color. 

This led to the inability to set different styles for the primary color of the mode, and users couldn't control the mode style independently because it depended on the separator style.

This PR separates the mode from the separator style, making it its own distinct style. Users will now be able to set different main and alternate styles for each of the 3 modes individually.

## ⚠️ Breaking changes

`mode_normal`, `mode_select`, `mode_unset`, and `separator_style` have been separated into a new, independent `[mode]` section:
- `normal_main` - Main style for the normal mode
- `normal_alt` - Alternate style for the normal mode
- `select_main` - Main style for the select mode
- `select_alt` - Alternate style for the select mode
- `unset_main` - Main style for the unset mode
- `unset_alt` - Alternate style for the unset mode

`permissions_t`, `permissions_r`, `permissions_w`, `permissions_x`, and `permissions_s` have been renamed to `perm_type`, `perm_read`, `perm_write`, `perm_exec`, and `perm_sep` to improve readability and align with the naming conventions in https://github.com/sxyazi/yazi/pull/1761.