### PR TITLE
update: able to set header flag style

### DIFF
--- a/yazi-config/preset/theme-base.toml
+++ b/yazi-config/preset/theme-base.toml
@@ -16,7 +16,8 @@ light = ""
 # : Manager {{{
 
 [manager]
-cwd = { fg = "cyan" }
+cwd  = { fg = "cyan" }
+flag = { fg = "cyan" }
 
 # Hovered
 hovered         = { reversed = true }

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -44,6 +44,7 @@ impl FromStr for Theme {
 #[derive(Deserialize, Serialize, Validate)]
 pub struct Manager {
 	cwd: Style,
+	flag: Style,
 
 	// Hovered
 	hovered:         Style,

--- a/yazi-plugin/preset/components/header.lua
+++ b/yazi-plugin/preset/components/header.lua
@@ -27,8 +27,13 @@ function Header:cwd()
 		return ""
 	end
 
-	local s = ya.readable_path(tostring(self._current.cwd)) .. self:flags()
-	return ui.Span(ya.truncate(s, { max = max, rtl = true })):style(THEME.manager.cwd)
+	local s = ya.readable_path(tostring(self._current.cwd)) .. " "
+	local flag = self:flags()
+
+	return ui.Line {
+		ui.Span(ya.truncate(s, { max = max, rtl = true })):style(THEME.manager.cwd),
+		ui.Span(ya.truncate(flag, { max = max, rtl = true })):style(THEME.manager.flag)
+	}
 end
 
 function Header:flags()
@@ -46,7 +51,7 @@ function Header:flags()
 	if finder then
 		t[#t + 1] = string.format("find: %s", finder)
 	end
-	return #t == 0 and "" or " (" .. table.concat(t, ", ") .. ")"
+	return #t == 0 and "" or "(" .. table.concat(t, ", ") .. ")"
 end
 
 function Header:count()


### PR DESCRIPTION
I want to make the header flag more prominent. Currently, its style is determined by manager.cwd, which also affects the header's cwd. I think it would be better to have separate control over their styles.
So I added a [manager.flag] style to control this:
![image](https://github.com/user-attachments/assets/4681a211-e3d0-42c3-95d5-beec3249d365)
