### PR TITLE
update: change percent text Bot to End

### DIFF
--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -108,7 +108,7 @@ function Status:percent()
 	if percent == 0 then
 		percent = " Top "
 	elseif percent == 100 then
-		percent = " Bot "
+		percent = " End "
 	else
 		percent = string.format(" %2d%% ", percent)
 	end


### PR DESCRIPTION
In the status bar, the percentage text displays "Bot," which initially confused me. After moving the cursor around, I realized it stands for "bottom." It might be clearer to change it to "End," which would make the meaning more obvious to users.

![image](https://github.com/user-attachments/assets/ab38727d-45b1-4b75-bfdc-0b1d0637f48c)
