### PR TITLE
update: exit input instaed of change mode for empty input

### DIFF
--- a/yazi-core/src/input/commands/escape.rs
+++ b/yazi-core/src/input/commands/escape.rs
@@ -25,6 +25,11 @@ impl Input {
 				snap.op = InputOp::None;
 			}
 			InputMode::Insert => {
+				if snap.value.trim().is_empty() {
+					self.close(false);
+					return;
+				}
+
 				snap.mode = InputMode::Normal;
 				self.move_(-1);
 


### PR DESCRIPTION
Sometimes, I accidentally open an input window and want to exit it. I currently have to press Esc twice: once to return to normal mode and again to exit. But if the input field is empty, I believe it should be possible to exit directly.