### PR TITLE
feat: support cd - (cd last)

### DIFF
--- a/yazi-core/src/tab/commands/cd.rs
+++ b/yazi-core/src/tab/commands/cd.rs
@@ -26,7 +26,7 @@ impl From<Cmd> for Opt {
 
 impl From<Url> for Opt {
 	fn from(mut target: Url) -> Self {
-		if target.is_regular() {
+		if target.is_regular() && target.to_string() != "-" {
 			target = Url::from(expand_path(&target));
 		}
 		Self { target, interactive: false }
@@ -45,6 +45,15 @@ impl Tab {
 		}
 
 		if opt.target == *self.cwd() {
+			return;
+		}
+
+		if opt.target.to_string() == "-" {
+			if let Some(last_cwd) = self.backstack.shift_backward() {
+				TabProxy::cd(&last_cwd);
+			}
+
+			self.backstack.push(self.cwd().clone());
 			return;
 		}
 


### PR DESCRIPTION
Support `cd -`, go to last visit dir.
I konw in #1913 you metioned there's `back` and `forward`, but it's logic is not exactly the same with `cd -`, "back" shift from backstack but won't add current cwd into it. 
https://github.com/sxyazi/yazi/blob/af565fbc40b9d443669db2ab46ee491be323c6fd/yazi-config/preset/keymap.toml#L42-L43
`cd -` can toggle between two places, I know we can simulate this with tabs. But I personally want the `cd -` feature, feel free to close or merge this PR.