### PR TITLE
feat!: remove the meaningless `--confirm` option to simplify the `shell` command

### DIFF
--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -28,28 +28,6 @@ pub fn init() -> anyhow::Result<()> {
 		try_init(false)?;
 	}
 
-	// TODO: Remove in v0.3.2
-	for c in &KEYMAP.manager {
-		for r in &c.run {
-			if r.name != "shell" {
-				continue;
-			}
-			if !r.bool("confirm") && !r.bool("interactive") {
-				let s = format!("`{}` ({})", c.on(), c.desc_or_run());
-				eprintln!(
-					r#"WARNING: In Yazi v0.3, the behavior of the interactive `shell` (i.e., shell templates) must be explicitly specified with either `--interactive` or `--confirm`.
-
-Please replace e.g. `shell` with `shell --interactive`, `shell "my-template"` with `shell "my-template" --interactive`, in your keymap.toml for the key: {s}"#
-				);
-				return Ok(());
-			} else if r.bool("confirm") && r.bool("interactive") {
-				eprintln!(
-					"The `shell` command cannot specify both `--confirm` and `--interactive` at the same time.",
-				);
-			}
-		}
-	}
-
 	// TODO: Remove in v0.3.6
 	if matches!(INPUT.create_title, popup::InputCreateTitle::One(_)) {
 		eprintln!(

--- a/yazi-shared/src/event/data.rs
+++ b/yazi-shared/src/event/data.rs
@@ -18,6 +18,8 @@ pub enum Data {
 	#[serde(skip_deserializing)]
 	Url(Url),
 	#[serde(skip)]
+	Bytes(Vec<u8>),
+	#[serde(skip)]
 	Any(Box<dyn Any + Send + Sync>),
 }
 


### PR DESCRIPTION
This PR removes the `--confirm` option for the [`shell` command](https://yazi-rs.github.io/docs/configuration/keymap/#manager.shell), as it was a design flaw - running shell commands shouldn't be so painful; it should feel as natural as drinking water. 

When users write shell commands, they usually want to run them directly, not enter an interactive mode through a shell input box.

To ensure the safe removal of this option, [since Yazi v0.3](https://github.com/sxyazi/yazi/commit/987b1d5c49f5d11ab9e6a9cdea21974b440ae463#diff-50eb0ae5b409b5134616d6b4fa8f88d4d6010ada7bc2fc2ec2f64da126d1fe58), users have been required to explicitly specify the `--interactive` flag for interactive shell commands:

https://github.com/sxyazi/yazi/blob/4bd8b0b44681cef9d12b16e3b3e70520711599ba/yazi-config/src/lib.rs#L31-L51

https://github.com/sxyazi/yazi/blob/4bd8b0b44681cef9d12b16e3b3e70520711599ba/yazi-core/src/tab/commands/shell.rs#L51-L66

This ensures that removing the `--confirm` option won't cause these interactive commands to run unexpectedly, and I think Yazi v0.4 is the right time to remove the `--confirm` option fully now.