### PR TITLE
fix: add missing rar mime type

### DIFF
--- a/yazi-config/preset/theme-base.toml
+++ b/yazi-config/preset/theme-base.toml
@@ -205,7 +205,7 @@ rules = [
 
 	# Archives
 	{ mime = "application/{,g}zip", fg = "red" },
-	{ mime = "application/{tar,bzip*,7z-compressed,xz,rar}", fg = "red" },
+	{ mime = "application/{tar,bzip*,7z-compressed,xz,rar,vnd.rar}", fg = "red" },
 
 	# Documents
 	{ mime = "application/{pdf,doc,rtf,vnd.*}", fg = "cyan" },

--- a/yazi-config/preset/yazi.toml
+++ b/yazi-config/preset/yazi.toml
@@ -68,7 +68,7 @@ rules = [
 	{ mime = "{audio,video}/*", use = [ "play", "reveal" ] },
 	# Archive
 	{ mime = "application/{,g}zip", use = [ "extract", "reveal" ] },
-	{ mime = "application/{tar,bzip*,7z-compressed,xz,rar}", use = [ "extract", "reveal" ] },
+	{ mime = "application/{tar,bzip*,7z-compressed,xz,rar,vnd.rar}", use = [ "extract", "reveal" ] },
 	# JSON
 	{ mime = "application/{json,ndjson}", use = [ "edit", "reveal" ] },
 	{ mime = "*/javascript", use = [ "edit", "reveal" ] },
@@ -133,7 +133,7 @@ previewers = [
 	{ mime = "application/pdf", run = "pdf" },
 	# Archive
 	{ mime = "application/{,g}zip", run = "archive" },
-	{ mime = "application/{tar,bzip*,7z-compressed,xz,rar,iso9660-image}", run = "archive" },
+	{ mime = "application/{tar,bzip*,7z-compressed,xz,rar,vnd.rar,iso9660-image}", run = "archive" },
 	# Font
 	{ mime = "font/*", run = "font" },
 	{ mime = "application/vnd.ms-opentype", run = "font" },


### PR DESCRIPTION
The newest version of file, file 5.46, now classifies `rar` archives as `application/vnd.rar` instead of `application/rar`.

There is also a [bug](https://bugs.astron.com/view.php?id=571) in this newest version of file that classifies some `zip` archives as `application/octet-stream`, but hopefully that will get fixed before Yazi 0.4 goes live so we don't have to classify a data stream as an archive.