### PR TITLE
fix: revise `revision` if the new file list is empty but the previous one was not

### DIFF
--- a/yazi-fs/src/files.rs
+++ b/yazi-fs/src/files.rs
@@ -103,10 +103,12 @@ impl Files {
 	pub fn update_full(&mut self, files: Vec<File>) {
 		self.ticket = FILES_TICKET.next();
 
-		(self.hidden, self.items) = self.split_files(files);
-		if !self.items.is_empty() {
+		let (hidden, items) = self.split_files(files);
+		if !(items.is_empty() && self.items.is_empty()) {
 			self.revision += 1;
 		}
+
+		(self.hidden, self.items) = (hidden, items);
 	}
 
 	pub fn update_part(&mut self, files: Vec<File>, ticket: Id) {


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/1990