### PR TITLE
fix: respect `PREVIEW.image_quality` for the default PDF previewer

### DIFF
--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -27,7 +27,7 @@ function M:preload(job)
 		"-resize",
 		string.format("%dx%d^", PREVIEW.max_width, PREVIEW.max_height),
 		"-quality",
-		tostring(PREVIEW.image_quality),
+		PREVIEW.image_quality,
 		"-auto-orient",
 		"JPG:" .. tostring(cache),
 	}):status()

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -26,7 +26,15 @@ function M:preload(job)
 	end
 
 	local output = Command("pdftoppm")
-		:args({ "-singlefile", "-jpeg", "-jpegopt", "quality=75", "-f", tostring(job.skip + 1), tostring(job.file.url) })
+		:args({
+			"-singlefile",
+			"-jpeg",
+			"-jpegopt",
+			"quality=" .. tostring(PREVIEW.image_quality),
+			"-f",
+			tostring(job.skip + 1),
+			tostring(job.file.url),
+		})
 		:stdout(Command.PIPED)
 		:stderr(Command.PIPED)
 		:output()

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -30,9 +30,9 @@ function M:preload(job)
 			"-singlefile",
 			"-jpeg",
 			"-jpegopt",
-			"quality=" .. tostring(PREVIEW.image_quality),
+			"quality=" .. PREVIEW.image_quality,
 			"-f",
-			tostring(job.skip + 1),
+			job.skip + 1,
 			tostring(job.file.url),
 		})
 		:stdout(Command.PIPED)


### PR DESCRIPTION
See also: https://man.archlinux.org/man/pdftoppm.1#quality