### PR TITLE
fix: avoid upscaling for the video previewer

### DIFF
--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -56,7 +56,7 @@ function M:preload(job)
 		"-i", tostring(job.file.url),
 		"-vframes", 1,
 		"-q:v", qv,
-		"-vf", string.format("scale='min(%d,iw)':-2:flags=fast_bilinear", PREVIEW.max_width),
+		"-vf", string.format("scale='min(%d,iw)':-1:flags=fast_bilinear", PREVIEW.max_width),
 		"-f", "image2",
 		"-y", tostring(cache),
 	}):status()

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -56,7 +56,7 @@ function M:preload(job)
 		"-i", tostring(job.file.url),
 		"-vframes", 1,
 		"-q:v", qv,
-		"-vf", string.format("scale=%d:-2:flags=fast_bilinear", PREVIEW.max_width),
+		"-vf", string.format("scale='min(%d,iw)':-2:flags=fast_bilinear", PREVIEW.max_width),
 		"-f", "image2",
 		"-y", tostring(cache),
 	}):status()


### PR DESCRIPTION
See also:
- https://trac.ffmpeg.org/wiki/Scaling
- https://superuser.com/questions/566998/how-can-i-fit-a-video-to-a-certain-size-but-dont-upscale-it-with-ffmpeg

Additionally, ensuring even dimensions (using `-2`) may not be necessary, as these frames are only being extracted as images without any further encoding.