### PR TITLE
refactor: replace `format!` with `concat!` for string literals

### DIFF
--- a/yazi-boot/src/actions/version.rs
+++ b/yazi-boot/src/actions/version.rs
@@ -1,12 +1,14 @@
 use super::Actions;
 
 impl Actions {
-	pub(super) fn version() -> String {
-		format!(
-			"{} ({} {})",
+	pub(super) fn version() -> &'static str {
+		concat!(
 			env!("CARGO_PKG_VERSION"),
+			" (",
 			env!("VERGEN_GIT_SHA"),
-			env!("VERGEN_BUILD_DATE")
+			" ",
+			env!("VERGEN_BUILD_DATE"),
+			")"
 		)
 	}
 }

--- a/yazi-dds/src/body/hey.rs
+++ b/yazi-dds/src/body/hey.rs
@@ -15,7 +15,7 @@ pub struct BodyHey {
 impl BodyHey {
 	#[inline]
 	pub fn owned(peers: HashMap<u64, Peer>) -> Body<'static> {
-		Self { peers, version: BodyHi::version() }.into()
+		Self { peers, version: BodyHi::version().to_string() }.into()
 	}
 }
 

--- a/yazi-dds/src/body/hey.rs
+++ b/yazi-dds/src/body/hey.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use mlua::{ExternalResult, IntoLua, Lua, Value};
 use serde::{Deserialize, Serialize};
@@ -9,13 +9,13 @@ use crate::Peer;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BodyHey {
 	pub peers:   HashMap<u64, Peer>,
-	pub version: String,
+	pub version: Cow<'static, str>,
 }
 
 impl BodyHey {
 	#[inline]
 	pub fn owned(peers: HashMap<u64, Peer>) -> Body<'static> {
-		Self { peers, version: BodyHi::version().to_string() }.into()
+		Self { peers, version: BodyHi::version().into() }.into()
 	}
 }
 

--- a/yazi-dds/src/body/hi.rs
+++ b/yazi-dds/src/body/hi.rs
@@ -10,7 +10,7 @@ use super::Body;
 pub struct BodyHi<'a> {
 	/// Specifies the kinds of events that the client can handle
 	pub abilities: HashSet<Cow<'a, str>>,
-	pub version:   String,
+	pub version:   Cow<'static, str>,
 }
 
 impl<'a> BodyHi<'a> {
@@ -18,7 +18,7 @@ impl<'a> BodyHi<'a> {
 	pub fn borrowed(abilities: HashSet<&'a str>) -> Body<'a> {
 		Self {
 			abilities: abilities.into_iter().map(Cow::Borrowed).collect(),
-			version:   Self::version().to_string(),
+			version:   Self::version().into(),
 		}
 		.into()
 	}

--- a/yazi-dds/src/body/hi.rs
+++ b/yazi-dds/src/body/hi.rs
@@ -18,13 +18,15 @@ impl<'a> BodyHi<'a> {
 	pub fn borrowed(abilities: HashSet<&'a str>) -> Body<'a> {
 		Self {
 			abilities: abilities.into_iter().map(Cow::Borrowed).collect(),
-			version:   Self::version(),
+			version:   Self::version().to_string(),
 		}
 		.into()
 	}
 
 	#[inline]
-	pub fn version() -> String { format!("{} {}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA")) }
+	pub fn version() -> &'static str {
+		concat!(env!("CARGO_PKG_VERSION"), " ", env!("VERGEN_GIT_SHA"))
+	}
 }
 
 impl<'a> From<BodyHi<'a>> for Body<'a> {

--- a/yazi-dds/src/client.rs
+++ b/yazi-dds/src/client.rs
@@ -92,7 +92,7 @@ impl Client {
 			}
 		}
 
-		if version != Some(BodyHi::version()) {
+		if version.as_deref() != Some(BodyHi::version()) {
 			bail!(
 				"Incompatible version (Ya {}, Yazi {})",
 				BodyHi::version(),


### PR DESCRIPTION
- Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.