### PR TITLE
fix: correctly handle CRLF on Windows in preset `archive` and `json` plugins

### DIFF
--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -110,7 +110,7 @@ function M.list_files(args, skip, limit)
 			goto continue
 		end
 
-		key, value = next:match("^(%u%l+) = (.+)[\r\n]+")
+		key, value = next:match("^(%u%l+) = (.-)[\r\n]+")
 		if key == "Path" then
 			files[#files].path = value
 		elseif key == "Size" then

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -2,12 +2,7 @@ local M = {}
 
 function M:peek(job)
 	local child = Command("jq")
-		:args({
-			"-C",
-			"--tab",
-			".",
-			tostring(job.file.url),
-		})
+		:args({ "-b", "-C", "--tab", ".", tostring(job.file.url) })
 		:stdout(Command.PIPED)
 		:stderr(Command.PIPED)
 		:spawn()


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2016