### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,7 +3342,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yazi-adapter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-boot"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-codegen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "quote",
  "syn",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-dds"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "mlua",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-fm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "better-panic",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-fs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3537,11 +3537,11 @@ dependencies = [
 
 [[package]]
 name = "yazi-macro"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "yazi-plugin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -3581,7 +3581,7 @@ checksum = "f4b6c8e12e39ac0f79fa96f36e5b88e0da8d230691abd729eec709b43c74f632"
 
 [[package]]
 name = "yazi-proxy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "mlua",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-scheduler"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-priority-channel",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "yazi-shared"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-adapter"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,9 +9,9 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-config = { path = "../yazi-config", version = "0.4.0" }
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-config = { path = "../yazi-config", version = "0.4.1" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 ansi-to-tui = { workspace = true }

--- a/yazi-boot/Cargo.toml
+++ b/yazi-boot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-boot"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,11 +9,11 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-adapter = { path = "../yazi-adapter", version = "0.4.0" }
-yazi-config  = { path = "../yazi-config", version = "0.4.0" }
-yazi-fs      = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro   = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared  = { path = "../yazi-shared", version = "0.4.0" }
+yazi-adapter = { path = "../yazi-adapter", version = "0.4.1" }
+yazi-config  = { path = "../yazi-config", version = "0.4.1" }
+yazi-fs      = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro   = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared  = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 clap  = { workspace = true }

--- a/yazi-cli/Cargo.toml
+++ b/yazi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-cli"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,11 +9,11 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-boot   = { path = "../yazi-boot", version = "0.4.0" }
-yazi-dds    = { path = "../yazi-dds", version = "0.4.0" }
-yazi-fs     = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-boot   = { path = "../yazi-boot", version = "0.4.1" }
+yazi-dds    = { path = "../yazi-dds", version = "0.4.1" }
+yazi-fs     = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow     = { workspace = true }
@@ -25,7 +25,7 @@ tokio      = { workspace = true }
 toml_edit  = "0.22.22"
 
 [build-dependencies]
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External build dependencies
 anyhow                = { workspace = true }

--- a/yazi-codegen/Cargo.toml
+++ b/yazi-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-codegen"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-config"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,9 +9,9 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-fs     = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-fs     = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow    = { workspace = true }

--- a/yazi-core/Cargo.toml
+++ b/yazi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-core"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,17 +9,17 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-adapter   = { path = "../yazi-adapter", version = "0.4.0" }
-yazi-boot      = { path = "../yazi-boot", version = "0.4.0" }
-yazi-codegen   = { path = "../yazi-codegen", version = "0.4.0" }
-yazi-config    = { path = "../yazi-config", version = "0.4.0" }
-yazi-dds       = { path = "../yazi-dds", version = "0.4.0" }
-yazi-fs        = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro     = { path = "../yazi-macro", version = "0.4.0" }
-yazi-plugin    = { path = "../yazi-plugin", version = "0.4.0" }
-yazi-proxy     = { path = "../yazi-proxy", version = "0.4.0" }
-yazi-scheduler = { path = "../yazi-scheduler", version = "0.4.0" }
-yazi-shared    = { path = "../yazi-shared", version = "0.4.0" }
+yazi-adapter   = { path = "../yazi-adapter", version = "0.4.1" }
+yazi-boot      = { path = "../yazi-boot", version = "0.4.1" }
+yazi-codegen   = { path = "../yazi-codegen", version = "0.4.1" }
+yazi-config    = { path = "../yazi-config", version = "0.4.1" }
+yazi-dds       = { path = "../yazi-dds", version = "0.4.1" }
+yazi-fs        = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro     = { path = "../yazi-macro", version = "0.4.1" }
+yazi-plugin    = { path = "../yazi-plugin", version = "0.4.1" }
+yazi-proxy     = { path = "../yazi-proxy", version = "0.4.1" }
+yazi-scheduler = { path = "../yazi-scheduler", version = "0.4.1" }
+yazi-shared    = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow        = { workspace = true }

--- a/yazi-dds/Cargo.toml
+++ b/yazi-dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-dds"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -13,10 +13,10 @@ default      = [ "vendored-lua" ]
 vendored-lua = [ "mlua/vendored" ]
 
 [dependencies]
-yazi-boot   = { path = "../yazi-boot", version = "0.4.0" }
-yazi-fs     = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-boot   = { path = "../yazi-boot", version = "0.4.1" }
+yazi-fs     = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow       = { workspace = true }

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-fm"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -13,17 +13,17 @@ default      = [ "vendored-lua" ]
 vendored-lua = [ "mlua/vendored" ]
 
 [dependencies]
-yazi-adapter = { path = "../yazi-adapter", version = "0.4.0" }
-yazi-boot    = { path = "../yazi-boot", version = "0.4.0" }
-yazi-codegen = { path = "../yazi-codegen", version = "0.4.0" }
-yazi-config  = { path = "../yazi-config", version = "0.4.0" }
-yazi-core    = { path = "../yazi-core", version = "0.4.0" }
-yazi-dds     = { path = "../yazi-dds", version = "0.4.0" }
-yazi-fs      = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro   = { path = "../yazi-macro", version = "0.4.0" }
-yazi-plugin  = { path = "../yazi-plugin", version = "0.4.0" }
-yazi-proxy   = { path = "../yazi-proxy", version = "0.4.0" }
-yazi-shared  = { path = "../yazi-shared", version = "0.4.0" }
+yazi-adapter = { path = "../yazi-adapter", version = "0.4.1" }
+yazi-boot    = { path = "../yazi-boot", version = "0.4.1" }
+yazi-codegen = { path = "../yazi-codegen", version = "0.4.1" }
+yazi-config  = { path = "../yazi-config", version = "0.4.1" }
+yazi-core    = { path = "../yazi-core", version = "0.4.1" }
+yazi-dds     = { path = "../yazi-dds", version = "0.4.1" }
+yazi-fs      = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro   = { path = "../yazi-macro", version = "0.4.1" }
+yazi-plugin  = { path = "../yazi-plugin", version = "0.4.1" }
+yazi-proxy   = { path = "../yazi-proxy", version = "0.4.1" }
+yazi-shared  = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow       = { workspace = true }

--- a/yazi-fs/Cargo.toml
+++ b/yazi-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-fs"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,8 +9,8 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow   = { workspace = true }

--- a/yazi-macro/Cargo.toml
+++ b/yazi-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-macro"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-plugin"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -13,14 +13,14 @@ default      = [ "vendored-lua" ]
 vendored-lua = [ "mlua/vendored" ]
 
 [dependencies]
-yazi-adapter = { path = "../yazi-adapter", version = "0.4.0" }
-yazi-boot    = { path = "../yazi-boot", version = "0.4.0" }
-yazi-config  = { path = "../yazi-config", version = "0.4.0" }
-yazi-dds     = { path = "../yazi-dds", version = "0.4.0" }
-yazi-fs      = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro   = { path = "../yazi-macro", version = "0.4.0" }
-yazi-proxy   = { path = "../yazi-proxy", version = "0.4.0" }
-yazi-shared  = { path = "../yazi-shared", version = "0.4.0" }
+yazi-adapter = { path = "../yazi-adapter", version = "0.4.1" }
+yazi-boot    = { path = "../yazi-boot", version = "0.4.1" }
+yazi-config  = { path = "../yazi-config", version = "0.4.1" }
+yazi-dds     = { path = "../yazi-dds", version = "0.4.1" }
+yazi-fs      = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro   = { path = "../yazi-macro", version = "0.4.1" }
+yazi-proxy   = { path = "../yazi-proxy", version = "0.4.1" }
+yazi-shared  = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 ansi-to-tui   = { workspace = true }

--- a/yazi-proxy/Cargo.toml
+++ b/yazi-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-proxy"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -13,9 +13,9 @@ default      = [ "vendored-lua" ]
 vendored-lua = [ "mlua/vendored" ]
 
 [dependencies]
-yazi-config = { path = "../yazi-config", version = "0.4.0" }
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-config = { path = "../yazi-config", version = "0.4.1" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow      = { workspace = true }

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "yazi-scheduler"
-version     = "0.4.0"
+version     = "0.4.1"
 edition     = "2021"
 license     = "MIT"
 authors     = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -9,13 +9,13 @@ homepage    = "https://yazi-rs.github.io"
 repository  = "https://github.com/sxyazi/yazi"
 
 [dependencies]
-yazi-config = { path = "../yazi-config", version = "0.4.0" }
-yazi-dds    = { path = "../yazi-dds", version = "0.4.0" }
-yazi-fs     = { path = "../yazi-fs", version = "0.4.0" }
-yazi-macro  = { path = "../yazi-macro", version = "0.4.0" }
-yazi-plugin = { path = "../yazi-plugin", version = "0.4.0" }
-yazi-proxy  = { path = "../yazi-proxy", version = "0.4.0" }
-yazi-shared = { path = "../yazi-shared", version = "0.4.0" }
+yazi-config = { path = "../yazi-config", version = "0.4.1" }
+yazi-dds    = { path = "../yazi-dds", version = "0.4.1" }
+yazi-fs     = { path = "../yazi-fs", version = "0.4.1" }
+yazi-macro  = { path = "../yazi-macro", version = "0.4.1" }
+yazi-plugin = { path = "../yazi-plugin", version = "0.4.1" }
+yazi-proxy  = { path = "../yazi-proxy", version = "0.4.1" }
+yazi-shared = { path = "../yazi-shared", version = "0.4.1" }
 
 # External dependencies
 anyhow                 = { workspace = true }

--- a/yazi-shared/Cargo.toml
+++ b/yazi-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "yazi-shared"
-version      = "0.4.0"
+version      = "0.4.1"
 edition      = "2021"
 license      = "MIT"
 authors      = [ "sxyazi <sxyazi@gmail.com>" ]
@@ -10,7 +10,7 @@ repository   = "https://github.com/sxyazi/yazi"
 rust-version = "1.78.0"
 
 [dependencies]
-yazi-macro = { path = "../yazi-macro", version = "0.4.0" }
+yazi-macro = { path = "../yazi-macro", version = "0.4.1" }
 
 # External dependencies
 anyhow           = { workspace = true }


### PR DESCRIPTION
This is a quick patch version with 4 fixes:

- Fixed an issue where Yazi would freeze when waiting for terminal response, in old tmux versions (v3.2a or lower), or 2-layer nested terminal setup (tmux -> Neovim's `:terminal` -> Yazi).
- Fixed a bug in the Überzug++ backend where certain image dimension parsing failed, preventing images from displaying.
- Fixed a build failure for Android 32-bit architectures.
- Fixed an issue with the preset `archive` and `json` plugins not handling CRLF properly on Windows.
