### PR TITLE
feat: new option to suppress 0.4 deprecation warnings

### DIFF
--- a/yazi-config/src/manager/manager.rs
+++ b/yazi-config/src/manager/manager.rs
@@ -26,6 +26,10 @@ pub struct Manager {
 	pub scrolloff:    u8,
 	pub mouse_events: MouseEvents,
 	pub title_format: String,
+
+	// TODO: remove this in Yazi 0.4.2
+	#[serde(default)]
+	pub _v4_suppress_deprecation_warnings: bool,
 }
 
 impl FromStr for Manager {

--- a/yazi-plugin/src/bindings/cha.rs
+++ b/yazi-plugin/src/bindings/cha.rs
@@ -18,10 +18,9 @@ impl<T: Into<yazi_fs::Cha>> From<T> for Cha {
 	fn from(cha: T) -> Self { Self(cha.into()) }
 }
 
-static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
 #[inline]
 fn warn_deprecated(id: Option<&str>) {
+	static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 	if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
 		let id = match id {
 			Some(id) => format!("`{id}.yazi` plugin"),

--- a/yazi-proxy/src/app.rs
+++ b/yazi-proxy/src/app.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use tokio::sync::oneshot;
+use yazi_config::MANAGER;
 use yazi_macro::emit;
 use yazi_shared::{Layer, event::Cmd};
 
@@ -23,6 +24,10 @@ impl AppProxy {
 
 	#[inline]
 	pub fn notify(opt: NotifyOpt) {
+		if MANAGER._v4_suppress_deprecation_warnings && opt.title.contains("Deprecated") {
+			return;
+		}
+
 		emit!(Call(Cmd::new("notify").with_any("option", opt), Layer::App));
 	}
 


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2026

Closes https://github.com/sxyazi/yazi/issues/2026

```toml
# yazi.toml
[manager]
_v4_suppress_deprecation_warnings = true
```