### PR TITLE
fix: choose a more conservative `macro_workers` value to ensure concurrency safety with certain USB flash drives

### DIFF
--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -80,8 +80,8 @@ rules = [
 
 [tasks]
 micro_workers    = 10
-macro_workers    = 25
-bizarre_retry    = 5
+macro_workers    = 10
+bizarre_retry    = 3
 image_alloc      = 536870912  # 512MB
 image_bound      = [ 0, 0 ]
 suppress_preload = false

--- a/yazi-fs/src/path.rs
+++ b/yazi-fs/src/path.rs
@@ -65,6 +65,16 @@ fn _expand_path(p: &Path) -> PathBuf {
 	}
 }
 
+pub fn skip_path(p: &Path, u: usize) -> &Path {
+	let mut it = p.components();
+	for _ in 0..u {
+		if it.next().is_none() {
+			return Path::new("");
+		}
+	}
+	it.as_path()
+}
+
 pub async fn unique_name<F>(u: Url, append: F) -> io::Result<Url>
 where
 	F: Future<Output = bool>,

--- a/yazi-scheduler/src/file/file.rs
+++ b/yazi-scheduler/src/file/file.rs
@@ -1,10 +1,10 @@
-use std::{borrow::Cow, collections::VecDeque, path::{Path, PathBuf}};
+use std::{borrow::Cow, collections::VecDeque, path::Path};
 
 use anyhow::{Result, anyhow};
 use tokio::{fs::{self, DirEntry}, io::{self, ErrorKind::{AlreadyExists, NotFound}}, sync::mpsc};
 use tracing::warn;
 use yazi_config::TASKS;
-use yazi_fs::{Cha, calculate_size, copy_with_progress, maybe_exists, ok_or_not_found, path_relative_to};
+use yazi_fs::{Cha, calculate_size, copy_with_progress, maybe_exists, ok_or_not_found, path_relative_to, skip_path};
 use yazi_shared::url::Url;
 
 use super::{FileOp, FileOpDelete, FileOpHardlink, FileOpLink, FileOpPaste, FileOpTrash};
@@ -190,7 +190,7 @@ impl File {
 		let mut dirs = VecDeque::from([task.from.clone()]);
 
 		while let Some(src) = dirs.pop_front() {
-			let dest = root.join(src.components().skip(skip).collect::<PathBuf>());
+			let dest = root.join(skip_path(&src, skip));
 			continue_unless_ok!(match fs::create_dir(&dest).await {
 				Err(e) if e.kind() != AlreadyExists => Err(e),
 				_ => Ok(()),
@@ -261,7 +261,7 @@ impl File {
 		let mut dirs = VecDeque::from([task.from.clone()]);
 
 		while let Some(src) = dirs.pop_front() {
-			let dest = root.join(src.components().skip(skip).collect::<PathBuf>());
+			let dest = root.join(skip_path(&src, skip));
 			continue_unless_ok!(match fs::create_dir(&dest).await {
 				Err(e) if e.kind() != AlreadyExists => Err(e),
 				_ => Ok(()),


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2036