### PR TITLE
fix: `allow-passthrough` must be set to `on` to prevent `tmux` from forwarding the real terminal's response to the inactive pane

### DIFF
--- a/yazi-adapter/src/lib.rs
+++ b/yazi-adapter/src/lib.rs
@@ -25,6 +25,18 @@ pub static WSL: RoCell<bool> = RoCell::new();
 pub static NVIM: RoCell<bool> = RoCell::new();
 
 pub fn init() -> anyhow::Result<()> {
+	init_default();
+
+	EMULATOR.init(Emulator::detect());
+	yazi_config::init_flavor(EMULATOR.light)?;
+
+	ADAPTOR.init(Adapter::matches(*EMULATOR));
+	ADAPTOR.start();
+
+	Ok(())
+}
+
+pub fn init_default() {
 	// Tmux support
 	TMUX.init(Mux::tmux_passthrough());
 	ESCAPE.init(if *TMUX == 2 { "\x1b\x1b" } else { "\x1b" });
@@ -36,12 +48,4 @@ pub fn init() -> anyhow::Result<()> {
 
 	// Neovim support
 	NVIM.init(env_exists("NVIM_LOG_FILE") && env_exists("NVIM"));
-
-	EMULATOR.init(Emulator::detect());
-	yazi_config::init_flavor(EMULATOR.light)?;
-
-	ADAPTOR.init(Adapter::matches(*EMULATOR));
-	ADAPTOR.start();
-
-	Ok(())
 }

--- a/yazi-adapter/src/mux.rs
+++ b/yazi-adapter/src/mux.rs
@@ -25,7 +25,7 @@ impl Mux {
 		}
 
 		let child = std::process::Command::new("tmux")
-			.args(["set", "-p", "allow-passthrough", "all"])
+			.args(["set", "-p", "allow-passthrough", "on"])
 			.stdin(std::process::Stdio::null())
 			.stdout(std::process::Stdio::null())
 			.stderr(std::process::Stdio::piped())
@@ -35,13 +35,13 @@ impl Mux {
 			Ok(output) if output.status.success() => return 2,
 			Ok(output) => {
 				error!(
-					"Running `tmux set -p allow-passthrough all` failed: {:?}, {}",
+					"Running `tmux set -p allow-passthrough on` failed: {:?}, {}",
 					output.status,
 					String::from_utf8_lossy(&output.stderr)
 				);
 			}
 			Err(err) => {
-				error!("Failed to spawn `tmux set -p allow-passthrough all`: {err}");
+				error!("Failed to spawn `tmux set -p allow-passthrough on`: {err}");
 			}
 		}
 		1

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -26,13 +26,17 @@ impl Term {
 		};
 
 		enable_raw_mode()?;
+		if *yazi_adapter::TMUX != 0 {
+			yazi_adapter::Mux::tmux_passthrough();
+		}
+
 		execute!(
 			BufWriter::new(stderr()),
-			EnterAlternateScreen,
 			Print(Mux::csi("\x1bP$q q\x1b\\")), // Request cursor shape (DECRQM)
 			Print(Mux::csi("\x1b[?12$p")),      // Request cursor blink status (DECSET)
 			Print("\x1b[?u"),                   // Request keyboard enhancement flags (CSI u)
 			Print(Mux::csi("\x1b[0c")),         // Request device attributes
+			EnterAlternateScreen,
 			EnableBracketedPaste,
 			mouse::SetMouse(true),
 		)?;


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2050