### PR TITLE
fix: use a less intrusive `DSR` instead of `DA1` workaround to forward terminal responses twice in `tmux`

### DIFF
--- a/yazi-adapter/src/mux.rs
+++ b/yazi-adapter/src/mux.rs
@@ -1,7 +1,8 @@
+use anyhow::Result;
 use tracing::error;
 use yazi_shared::env_exists;
 
-use crate::{CLOSE, ESCAPE, NVIM, START, TMUX};
+use crate::{CLOSE, ESCAPE, Emulator, NVIM, START, TMUX};
 
 pub struct Mux;
 
@@ -45,6 +46,14 @@ impl Mux {
 			}
 		}
 		1
+	}
+
+	pub fn tmux_drain() -> Result<()> {
+		if *TMUX == 2 && !*NVIM {
+			crossterm::execute!(std::io::stderr(), crossterm::style::Print(Mux::csi("\x1b[5n")))?;
+			_ = futures::executor::block_on(Emulator::read_until_dsr());
+		}
+		Ok(())
 	}
 
 	pub fn tmux_sixel_flag() -> &'static str {

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -42,6 +42,8 @@ impl Term {
 		)?;
 
 		let da = futures::executor::block_on(Emulator::read_until_da1());
+		Mux::tmux_drain()?;
+
 		CSI_U.store(da.contains("\x1b[?0u"), Ordering::Relaxed);
 		BLINK.store(da.contains("\x1b[?12;1$y"), Ordering::Relaxed);
 		SHAPE.store(


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2050