### PR TITLE
feat: hide specified files and dirs

### DIFF
--- a/yazi-config/src/mgr/mgr.rs
+++ b/yazi-config/src/mgr/mgr.rs
@@ -26,6 +26,7 @@ pub struct Mgr {
 	pub scrolloff:    u8,
 	pub mouse_events: MouseEvents,
 	pub title_format: String,
+	pub ignore_rule:  String,
 }
 
 impl FromStr for Mgr {

--- a/yazi-core/src/tab/folder.rs
+++ b/yazi-core/src/tab/folder.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use yazi_config::{LAYOUT, MGR};
 use yazi_dds::Pubsub;
-use yazi_fs::{File, Files, FilesOp, FolderStage, Step, cha::Cha};
+use yazi_fs::{File, Files, FilesOp, FolderStage, Step, cha::Cha, Filter};
 use yazi_proxy::MgrProxy;
 use yazi_shared::{Id, url::{Url, Urn, UrnBuf}};
 
@@ -24,7 +24,7 @@ impl Default for Folder {
 		Self {
 			url:    Default::default(),
 			cha:    Default::default(),
-			files:  Files::new(MGR.show_hidden),
+			files:  Files::new(MGR.show_hidden, Filter::new(MGR.ignore_rule.as_str(), yazi_fs::FilterCase::Smart).ok()),
 			stage:  Default::default(),
 			offset: Default::default(),
 			cursor: Default::default(),


### PR DESCRIPTION
Try to fix #694.

Works with the given regex string:
https://github.com/TobisLee/yazi/blob/2fdd7b6f554dd4e15648ed8f611bd83cedd511c8/yazi-shared/src/url/urn.rs#L22
but failed with hidden_rule config:
https://github.com/TobisLee/yazi/blob/2fdd7b6f554dd4e15648ed8f611bd83cedd511c8/yazi-shared/src/url/urn.rs#L23

Cargo shows
```txt
error: cyclic package dependency: package `yazi-config v0.4.3 (/home/tlss/repos/rust_project/yazi/yazi-config)` depends on itself. Cycle:
package `yazi-config v0.4.3 (/home/tlss/repos/rust_project/yazi/yazi-config)`
    ... which satisfies path dependency `yazi-config` (locked to 0.4.3) of package `yazi-shared v0.4.3 (/home/tlss/repos/rust_project/yazi/yazi-shared)`
    ... which satisfies path dependency `yazi-shared` (locked to 0.4.3) of package `yazi-fs v0.4.3 (/home/tlss/repos/rust_project/yazi/yazi-fs)`
    ... which satisfies path dependency `yazi-fs` (locked to 0.4.3) of package `yazi-config v0.4.3 (/home/tlss/repos/rust_project/yazi/yazi-config)`
    ... which satisfies path dependency `yazi-config` (locked to 0.4.3) of package `yazi-adapter v0.4.3 (/home/tlss/repos/rust_project/yazi/yazi-adapter)`
```
