### PR TITLE
feat: prompt users without `fzf` for the `zoxide` plugin

### DIFF
--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -89,12 +89,6 @@ local function entry()
 
 	local _permit = ya.hide()
 
-	local fzf, _err = Command("fzf"):arg("--version"):stdout(Command.PIPED):stderr(Command.PIPED):output()
-
-	if not fzf then
-		return fail(string.format("%s\n%s", "`fzf` is required for the `zoxide` plugin.", "Please install `fzf`."))
-	end
-
 	local child, err = Command("zoxide")
 		:args({ "query", "-i", "--exclude" })
 		:arg(st.cwd)
@@ -114,6 +108,8 @@ local function entry()
 	local output, error = child:wait_with_output()
 	if not output then
 		return fail("Cannot read `zoxide` output, error: " .. error)
+	elseif output.stderr:find("could not find") then
+		return fail(output.stderr)
 	elseif not output.status.success and output.status.code ~= 130 then
 		return fail("`zoxide` exited with error code %s", output.status.code)
 	end

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -88,7 +88,6 @@ local function entry()
 	end
 
 	local _permit = ya.hide()
-
 	local child, err1 = Command("zoxide")
 		:args({ "query", "-i", "--exclude" })
 		:arg(st.cwd)

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -59,10 +59,10 @@ local function empty(cwd)
 	return not first
 end
 
-local function setup(_, opts)
-	opts = opts or {}
+local function setup(_, options)
+	options = options or {}
 
-	if opts.update_db then
+	if options.update_db then
 		ps.sub(
 			"cd",
 			function()
@@ -88,6 +88,13 @@ local function entry()
 	end
 
 	local _permit = ya.hide()
+
+	local fzf, _err = Command("fzf"):arg("--version"):stdout(Command.PIPED):stderr(Command.PIPED):output()
+
+	if not fzf then
+		return fail(string.format("%s\n%s", "`fzf` is required for the `zoxide` plugin.", "Please install `fzf`."))
+	end
+
 	local child, err = Command("zoxide")
 		:args({ "query", "-i", "--exclude" })
 		:arg(st.cwd)
@@ -104,9 +111,9 @@ local function entry()
 		return fail("Failed to start `zoxide`, error: " .. err)
 	end
 
-	local output, err = child:wait_with_output()
+	local output, error = child:wait_with_output()
 	if not output then
-		return fail("Cannot read `zoxide` output, error: " .. err)
+		return fail("Cannot read `zoxide` output, error: " .. error)
 	elseif not output.status.success and output.status.code ~= 130 then
 		return fail("`zoxide` exited with error code %s", output.status.code)
 	end

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -108,7 +108,7 @@ local function entry()
 	if not output then
 		return fail("Cannot read `zoxide` output, error: " .. err2)
 	elseif not output.status.success and output.status.code ~= 130 then
-		return fail("`zoxide` exited with code %s: %s", output.status.code, output.stderr:gsub("^zoxide:%s+", ""))
+		return fail("`zoxide` exited with code %s: %s", output.status.code, output.stderr:gsub("^zoxide:%s*", ""))
 	end
 
 	local target = output.stdout:gsub("\n$", "")

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -9,7 +9,7 @@ local set_state = ya.sync(function(st, empty) st.empty = empty end)
 
 local function fail(s, ...) ya.notify { title = "Zoxide", content = s:format(...), timeout = 5, level = "error" } end
 
-local function opts()
+local function options()
 	-- https://github.com/ajeetdsouza/zoxide/blob/main/src/cmd/query.rs#L92
 	local default = {
 		-- Search mode
@@ -59,10 +59,10 @@ local function empty(cwd)
 	return not first
 end
 
-local function setup(_, options)
-	options = options or {}
+local function setup(_, opts)
+	opts = opts or {}
 
-	if options.update_db then
+	if opts.update_db then
 		ps.sub(
 			"cd",
 			function()
@@ -89,29 +89,27 @@ local function entry()
 
 	local _permit = ya.hide()
 
-	local child, err = Command("zoxide")
+	local child, err1 = Command("zoxide")
 		:args({ "query", "-i", "--exclude" })
 		:arg(st.cwd)
 		:env("SHELL", "sh")
 		:env("CLICOLOR", "1")
 		:env("CLICOLOR_FORCE", "1")
-		:env("_ZO_FZF_OPTS", opts())
+		:env("_ZO_FZF_OPTS", options())
 		:stdin(Command.INHERIT)
 		:stdout(Command.PIPED)
-		:stderr(Command.INHERIT)
+		:stderr(Command.PIPED)
 		:spawn()
 
 	if not child then
-		return fail("Failed to start `zoxide`, error: " .. err)
+		return fail("Failed to start `zoxide`, error: " .. err1)
 	end
 
-	local output, error = child:wait_with_output()
+	local output, err2 = child:wait_with_output()
 	if not output then
-		return fail("Cannot read `zoxide` output, error: " .. error)
-	elseif output.stderr:find("could not find") then
-		return fail(output.stderr)
+		return fail("Cannot read `zoxide` output, error: " .. err2)
 	elseif not output.status.success and output.status.code ~= 130 then
-		return fail("`zoxide` exited with error code %s", output.status.code)
+		return fail("`zoxide` exited with code %s: %s", output.status.code, output.stderr:gsub("^zoxide:%s+", ""))
 	end
 
 	local target = output.stdout:gsub("\n$", "")


### PR DESCRIPTION
Also fixed some local variables that were redefined.

Closes #1851.