### PR TITLE
fix: correct Vec capacity allocation caused by variable name shadowing

### DIFF
--- a/yazi-fs/src/files.rs
+++ b/yazi-fs/src/files.rs
@@ -61,7 +61,7 @@ impl Files {
 		let (first, rest) = entries.split_at(entries.len() / 3);
 		let (second, third) = rest.split_at(entries.len() / 3);
 		async fn go(entries: &[DirEntry]) -> Vec<File> {
-			let mut files = Vec::with_capacity(entries.len() / 3 + 1);
+			let mut files = Vec::with_capacity(entries.len());
 			for entry in entries {
 				let url = Url::from(entry.path());
 				files.push(match entry.metadata().await {


### PR DESCRIPTION
as the title