### PR TITLE
feat: replace mode and Vim motions (`W`, `E`, `B`, `^`, `_`) for inputs

### DIFF
--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -238,6 +238,7 @@ keymap = [
 	{ on = "A", run = [ "move 999", "insert --append" ],     desc = "Move to the EOL, and enter append mode" },
 	{ on = "v", run = "visual",                              desc = "Enter visual mode" },
 	{ on = "V", run = [ "move -999", "visual", "move 999" ], desc = "Enter visual mode and select all" },
+	{ on = "r", run = "replace",                             desc = "Enter replace mode" },
 
 	# Character-wise movement
 	{ on = "h",       run = "move -1", desc = "Move back a character" },

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -237,7 +237,7 @@ keymap = [
 	{ on = "I", run = [ "move first-char", "insert" ],             desc = "Move to the BOL, and enter insert mode" },
 	{ on = "A", run = [ "move eol", "insert --append" ],           desc = "Move to the EOL, and enter append mode" },
 	{ on = "v", run = "visual",                                    desc = "Enter visual mode" },
-	{ on = "V", run = [ "move first-char", "visual", "move eol" ], desc = "Enter visual mode and select all" },
+	{ on = "V", run = [ "move bol", "visual", "move eol" ], desc = "Enter visual mode and select all" },
 	{ on = "r", run = "replace",                                   desc = "Replace a single character" },
 
 	# Character-wise movement

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -232,13 +232,13 @@ keymap = [
 	{ on = "<C-[>",   run = "escape",         desc = "Go back the normal mode, or cancel input" },
 
 	# Mode
-	{ on = "i", run = "insert",                                    desc = "Enter insert mode" },
-	{ on = "a", run = "insert --append",                           desc = "Enter append mode" },
-	{ on = "I", run = [ "move first-char", "insert" ],             desc = "Move to the BOL, and enter insert mode" },
-	{ on = "A", run = [ "move eol", "insert --append" ],           desc = "Move to the EOL, and enter append mode" },
-	{ on = "v", run = "visual",                                    desc = "Enter visual mode" },
+	{ on = "i", run = "insert",                             desc = "Enter insert mode" },
+	{ on = "I", run = [ "move first-char", "insert" ],      desc = "Move to the BOL, and enter insert mode" },
+	{ on = "a", run = "insert --append",                    desc = "Enter append mode" },
+	{ on = "A", run = [ "move eol", "insert --append" ],    desc = "Move to the EOL, and enter append mode" },
+	{ on = "v", run = "visual",                             desc = "Enter visual mode" },
 	{ on = "V", run = [ "move bol", "visual", "move eol" ], desc = "Enter visual mode and select all" },
-	{ on = "r", run = "replace",                                   desc = "Replace a single character" },
+	{ on = "r", run = "replace",                            desc = "Replace a single character" },
 
 	# Character-wise movement
 	{ on = "h",       run = "move -1", desc = "Move back a character" },
@@ -250,10 +250,10 @@ keymap = [
 
 	# Word-wise movement
 	{ on = "b",     run = "backward",                    desc = "Move back to the start of the current or previous word" },
-	{ on = "w",     run = "forward",                     desc = "Move forward to the start of the next word" },
-	{ on = "e",     run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
 	{ on = "B",     run = "backward --big",              desc = "Move back to the start of the current or previous WORD" },
+	{ on = "w",     run = "forward",                     desc = "Move forward to the start of the next word" },
 	{ on = "W",     run = "forward --big",               desc = "Move forward to the start of the next WORD" },
+	{ on = "e",     run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
 	{ on = "E",     run = "forward --big --end-of-word", desc = "Move forward to the end of the current or next WORD" },
 	{ on = "<A-b>", run = "backward",                    desc = "Move back to the start of the current or previous word" },
 	{ on = "<A-f>", run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -238,7 +238,7 @@ keymap = [
 	{ on = "A", run = [ "move 999", "insert --append" ],     desc = "Move to the EOL, and enter append mode" },
 	{ on = "v", run = "visual",                              desc = "Enter visual mode" },
 	{ on = "V", run = [ "move -999", "visual", "move 999" ], desc = "Enter visual mode and select all" },
-	{ on = "r", run = "replace",                             desc = "Enter replace mode" },
+	{ on = "r", run = "replace",                             desc = "Replace a single character" },
 
 	# Character-wise movement
 	{ on = "h",       run = "move -1", desc = "Move back a character" },

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -249,11 +249,14 @@ keymap = [
 	{ on = "<C-f>",   run = "move 1",  desc = "Move forward a character" },
 
 	# Word-wise movement
-	{ on = "b",     run = "backward",              desc = "Move back to the start of the current or previous word" },
-	{ on = "w",     run = "forward",               desc = "Move forward to the start of the next word" },
-	{ on = "e",     run = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
-	{ on = "<A-b>", run = "backward",              desc = "Move back to the start of the current or previous word" },
-	{ on = "<A-f>", run = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
+	{ on = "b",     run = "backward",                    desc = "Move back to the start of the current or previous word" },
+	{ on = "w",     run = "forward",                     desc = "Move forward to the start of the next word" },
+	{ on = "e",     run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
+	{ on = "B",     run = "backward --big",              desc = "Move back to the start of the current or previous WORD" },
+	{ on = "W",     run = "forward --big",               desc = "Move forward to the start of the next WORD" },
+	{ on = "E",     run = "forward --big --end-of-word", desc = "Move forward to the end of the current or next WORD" },
+	{ on = "<A-b>", run = "backward",                    desc = "Move back to the start of the current or previous word" },
+	{ on = "<A-f>", run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
 
 	# Line-wise movement
 	{ on = "0",      run = "move bol",        desc = "Move to the BOL" },

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -250,11 +250,11 @@ keymap = [
 
 	# Word-wise movement
 	{ on = "b",     run = "backward",                    desc = "Move back to the start of the current or previous word" },
-	{ on = "B",     run = "backward --big",              desc = "Move back to the start of the current or previous WORD" },
+	{ on = "B",     run = "backward --far",              desc = "Move back to the start of the current or previous WORD" },
 	{ on = "w",     run = "forward",                     desc = "Move forward to the start of the next word" },
-	{ on = "W",     run = "forward --big",               desc = "Move forward to the start of the next WORD" },
+	{ on = "W",     run = "forward --far",               desc = "Move forward to the start of the next WORD" },
 	{ on = "e",     run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
-	{ on = "E",     run = "forward --big --end-of-word", desc = "Move forward to the end of the current or next WORD" },
+	{ on = "E",     run = "forward --far --end-of-word", desc = "Move forward to the end of the current or next WORD" },
 	{ on = "<A-b>", run = "backward",                    desc = "Move back to the start of the current or previous word" },
 	{ on = "<A-f>", run = "forward --end-of-word",       desc = "Move forward to the end of the current or next word" },
 

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -232,13 +232,13 @@ keymap = [
 	{ on = "<C-[>",   run = "escape",         desc = "Go back the normal mode, or cancel input" },
 
 	# Mode
-	{ on = "i", run = "insert",                              desc = "Enter insert mode" },
-	{ on = "a", run = "insert --append",                     desc = "Enter append mode" },
-	{ on = "I", run = [ "move -999", "insert" ],             desc = "Move to the BOL, and enter insert mode" },
-	{ on = "A", run = [ "move 999", "insert --append" ],     desc = "Move to the EOL, and enter append mode" },
-	{ on = "v", run = "visual",                              desc = "Enter visual mode" },
-	{ on = "V", run = [ "move -999", "visual", "move 999" ], desc = "Enter visual mode and select all" },
-	{ on = "r", run = "replace",                             desc = "Replace a single character" },
+	{ on = "i", run = "insert",                                    desc = "Enter insert mode" },
+	{ on = "a", run = "insert --append",                           desc = "Enter append mode" },
+	{ on = "I", run = [ "move first-char", "insert" ],             desc = "Move to the BOL, and enter insert mode" },
+	{ on = "A", run = [ "move eol", "insert --append" ],           desc = "Move to the EOL, and enter append mode" },
+	{ on = "v", run = "visual",                                    desc = "Enter visual mode" },
+	{ on = "V", run = [ "move first-char", "visual", "move eol" ], desc = "Enter visual mode and select all" },
+	{ on = "r", run = "replace",                                   desc = "Replace a single character" },
 
 	# Character-wise movement
 	{ on = "h",       run = "move -1", desc = "Move back a character" },
@@ -256,12 +256,14 @@ keymap = [
 	{ on = "<A-f>", run = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
 
 	# Line-wise movement
-	{ on = "0",      run = "move -999", desc = "Move to the BOL" },
-	{ on = "$",      run = "move 999",  desc = "Move to the EOL" },
-	{ on = "<C-a>",  run = "move -999", desc = "Move to the BOL" },
-	{ on = "<C-e>",  run = "move 999",  desc = "Move to the EOL" },
-	{ on = "<Home>", run = "move -999", desc = "Move to the BOL" },
-	{ on = "<End>",  run = "move 999",  desc = "Move to the EOL" },
+	{ on = "0",      run = "move bol",          desc = "Move to the BOL" },
+	{ on = "_",      run = "move first-char",   desc = "Move to the first non-whitespace character" },
+	{ on = "^",      run = "move first-char",   desc = "Move to the first non-whitespace character" },
+	{ on = "$",      run = "move eol",          desc = "Move to the EOL" },
+	{ on = "<C-a>",  run = "move first-char",   desc = "Move to the BOL" },
+	{ on = "<C-e>",  run = "move eol",          desc = "Move to the EOL" },
+	{ on = "<Home>", run = "move first-char",   desc = "Move to the BOL" },
+	{ on = "<End>",  run = "move eol",          desc = "Move to the EOL" },
 
 	# Delete
 	{ on = "<Backspace>", run = "backspace",         desc = "Delete the character before the cursor" },
@@ -276,14 +278,14 @@ keymap = [
 	{ on = "<A-d>", run = "kill forward",  desc = "Kill forwards to the end of the current word" },
 
 	# Cut/Yank/Paste
-	{ on = "d", run = "delete --cut",                              desc = "Cut the selected characters" },
-	{ on = "D", run = [ "delete --cut", "move 999" ],              desc = "Cut until the EOL" },
-	{ on = "c", run = "delete --cut --insert",                     desc = "Cut the selected characters, and enter insert mode" },
-	{ on = "C", run = [ "delete --cut --insert", "move 999" ],     desc = "Cut until the EOL, and enter insert mode" },
-	{ on = "x", run = [ "delete --cut", "move 1 --in-operating" ], desc = "Cut the current character" },
-	{ on = "y", run = "yank",                                      desc = "Copy the selected characters" },
-	{ on = "p", run = "paste",                                     desc = "Paste the copied characters after the cursor" },
-	{ on = "P", run = "paste --before",                            desc = "Paste the copied characters before the cursor" },
+	{ on = "d", run = "delete --cut",                               desc = "Cut the selected characters" },
+	{ on = "D", run = [ "delete --cut", "move eol" ],               desc = "Cut until the EOL" },
+	{ on = "c", run = "delete --cut --insert",                      desc = "Cut the selected characters, and enter insert mode" },
+	{ on = "C", run = [ "delete --cut --insert", "move eol" ],      desc = "Cut until the EOL, and enter insert mode" },
+	{ on = "x", run = [ "delete --cut", "move 1 --in-operating" ],  desc = "Cut the current character" },
+	{ on = "y", run = "yank",                                       desc = "Copy the selected characters" },
+	{ on = "p", run = "paste",                                      desc = "Paste the copied characters after the cursor" },
+	{ on = "P", run = "paste --before",                             desc = "Paste the copied characters before the cursor" },
 
 	# Undo/Redo
 	{ on = "u",     run = "undo", desc = "Undo the last operation" },

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -256,14 +256,14 @@ keymap = [
 	{ on = "<A-f>", run = "forward --end-of-word", desc = "Move forward to the end of the current or next word" },
 
 	# Line-wise movement
-	{ on = "0",      run = "move bol",          desc = "Move to the BOL" },
-	{ on = "_",      run = "move first-char",   desc = "Move to the first non-whitespace character" },
-	{ on = "^",      run = "move first-char",   desc = "Move to the first non-whitespace character" },
-	{ on = "$",      run = "move eol",          desc = "Move to the EOL" },
-	{ on = "<C-a>",  run = "move first-char",   desc = "Move to the BOL" },
-	{ on = "<C-e>",  run = "move eol",          desc = "Move to the EOL" },
-	{ on = "<Home>", run = "move first-char",   desc = "Move to the BOL" },
-	{ on = "<End>",  run = "move eol",          desc = "Move to the EOL" },
+	{ on = "0",      run = "move bol",        desc = "Move to the BOL" },
+	{ on = "_",      run = "move first-char", desc = "Move to the first non-whitespace character" },
+	{ on = "^",      run = "move first-char", desc = "Move to the first non-whitespace character" },
+	{ on = "$",      run = "move eol",        desc = "Move to the EOL" },
+	{ on = "<C-a>",  run = "move first-char", desc = "Move to the BOL" },
+	{ on = "<C-e>",  run = "move eol",        desc = "Move to the EOL" },
+	{ on = "<Home>", run = "move first-char", desc = "Move to the BOL" },
+	{ on = "<End>",  run = "move eol",        desc = "Move to the EOL" },
 
 	# Delete
 	{ on = "<Backspace>", run = "backspace",         desc = "Delete the character before the cursor" },
@@ -278,14 +278,14 @@ keymap = [
 	{ on = "<A-d>", run = "kill forward",  desc = "Kill forwards to the end of the current word" },
 
 	# Cut/Yank/Paste
-	{ on = "d", run = "delete --cut",                               desc = "Cut the selected characters" },
-	{ on = "D", run = [ "delete --cut", "move eol" ],               desc = "Cut until the EOL" },
-	{ on = "c", run = "delete --cut --insert",                      desc = "Cut the selected characters, and enter insert mode" },
-	{ on = "C", run = [ "delete --cut --insert", "move eol" ],      desc = "Cut until the EOL, and enter insert mode" },
-	{ on = "x", run = [ "delete --cut", "move 1 --in-operating" ],  desc = "Cut the current character" },
-	{ on = "y", run = "yank",                                       desc = "Copy the selected characters" },
-	{ on = "p", run = "paste",                                      desc = "Paste the copied characters after the cursor" },
-	{ on = "P", run = "paste --before",                             desc = "Paste the copied characters before the cursor" },
+	{ on = "d", run = "delete --cut",                              desc = "Cut the selected characters" },
+	{ on = "D", run = [ "delete --cut", "move eol" ],              desc = "Cut until the EOL" },
+	{ on = "c", run = "delete --cut --insert",                     desc = "Cut the selected characters, and enter insert mode" },
+	{ on = "C", run = [ "delete --cut --insert", "move eol" ],     desc = "Cut until the EOL, and enter insert mode" },
+	{ on = "x", run = [ "delete --cut", "move 1 --in-operating" ], desc = "Cut the current character" },
+	{ on = "y", run = "yank",                                      desc = "Copy the selected characters" },
+	{ on = "p", run = "paste",                                     desc = "Paste the copied characters after the cursor" },
+	{ on = "P", run = "paste --before",                            desc = "Paste the copied characters before the cursor" },
 
 	# Undo/Redo
 	{ on = "u",     run = "undo", desc = "Undo the last operation" },

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -260,12 +260,12 @@ keymap = [
 
 	# Line-wise movement
 	{ on = "0",      run = "move bol",        desc = "Move to the BOL" },
+	{ on = "$",      run = "move eol",        desc = "Move to the EOL" },
 	{ on = "_",      run = "move first-char", desc = "Move to the first non-whitespace character" },
 	{ on = "^",      run = "move first-char", desc = "Move to the first non-whitespace character" },
-	{ on = "$",      run = "move eol",        desc = "Move to the EOL" },
-	{ on = "<C-a>",  run = "move first-char", desc = "Move to the BOL" },
+	{ on = "<C-a>",  run = "move bol",        desc = "Move to the BOL" },
 	{ on = "<C-e>",  run = "move eol",        desc = "Move to the EOL" },
-	{ on = "<Home>", run = "move first-char", desc = "Move to the BOL" },
+	{ on = "<Home>", run = "move bol",        desc = "Move to the BOL" },
 	{ on = "<End>",  run = "move eol",        desc = "Move to the EOL" },
 
 	# Delete

--- a/yazi-core/src/input/commands/backspace.rs
+++ b/yazi-core/src/input/commands/backspace.rs
@@ -17,7 +17,7 @@ impl From<bool> for Opt {
 impl Input {
 	#[yazi_codegen::command]
 	pub fn backspace(&mut self, opt: Opt) {
-		let snap = self.snaps.current_mut();
+		let snap = self.snap_mut();
 		if !opt.under && snap.cursor < 1 {
 			return;
 		} else if opt.under && snap.cursor >= snap.count() {

--- a/yazi-core/src/input/commands/backward.rs
+++ b/yazi-core/src/input/commands/backward.rs
@@ -22,13 +22,11 @@ impl Input {
 		let mut it = snap.value[..idx].chars().rev().enumerate();
 		let mut prev = CharKind::new(it.next().unwrap().1);
 		for (i, c) in it {
-			let c = CharKind::new(c);
-			let new_char_kind =
-				if opt.far { (c == CharKind::Space) != (prev == CharKind::Space) } else { c != prev };
-			if prev != CharKind::Space && new_char_kind {
+			let k = CharKind::new(c);
+			if prev != CharKind::Space && prev.vary(k, opt.far) {
 				return self.move_(-(i as isize));
 			}
-			prev = c;
+			prev = k;
 		}
 
 		if prev != CharKind::Space {

--- a/yazi-core/src/input/commands/backward.rs
+++ b/yazi-core/src/input/commands/backward.rs
@@ -3,12 +3,11 @@ use yazi_shared::{CharKind, event::CmdCow};
 use crate::input::Input;
 
 struct Opt {
-	big: bool,
+	far: bool,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { big: c.bool("big") }
-	}
+	fn from(c: CmdCow) -> Self { Self { far: c.bool("far") } }
 }
 
 impl Input {
@@ -24,11 +23,8 @@ impl Input {
 		let mut prev = CharKind::new(it.next().unwrap().1);
 		for (i, c) in it {
 			let c = CharKind::new(c);
-			let new_char_kind = if opt.big {
-				(c == CharKind::Space) != (prev == CharKind::Space)
-			} else {
-				c != prev
-			};
+			let new_char_kind =
+				if opt.far { (c == CharKind::Space) != (prev == CharKind::Space) } else { c != prev };
 			if prev != CharKind::Space && new_char_kind {
 				return self.move_(-(i as isize));
 			}

--- a/yazi-core/src/input/commands/backward.rs
+++ b/yazi-core/src/input/commands/backward.rs
@@ -2,8 +2,18 @@ use yazi_shared::{CharKind, event::CmdCow};
 
 use crate::input::Input;
 
+struct Opt {
+	big: bool,
+}
+
+impl From<CmdCow> for Opt {
+	fn from(c: CmdCow) -> Self { Self { big: c.bool("big") }
+	}
+}
+
 impl Input {
-	pub fn backward(&mut self, _: CmdCow) {
+	#[yazi_codegen::command]
+	pub fn backward(&mut self, opt: Opt) {
 		let snap = self.snap();
 		if snap.cursor == 0 {
 			return self.move_(0);
@@ -14,7 +24,12 @@ impl Input {
 		let mut prev = CharKind::new(it.next().unwrap().1);
 		for (i, c) in it {
 			let c = CharKind::new(c);
-			if prev != CharKind::Space && prev != c {
+			let new_char_kind = if opt.big {
+				(c == CharKind::Space) != (prev == CharKind::Space)
+			} else {
+				c != prev
+			};
+			if prev != CharKind::Space && new_char_kind {
 				return self.move_(-(i as isize));
 			}
 			prev = c;

--- a/yazi-core/src/input/commands/complete.rs
+++ b/yazi-core/src/input/commands/complete.rs
@@ -39,7 +39,7 @@ impl Input {
 			format!("{}{after}", opt.word).replace(SEPARATOR, MAIN_SEPARATOR_STR)
 		};
 
-		let snap = self.snaps.current_mut();
+		let snap = self.snap_mut();
 		if new == snap.value {
 			return;
 		}

--- a/yazi-core/src/input/commands/escape.rs
+++ b/yazi-core/src/input/commands/escape.rs
@@ -32,6 +32,9 @@ impl Input {
 					CompletionProxy::close();
 				}
 			}
+			InputMode::Replace => {
+				snap.mode = InputMode::Normal;
+			}
 		}
 
 		self.snaps.tag(self.limit());

--- a/yazi-core/src/input/commands/forward.rs
+++ b/yazi-core/src/input/commands/forward.rs
@@ -22,20 +22,18 @@ impl Input {
 		};
 
 		for (i, c) in it {
-			let c = CharKind::new(c);
-			let new_char_kind =
-				if opt.far { (c == CharKind::Space) != (prev == CharKind::Space) } else { c != prev };
+			let k = CharKind::new(c);
 			let b = if opt.end_of_word {
-				prev != CharKind::Space && new_char_kind && i != 1
+				prev != CharKind::Space && prev.vary(k, opt.far) && i != 1
 			} else {
-				c != CharKind::Space && new_char_kind
+				k != CharKind::Space && k.vary(prev, opt.far)
 			};
 			if b && !matches!(snap.op, InputOp::None | InputOp::Select(_)) {
 				return self.move_(i as isize);
 			} else if b {
 				return self.move_(if opt.end_of_word { i - 1 } else { i } as isize);
 			}
-			prev = c;
+			prev = k;
 		}
 
 		self.move_(snap.len() as isize)

--- a/yazi-core/src/input/commands/forward.rs
+++ b/yazi-core/src/input/commands/forward.rs
@@ -3,17 +3,12 @@ use yazi_shared::{CharKind, event::CmdCow};
 use crate::input::{Input, op::InputOp};
 
 struct Opt {
+	far:         bool,
 	end_of_word: bool,
-	big: bool,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self {
-		Self {
-			end_of_word: c.bool("end-of-word"),
-			big:         c.bool("big"),
-		}
-	}
+	fn from(c: CmdCow) -> Self { Self { far: c.bool("far"), end_of_word: c.bool("end-of-word") } }
 }
 
 impl Input {
@@ -28,11 +23,8 @@ impl Input {
 
 		for (i, c) in it {
 			let c = CharKind::new(c);
-			let new_char_kind = if opt.big {
-				(c == CharKind::Space) != (prev == CharKind::Space)
-			} else {
-				c != prev
-			};
+			let new_char_kind =
+				if opt.far { (c == CharKind::Space) != (prev == CharKind::Space) } else { c != prev };
 			let b = if opt.end_of_word {
 				prev != CharKind::Space && new_char_kind && i != 1
 			} else {

--- a/yazi-core/src/input/commands/forward.rs
+++ b/yazi-core/src/input/commands/forward.rs
@@ -4,10 +4,16 @@ use crate::input::{Input, op::InputOp};
 
 struct Opt {
 	end_of_word: bool,
+	big: bool,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { end_of_word: c.bool("end-of-word") } }
+	fn from(c: CmdCow) -> Self {
+		Self {
+			end_of_word: c.bool("end-of-word"),
+			big:         c.bool("big"),
+		}
+	}
 }
 
 impl Input {
@@ -22,10 +28,15 @@ impl Input {
 
 		for (i, c) in it {
 			let c = CharKind::new(c);
-			let b = if opt.end_of_word {
-				prev != CharKind::Space && prev != c && i != 1
+			let new_char_kind = if opt.big {
+				(c == CharKind::Space) != (prev == CharKind::Space)
 			} else {
-				c != CharKind::Space && c != prev
+				c != prev
+			};
+			let b = if opt.end_of_word {
+				prev != CharKind::Space && new_char_kind && i != 1
+			} else {
+				c != CharKind::Space && new_char_kind
 			};
 			if b && !matches!(snap.op, InputOp::None | InputOp::Select(_)) {
 				return self.move_(i as isize);

--- a/yazi-core/src/input/commands/mod.rs
+++ b/yazi-core/src/input/commands/mod.rs
@@ -1,4 +1,4 @@
 yazi_macro::mod_flat!(
 	backspace backward close complete delete escape forward insert kill move_ paste redo
-	show type_ undo visual yank
+	replace show type_ undo visual yank
 );

--- a/yazi-core/src/input/commands/mod.rs
+++ b/yazi-core/src/input/commands/mod.rs
@@ -1,4 +1,1 @@
-yazi_macro::mod_flat!(
-	backspace backward close complete delete escape forward insert kill move_ paste redo
-	replace show type_ undo visual yank
-);
+yazi_macro::mod_flat!(backspace backward close complete delete escape forward insert kill move_ paste redo replace show type_ undo visual yank);

--- a/yazi-core/src/input/commands/move_.rs
+++ b/yazi-core/src/input/commands/move_.rs
@@ -43,7 +43,7 @@ impl TryFrom<&Data> for OptStep {
 impl From<CmdCow> for Opt {
 	fn from(c: CmdCow) -> Self {
 		Self {
-			step: c.get(0).unwrap().try_into().unwrap(),
+			step: c.get(0).unwrap().try_into().unwrap_or(OptStep::Offset(0)),
 			in_operating: c.bool("in-operating"),
 		}
 	}

--- a/yazi-core/src/input/commands/move_.rs
+++ b/yazi-core/src/input/commands/move_.rs
@@ -20,15 +20,15 @@ enum OptStep {
 impl TryFrom<&Data> for OptStep {
 	type Error = ();
 
-	fn try_from(d: &Data) -> Result<Self, Self::Error> {
-		if let Some(offset) = d.as_isize() {
+	fn try_from(data: &Data) -> Result<Self, Self::Error> {
+		if let Some(offset) = data.as_isize() {
 			return Ok(OptStep::Offset(offset));
 		};
-		if let Some(s) = d.as_str() {
-			if let Ok(offset) = s.parse() {
+		if let Some(string) = data.as_str() {
+			if let Ok(offset) = string.parse() {
 				return Ok(OptStep::Offset(offset));
 			};
-			match s.as_ref() {
+			match string.as_ref() {
 				"bol" => return Ok(OptStep::Bol),
 				"eol" => return Ok(OptStep::Eol),
 				"first-char" => return Ok(OptStep::FirstChar),

--- a/yazi-core/src/input/commands/move_.rs
+++ b/yazi-core/src/input/commands/move_.rs
@@ -14,7 +14,7 @@ struct Opt {
 impl From<CmdCow> for Opt {
 	fn from(c: CmdCow) -> Self {
 		Self {
-			step:         c.get(0).and_then(|d| d.try_into().ok()).unwrap_or_default(),
+			step:         c.first().and_then(|d| d.try_into().ok()).unwrap_or_default(),
 			in_operating: c.bool("in-operating"),
 		}
 	}

--- a/yazi-core/src/input/commands/move_.rs
+++ b/yazi-core/src/input/commands/move_.rs
@@ -5,11 +5,11 @@ use yazi_shared::event::{CmdCow, Data};
 use crate::input::{Input, op::InputOp, snap::InputSnap};
 
 struct Opt {
-	step:         Step,
+	step:         OptStep,
 	in_operating: bool,
 }
 
-enum Step {
+enum OptStep {
 	Offset(isize),
 	Bol,
 	Eol,
@@ -17,22 +17,22 @@ enum Step {
 	LastChar,
 }
 
-impl TryFrom<&Data> for Step {
+impl TryFrom<&Data> for OptStep {
 	type Error = ();
 
 	fn try_from(d: &Data) -> Result<Self, Self::Error> {
 		if let Some(offset) = d.as_isize() {
-			return Ok(Step::Offset(offset));
+			return Ok(OptStep::Offset(offset));
 		};
 		if let Some(s) = d.as_str() {
 			if let Ok(offset) = s.parse() {
-				return Ok(Step::Offset(offset));
+				return Ok(OptStep::Offset(offset));
 			};
 			match s.as_ref() {
-				"bol" => return Ok(Step::Bol),
-				"eol" => return Ok(Step::Eol),
-				"first-char" => return Ok(Step::FirstChar),
-				"last-char" => return Ok(Step::LastChar),
+				"bol" => return Ok(OptStep::Bol),
+				"eol" => return Ok(OptStep::Eol),
+				"first-char" => return Ok(OptStep::FirstChar),
+				"last-char" => return Ok(OptStep::LastChar),
 				_ => (),
 			}
 		}
@@ -51,7 +51,7 @@ impl From<CmdCow> for Opt {
 impl From<isize> for Opt {
 	fn from(step: isize) -> Self {
 		Self {
-			step:         Step::Offset(step),
+			step:         OptStep::Offset(step),
 			in_operating: false,
 		}
 	}
@@ -66,15 +66,15 @@ impl Input {
 		}
 
 		let position = match opt.step {
-			Step::Offset(offset) =>
+			OptStep::Offset(offset) =>
 				if offset <= 0 {
 					snap.cursor.saturating_sub(offset.unsigned_abs())
 				} else {
 					snap.count().min(snap.cursor + offset as usize)
 				},
-			Step::Bol => 0,
-			Step::Eol => snap.count(),
-			Step::FirstChar => snap
+			OptStep::Bol => 0,
+			OptStep::Eol => snap.count(),
+			OptStep::FirstChar => snap
 				.value
 				.chars()
 				.enumerate()
@@ -82,7 +82,7 @@ impl Input {
 				.map(|(i, _)| i)
 				.next()
 				.unwrap_or(0),
-			Step::LastChar => snap
+			OptStep::LastChar => snap
 				.value
 				.chars()
 				.rev()

--- a/yazi-core/src/input/commands/move_.rs
+++ b/yazi-core/src/input/commands/move_.rs
@@ -60,13 +60,8 @@ enum OptStep {
 impl OptStep {
 	fn cursor(self, snap: &InputSnap) -> usize {
 		match self {
-			Self::Offset(n) => {
-				if n <= 0 {
-					snap.cursor.saturating_add_signed(n)
-				} else {
-					snap.count().min(snap.cursor + n as usize)
-				}
-			}
+			Self::Offset(n) if n <= 0 => snap.cursor.saturating_add_signed(n),
+			Self::Offset(n) => snap.count().min(snap.cursor + n as usize),
 			Self::Bol => 0,
 			Self::Eol => snap.count(),
 			Self::FirstChar => {

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -1,0 +1,20 @@
+use yazi_macro::render;
+use yazi_shared::event::CmdCow;
+
+use crate::input::{Input, InputMode, op::InputOp};
+
+impl Input {
+	#[yazi_codegen::command]
+	pub fn replace(&mut self, _: CmdCow) {
+		let snap = self.snap_mut();
+		if snap.mode == InputMode::Normal {
+			snap.op = InputOp::None;
+			snap.mode = InputMode::Replace;
+		} else {
+			return;
+		}
+
+		render!();
+	}
+}
+

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -10,11 +10,7 @@ impl Input {
 		if snap.mode == InputMode::Normal {
 			snap.op = InputOp::None;
 			snap.mode = InputMode::Replace;
-		} else {
-			return;
+			render!();
 		}
-
-		render!();
 	}
 }
-

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -14,8 +14,6 @@ impl Input {
 		}
 	}
 
-	// FIXME: need to create a new snap for each replace operation, otherwise we
-	// can't undo/redo it with `u` and `Ctrl-r`
 	pub fn replace_str(&mut self, s: &str) {
 		let snap = self.snap_mut();
 
@@ -25,7 +23,7 @@ impl Input {
 		snap.mode = InputMode::Normal;
 		snap.value.replace_range(start..end, s);
 
-		self.flush_value();
+		self.snaps.tag(self.limit()).then(|| self.flush_value());
 		render!();
 	}
 }

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -17,8 +17,14 @@ impl Input {
 	pub fn replace_str(&mut self, s: &str) {
 		let snap = self.snap_mut();
 
+		if snap.value.is_empty() {
+			snap.mode = InputMode::Normal;
+			render!();
+			return;
+		}
+
 		let start = snap.idx(snap.cursor).unwrap();
-		let end = snap.idx(snap.cursor + 1).unwrap(); // FIXME: panic if the input is empty while in replace mode
+		let end = snap.idx(snap.cursor + 1).unwrap();
 
 		snap.mode = InputMode::Normal;
 		snap.value.replace_range(start..end, s);

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -13,4 +13,15 @@ impl Input {
 			render!();
 		}
 	}
+
+	pub fn replace_str(&mut self, s: &str) {
+		let snap = self.snaps.current_mut();
+
+		let start = snap.idx(snap.cursor).unwrap();
+		let end = snap.idx(snap.cursor + 1).unwrap();
+		snap.value.replace_range(start..end, s);
+
+		self.flush_value();
+		render!();
+	}
 }

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -16,20 +16,17 @@ impl Input {
 
 	pub fn replace_str(&mut self, s: &str) {
 		let snap = self.snap_mut();
-
-		if snap.value.is_empty() {
-			snap.mode = InputMode::Normal;
-			render!();
-			return;
-		}
+		snap.mode = InputMode::Normal;
 
 		let start = snap.idx(snap.cursor).unwrap();
-		let end = snap.idx(snap.cursor + 1).unwrap();
+		let mut it = snap.value[start..].char_indices();
+		match (it.next(), it.next()) {
+			(None, _) => {}
+			(Some(_), None) => snap.value.replace_range(start..snap.len(), s),
+			(Some(_), Some((len, _))) => snap.value.replace_range(start..start + len, s),
+		}
 
-		snap.mode = InputMode::Normal;
-		snap.value.replace_range(start..end, s);
-
-		self.snaps.tag(self.limit()).then(|| self.flush_value());
 		render!();
+		self.snaps.tag(self.limit()).then(|| self.flush_value());
 	}
 }

--- a/yazi-core/src/input/commands/replace.rs
+++ b/yazi-core/src/input/commands/replace.rs
@@ -14,11 +14,15 @@ impl Input {
 		}
 	}
 
+	// FIXME: need to create a new snap for each replace operation, otherwise we
+	// can't undo/redo it with `u` and `Ctrl-r`
 	pub fn replace_str(&mut self, s: &str) {
-		let snap = self.snaps.current_mut();
+		let snap = self.snap_mut();
 
 		let start = snap.idx(snap.cursor).unwrap();
-		let end = snap.idx(snap.cursor + 1).unwrap();
+		let end = snap.idx(snap.cursor + 1).unwrap(); // FIXME: panic if the input is empty while in replace mode
+
+		snap.mode = InputMode::Normal;
 		snap.value.replace_range(start..end, s);
 
 		self.flush_value();

--- a/yazi-core/src/input/commands/show.rs
+++ b/yazi-core/src/input/commands/show.rs
@@ -40,7 +40,7 @@ impl Input {
 
 		// Set cursor after reset
 		if let Some(cursor) = opt.cfg.cursor {
-			self.snaps.current_mut().cursor = cursor;
+			self.snap_mut().cursor = cursor;
 			self.move_(0);
 		}
 

--- a/yazi-core/src/input/commands/type_.rs
+++ b/yazi-core/src/input/commands/type_.rs
@@ -11,6 +11,18 @@ impl From<CmdCow> for Opt {
 
 impl Input {
 	pub fn type_(&mut self, key: &Key) -> bool {
+		if self.mode() == InputMode::Replace {
+			let Some(c) = key.plain() else {
+				return false;
+			};
+
+			let snap = self.snaps.current_mut();
+			snap.mode = InputMode::Normal;
+			self.replace_str(c.encode_utf8(&mut [0; 4]));
+
+			return true;
+		}
+
 		if self.mode() != InputMode::Insert {
 			return false;
 		}

--- a/yazi-core/src/input/commands/type_.rs
+++ b/yazi-core/src/input/commands/type_.rs
@@ -1,4 +1,5 @@
 use yazi_config::keymap::Key;
+use yazi_macro::render;
 use yazi_shared::event::CmdCow;
 
 use crate::input::{Input, InputMode};
@@ -33,5 +34,18 @@ impl Input {
 		}
 
 		false
+	}
+
+	pub fn type_str(&mut self, s: &str) {
+		let snap = self.snaps.current_mut();
+		if snap.cursor < 1 {
+			snap.value.insert_str(0, s);
+		} else {
+			snap.value.insert_str(snap.idx(snap.cursor).unwrap(), s);
+		}
+
+		self.move_(s.chars().count() as isize);
+		self.flush_value();
+		render!();
 	}
 }

--- a/yazi-core/src/input/commands/type_.rs
+++ b/yazi-core/src/input/commands/type_.rs
@@ -12,24 +12,13 @@ impl From<CmdCow> for Opt {
 
 impl Input {
 	pub fn type_(&mut self, key: &Key) -> bool {
-		if self.mode() == InputMode::Replace {
-			let Some(c) = key.plain() else {
-				return false;
-			};
+		let Some(c) = key.plain() else { return false };
 
-			let snap = self.snaps.current_mut();
-			snap.mode = InputMode::Normal;
-			self.replace_str(c.encode_utf8(&mut [0; 4]));
-
-			return true;
-		}
-
-		if self.mode() != InputMode::Insert {
-			return false;
-		}
-
-		if let Some(c) = key.plain() {
+		if self.mode() == InputMode::Insert {
 			self.type_str(c.encode_utf8(&mut [0; 4]));
+			return true;
+		} else if self.mode() == InputMode::Replace {
+			self.replace_str(c.encode_utf8(&mut [0; 4]));
 			return true;
 		}
 
@@ -37,7 +26,7 @@ impl Input {
 	}
 
 	pub fn type_str(&mut self, s: &str) {
-		let snap = self.snaps.current_mut();
+		let snap = self.snap_mut();
 		if snap.cursor < 1 {
 			snap.value.insert_str(0, s);
 		} else {

--- a/yazi-core/src/input/input.rs
+++ b/yazi-core/src/input/input.rs
@@ -46,6 +46,17 @@ impl Input {
 		render!();
 	}
 
+	pub fn replace_str(&mut self, s: &str) {
+		let snap = self.snaps.current_mut();
+
+		let start = snap.idx(snap.cursor).unwrap();
+		let end = snap.idx(snap.cursor + 1).unwrap();
+		snap.value.replace_range(start..end, s);
+
+		self.flush_value();
+		render!();
+	}
+
 	pub(super) fn handle_op(&mut self, cursor: usize, include: bool) -> bool {
 		let old = self.snap().clone();
 		let snap = self.snaps.current_mut();

--- a/yazi-core/src/input/input.rs
+++ b/yazi-core/src/input/input.rs
@@ -33,30 +33,6 @@ impl Input {
 		self.position.offset.width.saturating_sub(INPUT.border()) as usize
 	}
 
-	pub fn type_str(&mut self, s: &str) {
-		let snap = self.snaps.current_mut();
-		if snap.cursor < 1 {
-			snap.value.insert_str(0, s);
-		} else {
-			snap.value.insert_str(snap.idx(snap.cursor).unwrap(), s);
-		}
-
-		self.move_(s.chars().count() as isize);
-		self.flush_value();
-		render!();
-	}
-
-	pub fn replace_str(&mut self, s: &str) {
-		let snap = self.snaps.current_mut();
-
-		let start = snap.idx(snap.cursor).unwrap();
-		let end = snap.idx(snap.cursor + 1).unwrap();
-		snap.value.replace_range(start..end, s);
-
-		self.flush_value();
-		render!();
-	}
-
 	pub(super) fn handle_op(&mut self, cursor: usize, include: bool) -> bool {
 		let old = self.snap().clone();
 		let snap = self.snaps.current_mut();

--- a/yazi-core/src/input/input.rs
+++ b/yazi-core/src/input/input.rs
@@ -3,7 +3,6 @@ use std::ops::Range;
 use tokio::sync::mpsc::UnboundedSender;
 use unicode_width::UnicodeWidthStr;
 use yazi_config::{INPUT, popup::Position};
-use yazi_macro::render;
 use yazi_plugin::CLIPBOARD;
 use yazi_shared::errors::InputError;
 
@@ -35,7 +34,7 @@ impl Input {
 
 	pub(super) fn handle_op(&mut self, cursor: usize, include: bool) -> bool {
 		let old = self.snap().clone();
-		let snap = self.snaps.current_mut();
+		let snap = self.snap_mut();
 
 		match snap.op {
 			InputOp::None | InputOp::Select(_) => {

--- a/yazi-core/src/input/mode.rs
+++ b/yazi-core/src/input/mode.rs
@@ -3,6 +3,7 @@ pub enum InputMode {
 	Normal,
 	#[default]
 	Insert,
+	Replace,
 }
 
 impl InputMode {

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -93,6 +93,9 @@ impl App {
 			if input.mode() == InputMode::Insert {
 				input.type_str(&str);
 			}
+			if input.mode() == InputMode::Replace {
+				input.replace_str(&str);
+			}
 		}
 	}
 }

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -92,8 +92,7 @@ impl App {
 			let input = &mut self.cx.input;
 			if input.mode() == InputMode::Insert {
 				input.type_str(&str);
-			}
-			if input.mode() == InputMode::Replace {
+			} else if input.mode() == InputMode::Replace {
 				input.replace_str(&str);
 			}
 		}

--- a/yazi-fm/src/executor.rs
+++ b/yazi-fm/src/executor.rs
@@ -259,6 +259,7 @@ impl<'a> Executor<'a> {
 			InputMode::Normal => {
 				on!(insert);
 				on!(visual);
+				on!(replace);
 
 				on!(delete);
 				on!(yank);
@@ -279,6 +280,7 @@ impl<'a> Executor<'a> {
 				on!(backspace);
 				on!(kill);
 			}
+			InputMode::Replace => {}
 		}
 	}
 

--- a/yazi-fm/src/input/input.rs
+++ b/yazi-fm/src/input/input.rs
@@ -59,6 +59,7 @@ impl Widget for Input<'_> {
 
 		_ = match input.mode() {
 			InputMode::Insert => Term::set_cursor_bar(),
+			InputMode::Replace => Term::set_cursor_underscore(),
 			_ => Term::set_cursor_block(),
 		};
 	}

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -159,6 +159,16 @@ impl Term {
 			queue!(stderr(), SetCursorStyle::SteadyBar)?
 		})
 	}
+
+	#[inline]
+	pub(super) fn set_cursor_underscore() -> Result<()> {
+		use crossterm::cursor::SetCursorStyle;
+		Ok(if INPUT.cursor_blink {
+			queue!(stderr(), SetCursorStyle::BlinkingUnderScore)?
+		} else {
+			queue!(stderr(), SetCursorStyle::SteadyUnderScore)?
+		})
+	}
 }
 
 impl Drop for Term {

--- a/yazi-shared/src/chars.rs
+++ b/yazi-shared/src/chars.rs
@@ -20,6 +20,10 @@ impl CharKind {
 			Self::Other
 		}
 	}
+
+	pub fn vary(self, other: Self, far: bool) -> bool {
+		if far { (self == Self::Space) != (other == Self::Space) } else { self != other }
+	}
 }
 
 pub fn strip_trailing_newline(mut s: String) -> String {


### PR DESCRIPTION
Draft!

Closes #2119 

- [x] `r`
- [x] `^`, `_`
  - [x] Fix `I` #2120
- [x] `W`, `E`
- [x] `B`