### PR TITLE
feat: new `ya pack -d` subcommand to delete packages

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -57,6 +57,9 @@ pub(super) struct CommandPack {
 	/// Add a package.
 	#[arg(short = 'a', long)]
 	pub(super) add:     Option<String>,
+	/// Delete a package.
+	#[arg(short = 'd', long)]
+	pub(super) delete:  Option<String>,
 	/// Install all packages.
 	#[arg(short = 'i', long)]
 	pub(super) install: bool,

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -73,6 +73,8 @@ async fn run() -> anyhow::Result<()> {
 				package::Package::load().await?.install(true).await?;
 			} else if let Some(repo) = cmd.add {
 				package::Package::load().await?.add(&repo).await?;
+			} else if let Some(repo) = cmd.delete {
+				package::Package::load().await?.delete(&repo).await?;
 			}
 		}
 

--- a/yazi-cli/src/package/delete.rs
+++ b/yazi-cli/src/package/delete.rs
@@ -9,10 +9,9 @@ impl Dependency {
 	pub(super) async fn delete(&self) -> Result<()> {
 		self.header("Deleting package `{name}`")?;
 
-		let path = self.deployed_directory();
-
-		if must_exists(&path).await {
-			fs::remove_dir_all(&path).await?;
+		let dir = self.target();
+		if must_exists(&dir).await {
+			fs::remove_dir_all(&dir).await?;
 		} else {
 			bail!(
 				"The package.toml file states that `{}` exists, but the directory was not found. The entry will be removed from package.toml.",

--- a/yazi-cli/src/package/delete.rs
+++ b/yazi-cli/src/package/delete.rs
@@ -1,0 +1,26 @@
+use anyhow::{Result, bail};
+use tokio::fs;
+use yazi_fs::must_exists;
+use yazi_macro::outln;
+
+use super::Dependency;
+
+impl Dependency {
+	pub(super) async fn delete(&self) -> Result<()> {
+		self.header("Deleting package `{name}`")?;
+
+		let path = self.deployed_directory();
+
+		if must_exists(&path).await {
+			fs::remove_dir_all(&path).await?;
+		} else {
+			bail!(
+				"The package.toml file states that `{}` exists, but the directory was not found. The entry will be removed from package.toml.",
+				self.name
+			);
+		}
+
+		outln!("Done!")?;
+		Ok(())
+	}
+}

--- a/yazi-cli/src/package/dependency.rs
+++ b/yazi-cli/src/package/dependency.rs
@@ -29,11 +29,11 @@ impl Dependency {
 
 	#[inline]
 	pub(super) fn deployed_directory(&self) -> PathBuf {
-		return if self.is_flavor {
+		if self.is_flavor {
 			Xdg::config_dir().join(format!("flavors/{}", self.name))
 		} else {
 			Xdg::config_dir().join(format!("plugins/{}", self.name))
-		};
+		}
 	}
 
 	#[inline]

--- a/yazi-cli/src/package/dependency.rs
+++ b/yazi-cli/src/package/dependency.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use twox_hash::XxHash3_128;
 use yazi_fs::Xdg;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct Dependency {
 	pub(crate) use_: String, // owner/repo:child
 	pub(crate) name: String, // child.yazi
@@ -37,6 +37,11 @@ impl Dependency {
 		} else {
 			Xdg::config_dir().join(format!("plugins/{}", self.name))
 		}
+	}
+
+	#[inline]
+	pub(super) fn identical(&self, other: &Self) -> bool {
+		self.parent == other.parent && self.child == other.child
 	}
 
 	pub(super) fn header(&self, s: &str) -> Result<()> {

--- a/yazi-cli/src/package/dependency.rs
+++ b/yazi-cli/src/package/dependency.rs
@@ -28,6 +28,15 @@ impl Dependency {
 	}
 
 	#[inline]
+	pub(super) fn deployed_directory(&self) -> PathBuf {
+		return if self.is_flavor {
+			Xdg::config_dir().join(format!("flavors/{}", self.name))
+		} else {
+			Xdg::config_dir().join(format!("plugins/{}", self.name))
+		};
+	}
+
+	#[inline]
 	pub(super) fn remote(&self) -> String {
 		// Support more Git hosting services in the future
 		format!("https://github.com/{}.git", self.parent)

--- a/yazi-cli/src/package/dependency.rs
+++ b/yazi-cli/src/package/dependency.rs
@@ -11,7 +11,7 @@ pub(crate) struct Dependency {
 	pub(crate) name: String, // child.yazi
 
 	pub(crate) parent: String, // owner/repo
-	pub(crate) child:  String, // child
+	pub(crate) child:  String, // child.yazi
 
 	pub(crate) rev:  String,
 	pub(crate) hash: String,

--- a/yazi-cli/src/package/dependency.rs
+++ b/yazi-cli/src/package/dependency.rs
@@ -20,26 +20,23 @@ pub(crate) struct Dependency {
 }
 
 impl Dependency {
-	#[inline]
 	pub(super) fn local(&self) -> PathBuf {
 		Xdg::state_dir()
 			.join("packages")
 			.join(format!("{:x}", XxHash3_128::oneshot(self.remote().as_bytes())))
 	}
 
-	#[inline]
-	pub(super) fn deployed_directory(&self) -> PathBuf {
+	pub(super) fn remote(&self) -> String {
+		// Support more Git hosting services in the future
+		format!("https://github.com/{}.git", self.parent)
+	}
+
+	pub(super) fn target(&self) -> PathBuf {
 		if self.is_flavor {
 			Xdg::config_dir().join(format!("flavors/{}", self.name))
 		} else {
 			Xdg::config_dir().join(format!("plugins/{}", self.name))
 		}
-	}
-
-	#[inline]
-	pub(super) fn remote(&self) -> String {
-		// Support more Git hosting services in the future
-		format!("https://github.com/{}.git", self.parent)
 	}
 
 	pub(super) fn header(&self, s: &str) -> Result<()> {

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -52,7 +52,9 @@ Please manually delete it from `{}` and re-run the command.",
 		self.delete_assets().await?;
 		Self::deploy_assets(from.join("assets"), to.join("assets")).await?;
 
+		self.hash = self.hash().await?;
 		outln!("Done!")?;
+
 		Ok(())
 	}
 

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -17,9 +17,11 @@ impl Dependency {
 		let to = self.target();
 		if maybe_exists(&to).await && self.hash != self.hash().await? {
 			bail!(
-				"The user has modified the contents of the `{}` package. For safety, the operation has been aborted.
-Please manually delete it from your plugins/flavors directory and re-run the command.",
-				self.name
+				"You have modified the contents of the `{}` {}. For safety, the operation has been aborted.
+Please manually delete it from `{}` and re-run the command.",
+				self.name,
+				if self.is_flavor { "flavor" } else { "plugin" },
+				to.display()
 			);
 		}
 

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -14,8 +14,7 @@ impl Dependency {
 		self.header("Deploying package `{name}`")?;
 		self.is_flavor = maybe_exists(&from.join("flavor.toml")).await;
 
-		let to = self.deployed_directory();
-
+		let to = self.target();
 		if maybe_exists(&to).await && self.hash != self.hash().await? {
 			bail!(
 				"The user has modified the contents of the `{}` package. For safety, the operation has been aborted.

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use tokio::fs;
-use yazi_fs::{Xdg, copy_and_seal, maybe_exists, remove_dir_clean};
+use yazi_fs::{copy_and_seal, maybe_exists, remove_dir_clean};
 use yazi_macro::outln;
 
 use super::Dependency;
@@ -13,11 +13,8 @@ impl Dependency {
 
 		self.header("Deploying package `{name}`")?;
 		self.is_flavor = maybe_exists(&from.join("flavor.toml")).await;
-		let to = if self.is_flavor {
-			Xdg::config_dir().join(format!("flavors/{}", self.name))
-		} else {
-			Xdg::config_dir().join(format!("plugins/{}", self.name))
-		};
+
+		let to = self.deployed_directory();
 
 		if maybe_exists(&to).await && self.hash != self.hash().await? {
 			bail!(

--- a/yazi-cli/src/package/hash.rs
+++ b/yazi-cli/src/package/hash.rs
@@ -1,17 +1,13 @@
 use anyhow::{Context, Result};
 use tokio::fs;
 use twox_hash::XxHash3_128;
-use yazi_fs::{Xdg, ok_or_not_found};
+use yazi_fs::ok_or_not_found;
 
 use super::Dependency;
 
 impl Dependency {
 	pub(crate) async fn hash(&self) -> Result<String> {
-		let dir = if self.is_flavor {
-			Xdg::config_dir().join(format!("flavors/{}", self.name))
-		} else {
-			Xdg::config_dir().join(format!("plugins/{}", self.name))
-		};
+		let dir = self.deployed_directory();
 
 		let files = if self.is_flavor {
 			&[

--- a/yazi-cli/src/package/hash.rs
+++ b/yazi-cli/src/package/hash.rs
@@ -7,8 +7,7 @@ use super::Dependency;
 
 impl Dependency {
 	pub(crate) async fn hash(&self) -> Result<String> {
-		let dir = self.deployed_directory();
-
+		let dir = self.target();
 		let files = if self.is_flavor {
 			&[
 				"LICENSE",

--- a/yazi-cli/src/package/install.rs
+++ b/yazi-cli/src/package/install.rs
@@ -5,7 +5,7 @@ use super::{Dependency, Git};
 
 impl Dependency {
 	pub(super) async fn install(&mut self) -> Result<()> {
-		self.header("Installing package `{name}`")?;
+		self.header("Fetching package `{name}`")?;
 
 		let path = self.local();
 		if !must_exists(&path).await {

--- a/yazi-cli/src/package/mod.rs
+++ b/yazi-cli/src/package/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_inception)]
 
-yazi_macro::mod_flat!(add dependency deploy git hash install package upgrade);
+yazi_macro::mod_flat!(add delete dependency deploy git hash install package upgrade);
 
 use anyhow::Context;
 use yazi_fs::Xdg;

--- a/yazi-cli/src/package/package.rs
+++ b/yazi-cli/src/package/package.rs
@@ -185,7 +185,7 @@ impl Package {
 
 	#[inline]
 	fn find_dep_in_package(&self, dep: &Dependency) -> Option<&Dependency> {
-		return self.plugins.iter().chain(self.flavors.iter()).find(|d| d.use_ == dep.use_);
+		self.plugins.iter().chain(self.flavors.iter()).find(|d| d.use_ == dep.use_)
 	}
 
 	#[inline]


### PR DESCRIPTION
Closes https://github.com/sxyazi/yazi/issues/2147

### Details about the implementation

To add the `delete` command, I followed the same pattern that existed in the `src/args.rs`, `src/main.rs` and `src/package/*` directories.

I tried to follow the existing code style, and kept refactorings to a minimum - I created two helper methods - `find_dep_in_package` and `deployed_directory`. If there are any naming issues or you would like the code to be structured differently, feel free to say!



### Follow up / Questions

#### Some code is still not deleted
As things are, this will not delete the package code that is present in `Xdg::local()` directory, as I don't understand why the `state_dir()` of a dependency is using an hash to identify the package (`format!("{:x}", XxHash3_128::oneshot(self.remote().as_bytes()))`) instead of just using the package name. 
I'm assuming it is desired to also remove the content of this `state_dir()`, but I'll `await` for the answer 🕵️ 

#### Can the field `Dependency.use_` be used the dependency ID?
The function `Package::add(..)` was detecting if a package existing with the following code:
```rust
if self.plugins.iter().any(|d| d.repo == dep.repo && d.child == dep.child) {
	bail!("Plugin `{name}` already exists in package.toml");
}
```
However, given that the objective is to see if a package already exists in `package.toml` and each package keeps the `use` value there, I'm under the impression that this can be simplified to using `use_`. 
If this `use` field is internal and should not be used, should there be a way of giving an ID to a package, or should we keep using the `parent` and `child` names?