### PR TITLE
docs: correct the `cargo test` command in the contribution guide

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
         run: cargo build --verbose
 
       - name: Test
-        run: cargo test --all --verbose
+        run: cargo test --workspace --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ A brief overview of the project's structure:
 3. Run the tests:
 
    ```sh
-   cargo test
+   cargo test --workspace
    ```
 
 4. Format the code (requires `rustfmt` nightly):


### PR DESCRIPTION
While following the [Development setup](https://github.com/sxyazi/yazi/blob/ba62b407bdf0cb0b21641981a5729c4a6de0fa6c/CONTRIBUTING.md#development-setup) section of the `CONTRIBUTING.MD`, I noticed that running `cargo test` in the root directory (`yazi/`) results in no tests being executed.

As specified in https://doc.rust-lang.org/cargo/commands/cargo-test.html, running `cargo test --workspace` executes all of the project tests, as expected.