### PR TITLE
feat: new `--no-cwd-file` option for the `close` command

### DIFF
--- a/yazi-core/src/manager/commands/close.rs
+++ b/yazi-core/src/manager/commands/close.rs
@@ -1,12 +1,26 @@
 use yazi_shared::event::CmdCow;
 
-use crate::{manager::Manager, tasks::Tasks};
+use crate::{manager::Manager, tasks::Tasks, manager::commands::quit};
+
+#[derive(Default)]
+struct Opt {
+	no_cwd_file: bool,
+}
+
+impl From<()> for Opt {
+	fn from(_: ()) -> Self { Self::default() }
+}
+
+impl From<CmdCow> for Opt {
+	fn from(c: CmdCow) -> Self { Self { no_cwd_file: c.bool("no-cwd-file") } }
+}
 
 impl Manager {
-	pub fn close(&mut self, c: CmdCow, tasks: &Tasks) {
+	#[yazi_codegen::command]
+	pub fn close(&mut self, opt: Opt, tasks: &Tasks) {
 		if self.tabs.len() > 1 {
 			return self.tabs.close(self.tabs.cursor);
 		}
-		self.quit(c, tasks);
+		self.quit(quit::Opt{ no_cwd_file: opt.no_cwd_file }, tasks);
 	}
 }

--- a/yazi-core/src/manager/commands/close.rs
+++ b/yazi-core/src/manager/commands/close.rs
@@ -3,10 +3,10 @@ use yazi_shared::event::CmdCow;
 use crate::{manager::Manager, tasks::Tasks};
 
 impl Manager {
-	pub fn close(&mut self, _: CmdCow, tasks: &Tasks) {
+	pub fn close(&mut self, c: CmdCow, tasks: &Tasks) {
 		if self.tabs.len() > 1 {
 			return self.tabs.close(self.tabs.cursor);
 		}
-		self.quit((), tasks);
+		self.quit(c, tasks);
 	}
 }

--- a/yazi-core/src/manager/commands/close.rs
+++ b/yazi-core/src/manager/commands/close.rs
@@ -1,18 +1,16 @@
 use yazi_shared::event::CmdCow;
 
-use crate::{manager::Manager, tasks::Tasks, manager::commands::quit};
+use crate::{manager::{Manager, commands::quit}, tasks::Tasks};
 
 #[derive(Default)]
 struct Opt {
 	no_cwd_file: bool,
 }
-
-impl From<()> for Opt {
-	fn from(_: ()) -> Self { Self::default() }
-}
-
 impl From<CmdCow> for Opt {
 	fn from(c: CmdCow) -> Self { Self { no_cwd_file: c.bool("no-cwd-file") } }
+}
+impl From<Opt> for quit::Opt {
+	fn from(value: Opt) -> Self { Self { no_cwd_file: value.no_cwd_file } }
 }
 
 impl Manager {
@@ -21,6 +19,6 @@ impl Manager {
 		if self.tabs.len() > 1 {
 			return self.tabs.close(self.tabs.cursor);
 		}
-		self.quit(quit::Opt{ no_cwd_file: opt.no_cwd_file }, tasks);
+		self.quit(opt, tasks);
 	}
 }

--- a/yazi-core/src/manager/commands/quit.rs
+++ b/yazi-core/src/manager/commands/quit.rs
@@ -9,8 +9,8 @@ use yazi_shared::event::{CmdCow, EventQuit};
 use crate::{manager::Manager, tasks::Tasks};
 
 #[derive(Default)]
-struct Opt {
-	no_cwd_file: bool,
+pub struct Opt {
+	pub no_cwd_file: bool,
 }
 impl From<()> for Opt {
 	fn from(_: ()) -> Self { Self::default() }

--- a/yazi-core/src/manager/commands/quit.rs
+++ b/yazi-core/src/manager/commands/quit.rs
@@ -10,7 +10,7 @@ use crate::{manager::Manager, tasks::Tasks};
 
 #[derive(Default)]
 pub(super) struct Opt {
-	pub no_cwd_file: bool,
+	pub(super) no_cwd_file: bool,
 }
 impl From<CmdCow> for Opt {
 	fn from(c: CmdCow) -> Self { Self { no_cwd_file: c.bool("no-cwd-file") } }

--- a/yazi-core/src/manager/commands/quit.rs
+++ b/yazi-core/src/manager/commands/quit.rs
@@ -9,11 +9,8 @@ use yazi_shared::event::{CmdCow, EventQuit};
 use crate::{manager::Manager, tasks::Tasks};
 
 #[derive(Default)]
-pub struct Opt {
+pub(super) struct Opt {
 	pub no_cwd_file: bool,
-}
-impl From<()> for Opt {
-	fn from(_: ()) -> Self { Self::default() }
 }
 impl From<CmdCow> for Opt {
 	fn from(c: CmdCow) -> Self { Self { no_cwd_file: c.bool("no-cwd-file") } }


### PR DESCRIPTION
It will be helpful to forward `close` params to `quit`. Then users can use commands like `close --cwd-file`, `close --no-cwd-file`, to control the quit behavior indirectly.