### PR TITLE
fix: incorrect monorepo sub-plugin path resolution

### DIFF
--- a/yazi-cli/src/package/dependency.rs
+++ b/yazi-cli/src/package/dependency.rs
@@ -73,7 +73,7 @@ impl FromStr for Dependency {
 			use_: s.to_owned(),
 			name: format!("{name}.yazi"),
 			parent: format!("{parent}{}", if child.is_empty() { ".yazi" } else { "" }),
-			child: child.to_owned(),
+			child: if child.is_empty() { String::new() } else { format!("{child}.yazi") },
 			..Default::default()
 		})
 	}

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -9,11 +9,7 @@ use super::Dependency;
 
 impl Dependency {
 	pub(super) async fn deploy(&mut self) -> Result<()> {
-		let from = if self.child.is_empty() {
-			self.local().join(&self.child)
-		} else {
-			self.local().join(format!("{}.yazi", self.child))
-		};
+		let from = self.local().join(&self.child);
 
 		self.header("Deploying package `{name}`")?;
 		self.is_flavor = maybe_exists(&from.join("flavor.toml")).await;

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -9,7 +9,11 @@ use super::Dependency;
 
 impl Dependency {
 	pub(super) async fn deploy(&mut self) -> Result<()> {
-		let from = self.local().join(&self.child);
+		let from = if self.child.is_empty() {
+			self.local().join(&self.child)
+		} else {
+			self.local().join(format!("{}.yazi", self.child))
+		};
 
 		self.header("Deploying package `{name}`")?;
 		self.is_flavor = maybe_exists(&from.join("flavor.toml")).await;

--- a/yazi-cli/src/package/git.rs
+++ b/yazi-cli/src/package/git.rs
@@ -43,8 +43,10 @@ impl Git {
 	}
 
 	async fn exec(f: impl FnOnce(&mut Command) -> &mut Command) -> Result<()> {
-		let status =
-			f(&mut Command::new("git")).status().await.context("Failed to execute `git` command")?;
+		let status = f(Command::new("git").args(["-c", "advice.detachedHead=false"]))
+			.status()
+			.await
+			.context("Failed to execute `git` command")?;
 
 		if !status.success() {
 			bail!("`git` command failed: {status}");


### PR DESCRIPTION
When attempting to install a plugin with a format like `yazi-rs/plugins:mime-ext`, an error message "No such file or directory" is returned.

The error occurs because the constructed local path to the plugin source is missing the `.yazi` extension. This results in incorrect paths such as `mime-ext/init.lua` instead of the correct `mime-ext.yazi/init.lua`.

This patch addresses this issue by ensuring the `.yazi` extension is correctly included when constructing the local path for these plugins.

Thanks for your amazing work!