### PR TITLE
feat: arm64 Snap package

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -182,7 +182,7 @@ jobs:
           snapcraft remote-build --launchpad-accept-public-upload
 
           # Output the build logs from the remote-build
-          cat snapcraft-${name}*${arch}*.txt || echo "Could not find build log"
+          cat snapcraft-yazi*.txt || echo "Could not find build log"
 
       - name: Rename snap
         run: mv yazi_*.snap yazi-${{ matrix.target }}.snap

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -145,12 +145,11 @@ jobs:
           path: yazi-${{ matrix.target }}.zip
 
   build-snap:
-    if: false # Can't make CI pass, disable for now
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+        arch:
+          - amd64
+          - arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -158,8 +157,32 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.6
 
-      - name: Build
-        uses: snapcore/action-build@v1
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v1
+
+      - name: Setup snapcraft
+        run: |
+          sudo snap install --classic snapcraft
+
+          mkdir -p ~/.local/share/snapcraft
+          echo "${{ secrets.LP_TOKEN }}" > ~/.local/share/snapcraft/launchpad-credentials
+
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "Github Actions"
+
+      - name: Build snap
+        env:
+          arch: ${{ matrix.arch }}
+        run: |
+          # Modify the `platforms` to use a single arch only, but run this in a matrix so they
+          # all get hit
+          yq -i '.platforms |= {env(arch): {"build-on": env(arch)}}' snap/snapcraft.yaml
+
+          # Now run a remote-build, targeting just the single arch specified
+          snapcraft remote-build --launchpad-accept-public-upload
+
+          # Output the build logs from the remote-build
+          cat snapcraft-${name}*${arch}*.txt || echo "Could not find build log"
 
       - name: Rename snap
         run: mv yazi_*.snap yazi-${{ matrix.target }}.snap

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ result-*
 
 .idea/
 .vscode/
+
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: classic
 
 platforms:
   amd64:
-  # arm64:
+  arm64:
 
 apps:
   yazi:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,34 +23,31 @@ parts:
   yazi:
     plugin: rust
     source: https://github.com/sxyazi/yazi.git
-    build-packages:
-      - wget
+    stage-snaps:
+      - jq
+    stage-packages:
+      - 7zip
+      - fd-find
+      - fzf
+      - ripgrep
+      - zoxide
     override-build: |
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0)
+    organize:
+      # Ubuntu's `fd` package installs a binary named `fdfind`. Rename it in the snap.
+      usr/bin/fdfind: usr/bin/fd
 
-      wget ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz
-      tar fxz ripgrep-*.tar.gz
-      mv ripgrep-*/rg $CRAFT_PART_INSTALL/bin/
-
-      wget https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-aarch64-unknown-linux-gnu.tar.gz
-      tar fxz fd-*.tar.gz
-      mv fd-*/fd $CRAFT_PART_INSTALL/bin/
-
-      wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
-      mv jq-linux-amd64 $CRAFT_PART_INSTALL/bin/jq
-
-      wget https://imagemagick.org/archive/binaries/magick
-      mv magick $CRAFT_PART_INSTALL/bin/magick
-
-      wget https://github.com/junegunn/fzf/releases/download/v0.56.2/fzf-0.56.2-linux_amd64.tar.gz
-      tar fxz fzf-*.tar.gz
-      mv fzf $CRAFT_PART_INSTALL/bin/
-
-      wget https://www.7-zip.org/a/7z2408-linux-x64.tar.xz
-      tar fxz 7z*.tar.xz
-      mv 7zz 7zzs $CRAFT_PART_INSTALL/bin/
-
-      wget https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.6/zoxide-0.9.6-x86_64-unknown-linux-musl.tar.gz
-      tar fxz zoxide-*.tar.gz
-      mv zoxide $CRAFT_PART_INSTALL/bin/
+  # The Ubuntu `imagemagick` package does not ship a `magick` binary,
+  # which `yazi` looks for. Building the package oursleves yields the
+  # expected binary without much overhead, and works across platforms.
+  magick:
+    plugin: autotools
+    source: https://imagemagick.org/archive/ImageMagick.tar.gz
+    source-type: tar
+    stage-packages:
+      - libgomp1
+    autotools-configure-parameters:
+      - --prefix=/usr
+    build-attributes:
+      - enable-patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,8 @@ parts:
       - fd-find
       - ffmpeg
       - fzf
+      - libglu1-mesa
+      - libglut3.12
       - poppler-utils
       - ripgrep
       - wl-clipboard
@@ -44,6 +46,73 @@ parts:
     organize:
       # Ubuntu's `fd` package installs a binary named `fdfind`. Rename it in the snap.
       usr/bin/fdfind: usr/bin/fd
+    prime:
+      # Remove unused items bought in by dependency packages
+      - -usr/bin/fc-*
+      - -usr/bin/ffplay
+      - -usr/bin/pdfattach
+      - -usr/bin/pdfdetach
+      - -usr/bin/pdffonts
+      - -usr/bin/pdfimages
+      - -usr/bin/pdfinfo
+      - -usr/bin/pdfseparate
+      - -usr/bin/pdfsig
+      - -usr/bin/pdftocairo
+      - -usr/bin/pdftohtml
+      - -usr/bin/pdftops
+      - -usr/bin/pdftotext
+      - -usr/bin/pdfunite
+      # Remove unused libraries identified by snapcraft's linter
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_bad_*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_civil_time.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_cord*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_examine_stack.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_exponential_biased.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_failure_signal_handler.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_flags*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_hash*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_log_severity.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_periodic_sampler.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_random*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_raw_hash_set.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_scoped_set_env.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_statusor.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_status.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_strerror.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libabsl_str_format_internal.so.*
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcaca++.so.0.99.20
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcjson_utils.so.1.7.17
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libfftw3_omp.so.3.6.10
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libfftw3_threads.so.3.6.10
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libflite_cmu_grapheme_lang.so.2.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libflite_cmu_grapheme_lex.so.2.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libflite_cmu_indic_lang.so.2.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libflite_cmu_indic_lex.so.2.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libflite_cmu_time_awb.so.2.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libfreebl3.so
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libfreeblpriv3.so
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLX_mesa.so.0.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhwy_contrib.so.1.0.7
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhwy_test.so.1.0.7
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libicui18n.so.74.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libicuio.so.74.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libicutest.so.74.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libicutu.so.74.2
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libjacknet.so.0.1.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libjackserver.so.0.1.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnssckbi.so
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnssdbm3.so
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpulse-simple.so.0.1.1
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsoftokn3.so
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsphinxad.so.3.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libssl3.so
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtheora.so.0.3.10
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-dri2.so.0.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-glx.so.0.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-present.so.0.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-sync.so.1.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxshmfence.so.1.0.0
+      - -usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libzvbi-chains.so.0.0.0
 
   # The Ubuntu `imagemagick` package does not ship a `magick` binary,
   # which `yazi` looks for. Building the package oursleves yields the
@@ -58,17 +127,37 @@ parts:
       - --prefix=/usr
     build-attributes:
       - enable-patchelf
+    prime:
+      - usr/bin/magick
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgomp.so.1
+      - usr/lib/libMagickCore-7.Q16HDRI.so*
+      - usr/lib/libMagickWand-7.Q16HDRI.so*
 
-  # This is a bit of hack to work around a bug in latest snapcraft.
-  # This should be done in `override-prime` of the `yazi` part, but doing
-  # so seems to disable the automatic ELF patching, meaning none of the bins
-  # work correctly!
-  #
-  # Ubuntu's /usr/bin/7zz is a simple bash wrapper that just exec's
-  # /usr/lib/7zip/7zz - this just shortcuts that and places the actual
-  # executable at $SNAP/usr/bin/7zz.
-  fix-7z:
-    after: [yazi]
+  # Most of what is done here should be done in the `yazi` part, but using
+  # `override-prime` there stops snapcraft from automatically patching ELF
+  # binaries (due to a bug), so we do that work here in a separate part.
+  cleanup:
+    after: [yazi, magick]
     plugin: nil
+    build-packages:
+      - patchelf
+    build-snaps:
+      - core24
     override-prime: |
+      # Ubuntu's /usr/bin/7zz is a simple bash wrapper that just exec's
+      # /usr/lib/7zip/7zz - this just shortcuts that and places the actual
+      # executable at $SNAP/usr/bin/7zz.
       mv $CRAFT_PRIME/usr/lib/7zip/7zz $CRAFT_PRIME/usr/bin/7zz
+
+      # The snapcraft linter highlighted issues with the rpath of these two libraries,
+      # so we fix them up manually here after they are primed in the yazi part.
+      patchelf --force-rpath --set-rpath "\$ORIGIN:\$ORIGIN/pulseaudio:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpulse.so.0.24.2
+      patchelf --force-rpath --set-rpath "\$ORIGIN/lapack:\$ORIGIN/blas:\$ORIGIN:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsphinxbase.so.3.0.0
+      patchelf --force-rpath --set-rpath "\$ORIGIN/../lib:\$ORIGIN/../lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/bin/magick
+      patchelf --force-rpath --set-rpath "\$ORIGIN/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/libMagickCore-7.Q16HDRI.so.10.0.2
+      patchelf --force-rpath --set-rpath "\$ORIGIN:\$ORIGIN/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/libMagickWand-7.Q16HDRI.so.10.0.2
+
+      # Ensure we don't ship duplicates of files that exist in the core24
+      # snap.
+      cd /snap/core24/current
+      find . -type f,l -exec rm -rf "${CRAFT_PRIME}/{}" \;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,11 +27,14 @@ parts:
       - jq
     stage-packages:
       - 7zip
+      - chafa
       - fd-find
       - ffmpeg
       - fzf
       - libpoppler-cpp0t64
       - ripgrep
+      - wl-clipboard
+      - xclip
       - zoxide
     override-build: |
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
       - fd-find
       - ffmpeg
       - fzf
-      - libpoppler-cpp0t64
+      - poppler-utils
       - ripgrep
       - wl-clipboard
       - xclip

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,9 @@ parts:
     stage-packages:
       - 7zip
       - fd-find
+      - ffmpeg
       - fzf
+      - libpoppler-cpp0t64
       - ripgrep
       - zoxide
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ parts:
     stage-snaps:
       - jq
     stage-packages:
-      - 7zip
+      - 7zip-standalone
       - chafa
       - fd-find
       - ffmpeg
@@ -58,3 +58,17 @@ parts:
       - --prefix=/usr
     build-attributes:
       - enable-patchelf
+
+  # This is a bit of hack to work around a bug in latest snapcraft.
+  # This should be done in `override-prime` of the `yazi` part, but doing
+  # so seems to disable the automatic ELF patching, meaning none of the bins
+  # work correctly!
+  #
+  # Ubuntu's /usr/bin/7zz is a simple bash wrapper that just exec's
+  # /usr/lib/7zip/7zz - this just shortcuts that and places the actual
+  # executable at $SNAP/usr/bin/7zz.
+  fix-7z:
+    after: [yazi]
+    plugin: nil
+    override-prime: |
+      mv $CRAFT_PRIME/usr/lib/7zip/7zz $CRAFT_PRIME/usr/bin/7zz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,8 @@ parts:
     override-build: |
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0)
+    build-attributes:
+      - enable-patchelf
     organize:
       # Ubuntu's `fd` package installs a binary named `fdfind`. Rename it in the snap.
       usr/bin/fdfind: usr/bin/fd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ apps:
   yazi:
     command: yazi
     environment:
-      PATH: $SNAP/bin:$PATH
+      PATH: $SNAP/bin:$SNAP/usr/bin:$PATH
 
 parts:
   yazi:


### PR DESCRIPTION
This PR makes a few small adjustments to the snap package.

Firstly, it uses packages from the Ubuntu archive (or Snap store) for `yazi`'s dependencies such as `fzf`, `zoxide`, `jq`, etc.

The one exception is `magick`, where in the Ubuntu package `magick` binary is not present (I don't know why!), so we build from source. This has the advantage over fetching the prebuilt binary in that it'll work across architectures.

Also re-enables `arm64` (see [post](https://forum.snapcraft.io/t/help-needed-cant-build-arm64-snap-with-github-actions/41356)).

Tested this on my `amd64` laptop - as far as I can tell it all works (including the image previews 😎 )