### PR TITLE
ci(snap): correct `runs-on` definition for snap workflow

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -150,7 +150,7 @@ jobs:
         arch:
           - amd64
           - arm64
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -185,13 +185,13 @@ jobs:
           cat snapcraft-yazi*.txt || echo "Could not find build log"
 
       - name: Rename snap
-        run: mv yazi_*.snap yazi-${{ matrix.target }}.snap
+        run: mv yazi_*.snap yazi-${{ matrix.arch }}.snap
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yazi-${{ matrix.target }}.snap
-          path: yazi-${{ matrix.target }}.snap
+          name: yazi-${{ matrix.arch }}.snap
+          path: yazi-${{ matrix.arch }}.snap
 
   draft:
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Fixes a minor error in recently merged CI pipeline for snap build.