### PR TITLE
ci(snap): don't use a shallow clone when checking out the repo for snap build

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -153,6 +153,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.6


### PR DESCRIPTION
Resolves an error in the latest snap build run in CI. Disables shallow cloning when pulling the code.