### PR TITLE
feat: custom modal component API

### DIFF
--- a/yazi-plugin/preset/components/modal.lua
+++ b/yazi-plugin/preset/components/modal.lua
@@ -1,0 +1,42 @@
+Modal = {
+	_id = "modal",
+
+	_inc = 1000,
+	_children = {},
+}
+
+function Modal:new(area) return setmetatable({ _area = area }, { __index = self }) end
+
+function Modal:reflow()
+	local components = {}
+	for _, child in ipairs(self._children) do
+		components = ya.list_merge(components, child[1]:new(self._area):reflow())
+	end
+	return components
+end
+
+function Modal:redraw()
+	local elements = {}
+	for _, child in ipairs(self._children) do
+		elements = ya.list_merge(elements, ya.redraw_with(child[1]:new(self._area)))
+	end
+	return elements
+end
+
+-- Children
+function Modal:children_add(tbl, order)
+	self._inc = self._inc + 1
+	self._children[#self._children + 1] = { tbl, id = self._inc, order = order }
+
+	table.sort(self._children, function(a, b) return a.order < b.order end)
+	return self._inc
+end
+
+function Modal:children_remove(id)
+	for i, child in ipairs(self._children) do
+		if child.id == id then
+			table.remove(self._children, i)
+			break
+		end
+	end
+end

--- a/yazi-plugin/preset/components/rail.lua
+++ b/yazi-plugin/preset/components/rail.lua
@@ -1,6 +1,5 @@
 Rail = {
 	_id = "rail",
-	_area = ui.Rect.default,
 }
 
 function Rail:new(chunks, tab)
@@ -20,7 +19,7 @@ function Rail:build()
 	}
 end
 
-function Rail:reflow() return { self } end
+function Rail:reflow() return {} end
 
 function Rail:redraw()
 	local elements = self._base or {}

--- a/yazi-plugin/preset/components/root.lua
+++ b/yazi-plugin/preset/components/root.lua
@@ -26,6 +26,7 @@ function Root:build()
 		Header:new(self._chunks[1], cx.active),
 		Tab:new(self._chunks[2], cx.active),
 		Status:new(self._chunks[3], cx.active),
+		Modal:new(self._area),
 	}
 end
 
@@ -47,17 +48,17 @@ end
 
 -- Mouse events
 function Root:click(event, up)
-	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self._children)
+	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self:reflow())
 	return c and c:click(event, up)
 end
 
 function Root:scroll(event, step)
-	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self._children)
+	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self:reflow())
 	return c and c:scroll(event, step)
 end
 
 function Root:touch(event, step)
-	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self._children)
+	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self:reflow())
 	return c and c:touch(event, step)
 end
 

--- a/yazi-plugin/preset/components/tab.lua
+++ b/yazi-plugin/preset/components/tab.lua
@@ -46,17 +46,8 @@ function Tab:redraw()
 end
 
 -- Mouse events
-function Tab:click(event, up)
-	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self._children)
-	return c and c:click(event, up)
-end
+function Tab:click(event, up) end
 
-function Tab:scroll(event, step)
-	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self._children)
-	return c and c:scroll(event, step)
-end
+function Tab:scroll(event, step) end
 
-function Tab:touch(event, step)
-	local c = ya.child_at(ui.Rect { x = event.x, y = event.y }, self._children)
-	return c and c:touch(event, step)
-end
+function Tab:touch(event, step) end

--- a/yazi-plugin/src/lua.rs
+++ b/yazi-plugin/src/lua.rs
@@ -43,6 +43,7 @@ fn stage_1(lua: &'static Lua) -> Result<()> {
 	lua.load(preset!("components/linemode")).set_name("linemode.lua").exec()?;
 
 	lua.load(preset!("components/marker")).set_name("marker.lua").exec()?;
+	lua.load(preset!("components/modal")).set_name("modal.lua").exec()?;
 	lua.load(preset!("components/parent")).set_name("parent.lua").exec()?;
 	lua.load(preset!("components/preview")).set_name("preview.lua").exec()?;
 	lua.load(preset!("components/progress")).set_name("progress.lua").exec()?;


### PR DESCRIPTION
With this PR, you'll be able to dynamically register custom modal components to Yazi. 

A modal is an isolated component on the screen where you can access all the app data that Yazi supports, and you can also use all available UI layout APIs to create flexible and powerful custom UIs.

To register a component to Yazi, use `Modal:children_add(component, order)`.

Each component has the following attributes:

- `_id`: A unique ID for the component, which cannot conflict with the [built-in component](https://github.com/sxyazi/yazi/tree/main/yazi-plugin/preset/components) IDs.
- `new`: The function to instantiate the component, which returns a component instance. This function accepts an `area` parameter, a `Rect` that represents the entire screen area.
- `reflow`: The component's reflow function. If you need to support mouse events, it should return an array with the component itself, where mouse events will be passed into the `click`, `scroll`, or `touch` methods. Otherwise, return `{}`.
- `redraw`: The component's render function, which returns a list of renderable elements.

For example:

```lua
Modal:children_add({
  _id = "my-component",
  new = function(self, area)
    self._area = self.layout(area)
    return self
  end,
  reflow = function(self) return { self } end,
  redraw = function(self)
    return {
      ui.Clear(self._area),
      ui.Text("Hello, World!"):area(self._area):bg("blue"):bold(),
    }
  end,

  -- Optional methods:
  layout = function(area)
    local chunks = ui.Layout()
      :constraints({
        ui.Constraint.Ratio(1, 3),
        ui.Constraint.Ratio(1, 3),
        ui.Constraint.Ratio(1, 3),
      })
      :split(area)
    return chunks[2]
  end,
  click = function(self, event, up) end,
  scroll = function(self, event, step) end,
  touch = function(self, event, step) end,
}, 10)
```