### PR TITLE
ci: use GitHub Linux arm64 runners for the snap build

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -145,43 +145,27 @@ jobs:
           path: yazi-${{ matrix.target }}.zip
 
   build-snap:
-    if: false # Can't make CI pass, disable for now
     strategy:
       matrix:
-        arch:
-          - amd64
-          - arm64
-    runs-on: ubuntu-latest
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
+          - os: ubuntu-24.04
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: canonical/setup-lxd@v0.1.2
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.2
 
       - name: Setup snapcraft
-        run: |
-          sudo snap install --classic snapcraft
-
-          mkdir -p ~/.local/share/snapcraft
-          echo "${{ secrets.LP_TOKEN }}" > ~/.local/share/snapcraft/launchpad-credentials
-
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "Github Actions"
+        run: sudo snap install --classic snapcraft
 
       - name: Build snap
-        env:
-          arch: ${{ matrix.arch }}
-        run: |
-          # Modify the `platforms` to use a single arch only, but run this in a matrix so they
-          # all get hit
-          yq -i '.platforms |= {env(arch): {"build-on": env(arch)}}' snap/snapcraft.yaml
-
-          # Now run a remote-build, targeting just the single arch specified
-          snapcraft remote-build --launchpad-accept-public-upload
-
-          # Output the build logs from the remote-build
-          cat snapcraft-yazi*.txt || echo "Could not find build log"
+        run: snapcraft --verbose
 
       - name: Rename snap
         run: mv yazi_*.snap yazi-${{ matrix.arch }}.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -133,9 +133,6 @@ parts:
       - usr/lib/libMagickCore-7.Q16HDRI.so*
       - usr/lib/libMagickWand-7.Q16HDRI.so*
 
-  # Most of what is done here should be done in the `yazi` part, but using
-  # `override-prime` there stops snapcraft from automatically patching ELF
-  # binaries (due to a bug), so we do that work here in a separate part.
   cleanup:
     after: [yazi, magick]
     plugin: nil
@@ -148,14 +145,6 @@ parts:
       # /usr/lib/7zip/7zz - this just shortcuts that and places the actual
       # executable at $SNAP/usr/bin/7zz.
       mv $CRAFT_PRIME/usr/lib/7zip/7zz $CRAFT_PRIME/usr/bin/7zz
-
-      # The snapcraft linter highlighted issues with the rpath of these two libraries,
-      # so we fix them up manually here after they are primed in the yazi part.
-      patchelf --force-rpath --set-rpath "\$ORIGIN:\$ORIGIN/pulseaudio:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpulse.so.0.24.2
-      patchelf --force-rpath --set-rpath "\$ORIGIN/lapack:\$ORIGIN/blas:\$ORIGIN:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsphinxbase.so.3.0.0
-      patchelf --force-rpath --set-rpath "\$ORIGIN/../lib:\$ORIGIN/../lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/bin/magick
-      patchelf --force-rpath --set-rpath "\$ORIGIN/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/libMagickCore-7.Q16HDRI.so.10.0.2
-      patchelf --force-rpath --set-rpath "\$ORIGIN:\$ORIGIN/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/core24/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" $CRAFT_PRIME/usr/lib/libMagickWand-7.Q16HDRI.so.10.0.2
 
       # Ensure we don't ship duplicates of files that exist in the core24
       # snap.


### PR DESCRIPTION
I've taken a look at the snap build failures on arm64. It looks like snapcraft behaves subtly differently on amd64 and arm64 with respect to automatically patching ELF binaries. This PR addresses that - it turns out we don't need the manual patch for things to function. Tested locally on my machine, and everything seems to work just fine.


In addition, Github [announced](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) yesterday that arm64 runners are now available to public repos - so this PR also simplifies the snap build pipeline to use those - which simplifies both the pipeline and (hopefully) the debugging of any issues.