### PR TITLE
fix(nix): rust overlay infinite recursion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,21 +21,12 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [
-            rust-overlay.overlays.default
-            (
-              final: prev:
-              let
-                toolchain = final.rust-bin.stable.latest.default;
-              in
-              {
-                rustPlatform = prev.makeRustPlatform {
-                  cargo = toolchain;
-                  rustc = toolchain;
-                };
-              }
-            )
-          ];
+          overlays = [ rust-overlay.overlays.default ];
+        };
+        toolchain = pkgs.rust-bin.stable.latest.default;
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = toolchain;
+          rustc = toolchain;
         };
 
         rev = self.shortRev or self.dirtyShortRev or "dirty";
@@ -46,7 +37,14 @@
       in
       {
         packages = {
-          yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix { inherit version rev date; };
+          yazi-unwrapped = pkgs.callPackage ./nix/yazi-unwrapped.nix {
+            inherit
+              version
+              rev
+              date
+              rustPlatform
+              ;
+          };
           yazi = pkgs.callPackage ./nix/yazi.nix { inherit (self.packages.${system}) yazi-unwrapped; };
           default = self.packages.${system}.yazi;
         };


### PR DESCRIPTION
The `rust-overlay` project strongly recommend not overlaying the global Rust platform since that can cause a dependency loop, creating an infinite recursion (see https://github.com/oxalica/rust-overlay/issues/198#issuecomment-2566755261).

Instead, a custom `rustPlatform` can be passed to the derivation, as per the instructions in the [Nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#using-rust-nightly-in-a-derivation-with-buildrustpackage).

Fixes: https://github.com/sxyazi/yazi/issues/2215