### PR TITLE
ci(snap): correct arm64 runner OS

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -150,7 +150,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             arch: amd64
-          - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
             arch: arm64
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
 Correct a minor error I introduced in refactoring the snap workflow. Now this actually uses an arm runner 🤦‍♂️ 

Sorry about the noise!