### PR TITLE
fix: ignore completions artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target/
-yazi-config/completions
+yazi-*/completions
 
 .DS_Store
 


### PR DESCRIPTION
Update `.gitignore` to not track the built completions files.

Added general pattern to ignore all `completions` directories in the first level of any `yazi-*` directory.