### PR TITLE
fix: use `u32` for parsing Linux partition blocks

### DIFF
--- a/yazi-fs/src/mounts/linux.rs
+++ b/yazi-fs/src/mounts/linux.rs
@@ -117,7 +117,7 @@ impl Partitions {
 			let mut it = line.split_whitespace();
 			let Some(Ok(_major)) = it.next().map(|s| s.parse::<u16>()) else { continue };
 			let Some(Ok(_minor)) = it.next().map(|s| s.parse::<u16>()) else { continue };
-			let Some(Ok(_blocks)) = it.next().map(|s| s.parse::<u16>()) else { continue };
+			let Some(Ok(_blocks)) = it.next().map(|s| s.parse::<u32>()) else { continue };
 			if let Some(name) = it.next() {
 				set.insert(Self::unmangle_octal(name).into_owned());
 			}


### PR DESCRIPTION
Now it matches the `#blocks` size of the `/proc/partitions` table, for example:

```
major minor  #blocks  name

   8        0  234431064 sda
   8       16  488386584 sdb
   8       17  488385536 sdb1
 259        0  468851544 nvme0n1
 259        1    1048576 nvme0n1p1
 259        2    8388608 nvme0n1p2
 259        3  459412480 nvme0n1p3
   8       32   61587456 sdc
```