### PR TITLE
feat: apply natural sort to partitions on both Linux and macOS

### DIFF
--- a/yazi-fs/src/mounts/linux.rs
+++ b/yazi-fs/src/mounts/linux.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::{HashMap, HashSet}, ffi::{OsStr, OsString}, 
 use anyhow::Result;
 use tokio::{io::{Interest, unix::AsyncFd}, time::sleep};
 use tracing::error;
-use yazi_shared::{replace_cow, replace_vec_cow};
+use yazi_shared::{natsort, replace_cow, replace_vec_cow};
 
 use super::{Locked, Partition, Partitions};
 
@@ -77,6 +77,7 @@ impl Partitions {
 			let mut set: HashSet<&OsStr> = set.iter().map(AsRef::as_ref).collect();
 			mounts.iter().filter_map(|p| p.dev_name()).for_each(|s| _ = set.remove(s));
 			mounts.extend(set.into_iter().map(Partition::new));
+			mounts.sort_unstable_by(|a, b| natsort(a.src.as_bytes(), b.src.as_bytes(), false));
 		};
 
 		let labels = Self::labels()?;

--- a/yazi-fs/src/mounts/macos.rs
+++ b/yazi-fs/src/mounts/macos.rs
@@ -7,6 +7,7 @@ use objc::{msg_send, runtime::Object, sel, sel_impl};
 use scopeguard::defer;
 use tracing::error;
 use yazi_ffi::{CFDict, CFString, DADiskCopyDescription, DADiskCreateFromBSDName, DARegisterDiskAppearedCallback, DARegisterDiskDescriptionChangedCallback, DARegisterDiskDisappearedCallback, DASessionCreate, DASessionScheduleWithRunLoop, IOIteratorNext, IOObjectRelease, IORegistryEntryCreateCFProperty, IOServiceGetMatchingServices, IOServiceMatching};
+use yazi_shared::natsort;
 
 use super::{Locked, Partition, Partitions};
 
@@ -145,7 +146,7 @@ impl Partitions {
 			}
 		}
 
-		names.sort_unstable();
+		names.sort_unstable_by(|a, b| natsort(a.as_bytes(), b.as_bytes(), false));
 		Ok(names)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/yazi-rs/plugins/pull/53#issuecomment-2607313343

This will benefit downstream plugins using the `ya.partitions()` API, as the results they get will always be ordered after this PR.