### PR TITLE
feat: wrap long task descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -717,6 +717,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1025,15 +1031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,9 +1237,9 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1464,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "luajit-src"
-version = "210.5.11+97813fb"
+version = "210.5.12+a4f56a4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3015551c284515db7c30c559fc1080f9cb9ee990d1f6fca315451a107c7540bb"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
 dependencies = [
  "cc",
  "which",
@@ -1740,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -2200,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.8.0",
  "errno",
@@ -2240,9 +2237,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -2276,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2837,9 +2834,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2934,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
 dependencies = [
  "idna",
  "once_cell",
@@ -2950,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac855a2ce6f843beb229757e6e570a42e837bcb15e5f449dd48d5747d41bf77"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
  "darling",
  "once_cell",
@@ -3101,12 +3098,12 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
 dependencies = [
  "either",
- "home",
+ "env_home",
  "rustix",
  "winsafe",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,6 +2511,17 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "thiserror"
@@ -2823,6 +2840,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3459,6 +3482,7 @@ dependencies = [
  "scopeguard",
  "signal-hook-tokio",
  "syntect",
+ "textwrap",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ ansi-to-tui         = "7.0.0"
 anyhow              = "1.0.95"
 base64              = "0.22.1"
 bitflags            = "2.8.0"
-clap                = { version = "4.5.26", features = [ "derive" ] }
+clap                = { version = "4.5.27", features = [ "derive" ] }
 core-foundation-sys = "0.8.7"
 crossterm           = { version = "0.28.1", features = [ "event-stream" ] }
 dirs                = "6.0.0"
@@ -29,7 +29,7 @@ ratatui             = { version = "0.29.0", features = [ "unstable-rendered-line
 regex               = "1.11.1"
 scopeguard          = "1.2.0"
 serde               = { version = "1.0.217", features = [ "derive" ] }
-serde_json          = "1.0.136"
+serde_json          = "1.0.137"
 shell-words         = "1.1.0"
 tokio               = { version = "1.43.0", features = [ "full" ] }
 tokio-stream        = "0.1.17"

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -18,13 +18,13 @@ anyhow    = { workspace = true }
 bitflags  = { workspace = true }
 crossterm = { workspace = true }
 globset   = { workspace = true }
-indexmap  = { version = "2.7.0", features = [ "serde" ] }
+indexmap  = { version = "2.7.1", features = [ "serde" ] }
 ratatui   = { workspace = true }
 regex     = { workspace = true }
 serde     = { workspace = true }
 toml      = { workspace = true }
 tracing   = { workspace = true }
-validator = { version = "0.19.0", features = [ "derive" ] }
+validator = { version = "0.20.0", features = [ "derive" ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 crossterm = { workspace = true, features = [ "use-dev-tty", "libc" ] }

--- a/yazi-core/src/tab/commands/search.rs
+++ b/yazi-core/src/tab/commands/search.rs
@@ -4,9 +4,9 @@ use tokio::pin;
 use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
 use tracing::error;
 use yazi_config::popup::InputCfg;
+use yazi_fs::{Cha, FilesOp};
 use yazi_plugin::external;
 use yazi_proxy::{AppProxy, InputProxy, ManagerProxy, TabProxy, options::{SearchOpt, SearchOptVia}};
-use yazi_fs::{Cha, FilesOp};
 
 use crate::tab::Tab;
 

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -42,6 +42,7 @@ tokio-stream = { workspace = true }
 tracing            = { workspace = true }
 tracing-appender   = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = [ "env-filter" ] }
+textwrap = "0.16.1"
 
 [target."cfg(unix)".dependencies]
 libc              = { workspace = true }

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -42,7 +42,7 @@ tokio-stream = { workspace = true }
 tracing            = { workspace = true }
 tracing-appender   = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = [ "env-filter" ] }
-textwrap = "0.16.1"
+textwrap           = "0.16.1"
 
 [target."cfg(unix)".dependencies]
 libc              = { workspace = true }

--- a/yazi-fm/src/tasks/tasks.rs
+++ b/yazi-fm/src/tasks/tasks.rs
@@ -1,9 +1,4 @@
-use ratatui::{
-	buffer::Buffer,
-	layout::{self, Alignment, Constraint, Rect},
-	text::{Line, Text},
-	widgets::{Block, BorderType, List, Padding, Widget},
-};
+use ratatui::{buffer::Buffer, layout::{self, Alignment, Constraint, Rect}, text::{Line, Text}, widgets::{Block, BorderType, List, Padding, Widget}};
 use textwrap::Options;
 use yazi_config::THEME;
 use yazi_core::tasks::TASKS_PERCENT;
@@ -15,9 +10,7 @@ pub(crate) struct Tasks<'a> {
 }
 
 impl<'a> Tasks<'a> {
-	pub(crate) fn new(cx: &'a Ctx) -> Self {
-		Self { cx }
-	}
+	pub(crate) fn new(cx: &'a Ctx) -> Self { Self { cx } }
 
 	pub(super) fn area(area: Rect) -> Rect {
 		let chunk = layout::Layout::vertical([

--- a/yazi-fm/src/tasks/tasks.rs
+++ b/yazi-fm/src/tasks/tasks.rs
@@ -1,5 +1,4 @@
 use ratatui::{buffer::Buffer, layout::{self, Alignment, Constraint, Rect}, text::{Line, Text}, widgets::{Block, BorderType, List, Padding, Widget}};
-use textwrap::Options;
 use yazi_config::THEME;
 use yazi_core::tasks::TASKS_PERCENT;
 
@@ -42,27 +41,17 @@ impl Widget for Tasks<'_> {
 			.border_style(THEME.tasks.border);
 		block.clone().render(area, buf);
 
+		let inner = block.inner(area);
 		let tasks = &self.cx.tasks;
-		let items = tasks
-			.summaries
-			.iter()
-			.take(area.height.saturating_sub(2) as usize)
-			.enumerate()
-			.map(|(i, v)| {
-				let line_otions = Options::new(area.width as usize).subsequent_indent("  ");
-				let lines = textwrap::wrap(&v.name, line_otions)
-					.iter()
-					.map(|s| Line::from(s.clone()))
-					.collect::<Vec<Line>>();
 
-				let mut item = Text::from(lines);
-				if i == tasks.cursor {
-					item = item.style(THEME.tasks.hovered);
-				}
-				item
-			})
-			.collect::<Vec<_>>();
-
+		let items = tasks.summaries.iter().take(inner.height as usize).enumerate().map(|(i, v)| {
+			let mut item =
+				Text::from_iter(textwrap::wrap(&v.name, inner.width as usize).into_iter().map(Line::from));
+			if i == tasks.cursor {
+				item = item.style(THEME.tasks.hovered);
+			}
+			item
+		});
 		List::new(items).render(block.inner(area), buf);
 	}
 }

--- a/yazi-fm/src/tasks/tasks.rs
+++ b/yazi-fm/src/tasks/tasks.rs
@@ -1,4 +1,10 @@
-use ratatui::{buffer::Buffer, layout::{self, Alignment, Constraint, Rect}, text::Line, widgets::{Block, BorderType, List, ListItem, Padding, Widget}};
+use ratatui::{
+	buffer::Buffer,
+	layout::{self, Alignment, Constraint, Rect},
+	text::{Line, Text},
+	widgets::{Block, BorderType, List, Padding, Widget},
+};
+use textwrap::Options;
 use yazi_config::THEME;
 use yazi_core::tasks::TASKS_PERCENT;
 
@@ -9,7 +15,9 @@ pub(crate) struct Tasks<'a> {
 }
 
 impl<'a> Tasks<'a> {
-	pub(crate) fn new(cx: &'a Ctx) -> Self { Self { cx } }
+	pub(crate) fn new(cx: &'a Ctx) -> Self {
+		Self { cx }
+	}
 
 	pub(super) fn area(area: Rect) -> Rect {
 		let chunk = layout::Layout::vertical([
@@ -48,7 +56,13 @@ impl Widget for Tasks<'_> {
 			.take(area.height.saturating_sub(2) as usize)
 			.enumerate()
 			.map(|(i, v)| {
-				let mut item = ListItem::new(v.name.clone());
+				let line_otions = Options::new(area.width as usize).subsequent_indent("  ");
+				let lines = textwrap::wrap(&v.name, line_otions)
+					.iter()
+					.map(|s| Line::from(s.clone()))
+					.collect::<Vec<Line>>();
+
+				let mut item = Text::from(lines);
 				if i == tasks.cursor {
 					item = item.style(THEME.tasks.hovered);
 				}

--- a/yazi-fm/src/tasks/tasks.rs
+++ b/yazi-fm/src/tasks/tasks.rs
@@ -39,11 +39,11 @@ impl Widget for Tasks<'_> {
 			.padding(Padding::symmetric(1, 1))
 			.border_type(BorderType::Rounded)
 			.border_style(THEME.tasks.border);
-		block.clone().render(area, buf);
 
 		let inner = block.inner(area);
-		let tasks = &self.cx.tasks;
+		block.render(area, buf);
 
+		let tasks = &self.cx.tasks;
 		let items = tasks.summaries.iter().take(inner.height as usize).enumerate().map(|(i, v)| {
 			let mut item =
 				Text::from_iter(textwrap::wrap(&v.name, inner.width as usize).into_iter().map(Line::from));
@@ -52,6 +52,7 @@ impl Widget for Tasks<'_> {
 			}
 			item
 		});
-		List::new(items).render(block.inner(area), buf);
+
+		List::new(items).render(inner, buf);
 	}
 }


### PR DESCRIPTION

An implementation of the feature request: https://github.com/sxyazi/yazi/issues/1582

Closes https://github.com/sxyazi/yazi/issues/1582

---

If task description is longer than window width -> wrap rest
Changes were made in responce for existing enhancement https://github.com/sxyazi/yazi/issues/1582

Was implemented by spliting text in lines with textwrap and using Text instead of ListItem for display

**Before changes**
![image](https://github.com/user-attachments/assets/e2e38dad-d90d-48ef-92c5-24eacd543d72)

**After changes**
![Screenshot 2025-01-24 170343](https://github.com/user-attachments/assets/21840374-2cf3-49a2-a0e0-39ec50e8493a)

