### PR TITLE
fix(plugin): validate plugin path existence before file create

### DIFF
--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -12,6 +12,11 @@ impl Dependency {
 		let from = self.local().join(&self.child);
 
 		self.header("Deploying package `{name}`")?;
+		// TODO: maybe need to be removed
+		let plugin_exists = maybe_exists(&from).await;
+		if !plugin_exists {
+			bail!("Plugin `{}` not found", self.name);
+		}
 		self.is_flavor = maybe_exists(&from.join("flavor.toml")).await;
 
 		let to = self.target();


### PR DESCRIPTION
Previously, the deployment logic did not verify the existence of the plugin repository path before attempting to create files. This could lead to redundant file creation operations when the plugin path was invalid.

- Add pre-check for plugin directory existence
- Fail early when plugin path is not found Fixes #1763