### PR TITLE
docs: add Bobcat to the list of VTEs with images preview support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265
 | [Rio](https://github.com/raphamorim/rio)                                    | [Inline images protocol][iip]          | ❌ Rio doesn't correctly clear images [#709][rio-bug] |
 | [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)                  | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
 | [Hyper](https://github.com/vercel/hyper)                                    | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| [Bobcat](https://github.com/ismail-yilmaz/Bobcat)                           | [Inline images protocol][iip]          | ✅ Built-in                                           |
 | X11 / Wayland                                                               | Window system protocol                 | ☑️ [Überzug++][ueberzug] required                     |
 | Fallback                                                                    | [ASCII art (Unicode block)][ascii-art] | ☑️ [Chafa][chafa] required                            |
 

--- a/README.md
+++ b/README.md
@@ -38,24 +38,24 @@ https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265
 
 ## Image Preview
 
-| Platform                                                                    | Protocol                               | Support                                               |
-| --------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------- |
-| [kitty](https://github.com/kovidgoyal/kitty)                                | [Kitty unicode placeholders][kgp]      | ✅ Built-in                                           |
-| [iTerm2](https://iterm2.com)                                                | [Inline images protocol][iip]          | ✅ Built-in                                           |
-| [WezTerm](https://github.com/wez/wezterm)                                   | [Inline images protocol][iip]          | ✅ Built-in                                           |
-| [Konsole](https://invent.kde.org/utilities/konsole)                         | [Kitty old protocol][kgp-old]          | ✅ Built-in                                           |
-| [foot](https://codeberg.org/dnkl/foot)                                      | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
-| [Ghostty](https://github.com/ghostty-org/ghostty)                           | [Kitty unicode placeholders][kgp]      | ✅ Built-in                                           |
-| [Windows Terminal](https://github.com/microsoft/terminal) (>= v1.22.2702.0) | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
-| [st with Sixel patch](https://github.com/bakkeby/st-flexipatch)             | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
-| [Tabby](https://github.com/Eugeny/tabby)                                    | [Inline images protocol][iip]          | ✅ Built-in                                           |
-| [VSCode](https://github.com/microsoft/vscode)                               | [Inline images protocol][iip]          | ✅ Built-in                                           |
-| [Rio](https://github.com/raphamorim/rio)                                    | [Inline images protocol][iip]          | ❌ Rio doesn't correctly clear images [#709][rio-bug] |
-| [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)                  | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
-| [Hyper](https://github.com/vercel/hyper)                                    | [Inline images protocol][iip]          | ✅ Built-in                                           |
-| [Bobcat](https://github.com/ismail-yilmaz/Bobcat)                           | [Inline images protocol][iip]          | ✅ Built-in                                           |
-| X11 / Wayland                                                               | Window system protocol                 | ☑️ [Überzug++][ueberzug] required                     |
-| Fallback                                                                    | [ASCII art (Unicode block)][ascii-art] | ☑️ [Chafa][chafa] required                            |
+| Platform                                                                                                      | Protocol                               | Support                                               |
+| ------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------- |
+| [kitty](https://github.com/kovidgoyal/kitty) (>= 0.28.0)                                                      | [Kitty unicode placeholders][kgp]      | ✅ Built-in                                           |
+| [iTerm2](https://iterm2.com)                                                                                  | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| [WezTerm](https://github.com/wez/wezterm)                                                                     | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| [Konsole](https://invent.kde.org/utilities/konsole)                                                           | [Kitty old protocol][kgp-old]          | ✅ Built-in                                           |
+| [foot](https://codeberg.org/dnkl/foot)                                                                        | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
+| [Ghostty](https://github.com/ghostty-org/ghostty)                                                             | [Kitty unicode placeholders][kgp]      | ✅ Built-in                                           |
+| [Windows Terminal Preview](https://github.com/microsoft/terminal/releases/tag/v1.22.2702.0) (>= v1.22.2702.0) | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
+| [st with Sixel patch](https://github.com/bakkeby/st-flexipatch)                                               | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
+| [Tabby](https://github.com/Eugeny/tabby)                                                                      | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| [VSCode](https://github.com/microsoft/vscode)                                                                 | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| [Rio](https://github.com/raphamorim/rio)                                                                      | [Inline images protocol][iip]          | ❌ Rio doesn't correctly clear images [#709][rio-bug] |
+| [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)                                                    | [Sixel graphics format][sixel]         | ✅ Built-in                                           |
+| [Hyper](https://github.com/vercel/hyper)                                                                      | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| [Bobcat](https://github.com/ismail-yilmaz/Bobcat)                                                             | [Inline images protocol][iip]          | ✅ Built-in                                           |
+| X11 / Wayland                                                                                                 | Window system protocol                 | ☑️ [Überzug++][ueberzug] required                     |
+| Fallback                                                                                                      | [ASCII art (Unicode block)][ascii-art] | ☑️ [Chafa][chafa] required                            |
 
 See https://yazi-rs.github.io/docs/image-preview for details.
 

--- a/yazi-adapter/src/brand.rs
+++ b/yazi-adapter/src/brand.rs
@@ -22,6 +22,7 @@ pub enum Brand {
 	Neovim,
 	Apple,
 	Urxvt,
+	Bobcat,
 }
 
 impl Brand {
@@ -83,6 +84,7 @@ impl Brand {
 			("WezTerm", Self::WezTerm),
 			("foot", Self::Foot),
 			("ghostty", Self::Ghostty),
+			("Bobcat", Self::Bobcat),
 		];
 		names.into_iter().find(|&(n, _)| resp.contains(n)).map(|(_, b)| b)
 	}
@@ -110,6 +112,7 @@ impl Brand {
 			B::Neovim => &[],
 			B::Apple => &[],
 			B::Urxvt => &[],
+			B::Bobcat => &[A::Iip, A::Sixel],
 		}
 	}
 


### PR DESCRIPTION
Bobcat, yet another cross-platform terminal emulator, also supports yazi's image preview feature, with both iTerm2 & sixel protocols.  (See the [screenshots](https://github.com/ismail-yilmaz/Bobcat?tab=readme-ov-file#Screenshots) section for an example.)

This PR adds Bobcat to the brands list and updates the README file. With this change, Yazi can recognize Bobcat by sending an extended attributes report request (`CSI > q`).