### PR TITLE
fix: squeeze the parent directory offset after terminal size change

### DIFF
--- a/yazi-core/src/manager/manager.rs
+++ b/yazi-core/src/manager/manager.rs
@@ -71,6 +71,9 @@ impl Manager {
 	pub fn parent(&self) -> Option<&Folder> { self.active().parent.as_ref() }
 
 	#[inline]
+	pub fn parent_mut(&mut self) -> Option<&mut Folder> { self.active_mut().parent.as_mut() }
+
+	#[inline]
 	pub fn hovered(&self) -> Option<&File> { self.active().hovered() }
 
 	#[inline]

--- a/yazi-fm/src/app/commands/resize.rs
+++ b/yazi-fm/src/app/commands/resize.rs
@@ -20,5 +20,6 @@ impl App {
 
 		self.cx.current_mut().sync_page(true);
 		self.cx.manager.hover(None);
+		self.cx.manager.parent_mut().map(|f| f.arrow(0));
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/1859

Fixes https://github.com/sxyazi/yazi/issues/1860