### PR TITLE
feat: new `arrow top` and `arrow bot` commands to jump to the top and bottom

### DIFF
--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -29,8 +29,8 @@ keymap = [
 	{ on = "<PageUp>",     run = "arrow -100%", desc = "Move cursor up one page" },
 	{ on = "<PageDown>",   run = "arrow 100%",  desc = "Move cursor down one page" },
 
-	{ on = [ "g", "g" ], run = "arrow -99999999", desc = "Move cursor to the top" },
-	{ on = "G",          run = "arrow 99999999",  desc = "Move cursor to the bottom" },
+	{ on = [ "g", "g" ], run = "arrow top", desc = "Move cursor to the top" },
+	{ on = "G",          run = "arrow bot",  desc = "Move cursor to the bottom" },
 
 	# Navigation
 	{ on = "h", run = "leave", desc = "Go back to the parent directory" },

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -28,6 +28,17 @@ pub fn init() -> anyhow::Result<()> {
 		try_init(false)?;
 	}
 
+	// TODO: remove this
+	for c in KEYMAP.manager.iter().flat_map(|c| c.run.iter()) {
+		if c.name == "arrow"
+			&& c.first_str().unwrap_or_default().parse::<isize>().is_ok_and(|n| n <= -999 || n >= 999)
+		{
+			eprintln!("Deprecated command: `arrow -99999999` and `arrow 99999999` have been deprecated, please use `arrow top` and `arrow bot` instead, in your `keymap.toml`.
+
+See #2262 for more details: https://github.com/sxyazi/yazi/pull/2262");
+		}
+	}
+
 	Ok(())
 }
 

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -35,7 +35,7 @@ pub fn init() -> anyhow::Result<()> {
 		{
 			eprintln!("Deprecated command: `arrow -99999999` and `arrow 99999999` have been deprecated, please use `arrow top` and `arrow bot` instead, in your `keymap.toml`.
 
-See #2262 for more details: https://github.com/sxyazi/yazi/pull/2262");
+See #2294 for more details: https://github.com/sxyazi/yazi/pull/2294");
 		}
 	}
 

--- a/yazi-core/src/input/commands/move_.rs
+++ b/yazi-core/src/input/commands/move_.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{num::ParseIntError, str::FromStr};
 
 use unicode_width::UnicodeWidthStr;
 use yazi_macro::render;
@@ -76,14 +76,14 @@ impl Default for OptStep {
 }
 
 impl FromStr for OptStep {
-	type Err = ();
+	type Err = ParseIntError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		Ok(match s {
 			"bol" => Self::Bol,
 			"eol" => Self::Eol,
 			"first-char" => Self::FirstChar,
-			s => Self::Offset(s.parse().map_err(|_| ())?),
+			s => Self::Offset(s.parse()?),
 		})
 	}
 }

--- a/yazi-core/src/tab/commands/arrow.rs
+++ b/yazi-core/src/tab/commands/arrow.rs
@@ -29,7 +29,7 @@ impl Tab {
 					"Deprecated command",
 					"`arrow -99999999` and `arrow 99999999` have been deprecated, please use `arrow top` and `arrow bot` instead.
 
-See #2262 for more details: https://github.com/sxyazi/yazi/pull/2262",
+See #2294 for more details: https://github.com/sxyazi/yazi/pull/2294",
 				);
 			}
 		}

--- a/yazi-fs/src/step.rs
+++ b/yazi-fs/src/step.rs
@@ -1,7 +1,11 @@
 use std::{num::ParseIntError, str::FromStr};
 
+use yazi_shared::event::Data;
+
 #[derive(Clone, Copy)]
 pub enum Step {
+	Top,
+	Bot,
 	Fixed(isize),
 	Percent(i8),
 }
@@ -10,34 +14,41 @@ impl Default for Step {
 	fn default() -> Self { Self::Fixed(0) }
 }
 
-impl FromStr for Step {
-	type Err = ParseIntError;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Ok(if let Some(s) = s.strip_suffix('%') {
-			Self::Percent(s.parse()?)
-		} else {
-			Self::Fixed(s.parse()?)
-		})
-	}
-}
-
 impl From<isize> for Step {
 	fn from(n: isize) -> Self { Self::Fixed(n) }
 }
 
-impl Step {
-	#[inline]
-	pub fn prev(n: usize) -> Self { Self::Fixed(-(n as isize)) }
+impl FromStr for Step {
+	type Err = ParseIntError;
 
-	#[inline]
-	pub fn next(n: usize) -> Self { Self::Fixed(n as isize) }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s {
+			"top" => Self::Top,
+			"bot" => Self::Bot,
+			s if s.ends_with('%') => Self::Percent(s[..s.len() - 1].parse()?),
+			s => Self::Fixed(s.parse()?),
+		})
+	}
+}
+
+impl TryFrom<&Data> for Step {
+	type Error = ParseIntError;
+
+	fn try_from(value: &Data) -> Result<Self, Self::Error> {
+		Ok(match value {
+			Data::Integer(i) => Self::from(*i as isize),
+			Data::String(s) => s.parse()?,
+			_ => "".parse()?,
+		})
+	}
 }
 
 impl Step {
 	#[inline]
 	pub fn add(self, pos: usize, limit: usize) -> usize {
 		let fixed = match self {
+			Self::Top => return 0,
+			Self::Bot => return usize::MAX,
 			Self::Fixed(n) => n,
 			Self::Percent(0) => 0,
 			Self::Percent(n) => n as isize * limit as isize / 100,
@@ -48,6 +59,7 @@ impl Step {
 	#[inline]
 	pub fn is_positive(self) -> bool {
 		match self {
+			Self::Top | Self::Bot => false,
 			Self::Fixed(n) => n > 0,
 			Self::Percent(n) => n > 0,
 		}


### PR DESCRIPTION
This PR deprecates `arrow -99999999` and `arrow 99999999`, replacing them with `arrow top` and `arrow bot`, respectively. `-99999999` and `99999999` are still available but will trigger a warning.

This change is in preparation for an upcoming navigation wraparound feature — when the cursor reaches the top or bottom of the list, it will automatically jump to the opposite end.  

Some users requested this feature, and I initially [provided a plugin](https://yazi-rs.github.io/docs/tips#navigation-wraparound) as a solution. However, I believe it's worth integrating into the core. 

The issue is that when users enable this feature, pressing `gg` or `G` would cause the cursor to behave erratically since `arrow 99999999` would make it loop through the file list multiple times, so `top` and `bot` (bottom) are introduced.