### PR TITLE
feat: support end of options (`--`) marker for all commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,9 +2191,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2309,12 +2309,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -2697,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3107,9 +3101,9 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
@@ -3587,7 +3581,6 @@ version = "25.2.5"
 dependencies = [
  "anyhow",
  "mlua",
- "shell-words",
  "tokio",
  "yazi-config",
  "yazi-macro",
@@ -3630,7 +3623,6 @@ dependencies = [
  "percent-encoding",
  "ratatui",
  "serde",
- "shell-words",
  "tokio",
  "uzers",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,10 @@ regex               = "1.11.1"
 scopeguard          = "1.2.0"
 serde               = { version = "1.0.217", features = [ "derive" ] }
 serde_json          = "1.0.138"
-shell-words         = "1.1.0"
 tokio               = { version = "1.43.0", features = [ "full" ] }
 tokio-stream        = "0.1.17"
 tokio-util          = "0.7.13"
-toml                = { version = "0.8.19" }
+toml                = { version = "0.8.20" }
 tracing             = { version = "0.1.41", features = [ "max_level_debug", "release_max_level_debug" ] }
 twox-hash           = { version = "2.1.0", default-features = false, features = [ "std", "random", "xxhash3_128" ] }
 unicode-width       = "0.2.0"

--- a/yazi-proxy/Cargo.toml
+++ b/yazi-proxy/Cargo.toml
@@ -20,5 +20,4 @@ yazi-shared = { path = "../yazi-shared", version = "25.2.5" }
 # External dependencies
 anyhow      = { workspace = true }
 mlua        = { workspace = true }
-shell-words = { workspace = true }
 tokio       = { workspace = true }

--- a/yazi-proxy/src/options/plugin.rs
+++ b/yazi-proxy/src/options/plugin.rs
@@ -27,7 +27,7 @@ impl TryFrom<CmdCow> for PluginOpt {
 		};
 
 		let args = if let Some(s) = c.str("args") {
-			Cmd::parse_args(shell_words::split(s)?.into_iter(), true)?
+			Cmd::parse_args(yazi_shared::shell::split_unix(s)?.into_iter(), true)?
 		} else {
 			Default::default()
 		};

--- a/yazi-proxy/src/options/search.rs
+++ b/yazi-proxy/src/options/search.rs
@@ -23,7 +23,7 @@ impl TryFrom<CmdCow> for SearchOpt {
 		Ok(Self {
 			via,
 			subject,
-			args: shell_words::split(c.str("args").unwrap_or_default()).map_err(|_| ())?,
+			args: yazi_shared::shell::split_unix(c.str("args").unwrap_or_default()).map_err(|_| ())?,
 			args_raw: c.take_str("args").unwrap_or_default(),
 		})
 	}

--- a/yazi-shared/Cargo.toml
+++ b/yazi-shared/Cargo.toml
@@ -21,7 +21,6 @@ parking_lot      = { workspace = true }
 percent-encoding = "2.3.1"
 ratatui          = { workspace = true }
 serde            = { workspace = true }
-shell-words      = { workspace = true }
 tokio            = { workspace = true }
 
 [target."cfg(unix)".dependencies]

--- a/yazi-shared/src/event/cmd.rs
+++ b/yazi-shared/src/event/cmd.rs
@@ -165,7 +165,7 @@ impl FromStr for Cmd {
 
 	#[allow(clippy::explicit_counter_loop)]
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let mut args = shell_words::split(s)?;
+		let mut args = crate::shell::split_unix(s)?;
 		if args.is_empty() || args[0].is_empty() {
 			bail!("command name cannot be empty");
 		}

--- a/yazi-shared/src/shell/mod.rs
+++ b/yazi-shared/src/shell/mod.rs
@@ -1,11 +1,14 @@
 //! Escape characters that may have special meaning in a shell, including
-//! spaces. This is a modified version of the [`shell-escape`] crate and [`this
-//! PR`].
+//! spaces. This is a modified version of the [`shell-escape`], [`shell-words`]
+//! and [`this PR`].
 //!
 //! [`shell-escape`]: https://crates.io/crates/shell-escape
+//! [`shell-words`]: https://crates.io/crates/shell-words
 //! [`this PR`]: https://github.com/sfackler/shell-escape/pull/9
 
 use std::{borrow::Cow, ffi::OsStr};
+
+use anyhow::anyhow;
 
 mod unix;
 mod windows;
@@ -41,7 +44,9 @@ pub fn escape_os_str(s: &OsStr) -> Cow<OsStr> {
 }
 
 #[inline]
-pub fn split_unix(s: &str) -> anyhow::Result<Vec<String>> { Ok(shell_words::split(s)?) }
+pub fn split_unix(s: &str) -> anyhow::Result<Vec<String>> {
+	unix::split(s).map_err(|()| anyhow!("missing closing quote"))
+}
 
 #[cfg(windows)]
 pub fn split_windows(s: &str) -> anyhow::Result<Vec<String>> { Ok(windows::split(s)?) }

--- a/yazi-shared/src/shell/mod.rs
+++ b/yazi-shared/src/shell/mod.rs
@@ -8,8 +8,6 @@
 
 use std::{borrow::Cow, ffi::OsStr};
 
-use anyhow::anyhow;
-
 mod unix;
 mod windows;
 
@@ -45,7 +43,7 @@ pub fn escape_os_str(s: &OsStr) -> Cow<OsStr> {
 
 #[inline]
 pub fn split_unix(s: &str) -> anyhow::Result<Vec<String>> {
-	unix::split(s).map_err(|()| anyhow!("missing closing quote"))
+	unix::split(s).map_err(|()| anyhow::anyhow!("missing closing quote"))
 }
 
 #[cfg(windows)]

--- a/yazi-shared/src/shell/unix.rs
+++ b/yazi-shared/src/shell/unix.rs
@@ -227,10 +227,4 @@ mod tests {
 
 		from_bytes(&[0x66, 0x6f, 0x80, 0x6f], &[b'\'', 0x66, 0x6f, 0x80, 0x6f, b'\'']);
 	}
-
-	#[test]
-	fn test_split() {
-		let x = split("plugin --sync fzf -- 'echo {}' --preview").unwrap();
-		println!("{x:?}");
-	}
 }


### PR DESCRIPTION
This PR aims to simplify the usage of `shell` and `plugin` commands. 

The `shell` command accepts a shell script as a parameter that needs to be executed. Previously, if the script contained special characters like spaces, newlines, or quotes, it had to be quoted. 

For example, a simple `echo "hello 'world'"`:

```toml
[[manager.prepend_keymap]]
on  = "<C-e>"
run = '''
  shell --block 'echo "hello '\''world'\''"'
'''
```

This resulted in nested quotes, which was error-prone and not intuitive. 

Now, you can directly include the entire shell script as plain text after `--` without any escaping, like this:

```toml
[[manager.prepend_keymap]]
on  = "<C-e>"
run = '''
  shell --block -- echo "hello 'world'"
'''
```

Similarly, with (TODO), this will also simplify the usage of the `plugin` command, such as:

```toml
[[manager.prepend_keymap]]
on  = "<C-e>"
run = "plugin search --args='\'hello world\''"
```

Now it can be written as:

```toml
[[manager.prepend_keymap]]
on  = "<C-e>"
run = "plugin search -- 'hello world'"
```