### PR TITLE
feat: respect the user's `wrap` setting for the built-in JSON previewer

### DIFF
--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -32,7 +32,10 @@ function M:peek(job)
 		ya.manager_emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
 		lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
-		ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area) })
+		ya.preview_widgets(
+			job,
+			{ ui.Text.parse(lines):area(job.area):wrap(PREVIEW.wrap == "Yes" and ui.Text.WRAP or ui.Text.WRAP_NO) }
+		)
 	end
 end
 


### PR DESCRIPTION
Json previewer doesn't wrap even if user set `  wrap = "yes"` in yazi.toml. This PR fix it.

Before:
![image](https://github.com/user-attachments/assets/d9d72088-aded-4ee3-96d7-a2047e24ebb0)

After:
![image](https://github.com/user-attachments/assets/33fd98ab-6636-498f-993d-0a40e25f1050)