### PR TITLE
feat: add ripgrep-all support for search

### DIFF
--- a/yazi-core/src/tab/commands/search.rs
+++ b/yazi-core/src/tab/commands/search.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, mem, time::Duration};
 
+use anyhow::bail;
 use tokio::pin;
 use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
 use tracing::error;
@@ -67,7 +68,7 @@ impl Tab {
 					subject: opt.subject.into_owned(),
 					args: opt.args,
 				}),
-				SearchOptVia::None => Result::Err(anyhow::anyhow!("Invalid `search` option")),
+				SearchOptVia::None => bail!("Invalid `via` option for `search` command"),
 			}?;
 
 			let rx = UnboundedReceiverStream::new(rx).chunks_timeout(5000, Duration::from_millis(500));

--- a/yazi-core/src/tab/commands/search.rs
+++ b/yazi-core/src/tab/commands/search.rs
@@ -48,8 +48,9 @@ impl Tab {
 		let hidden = self.pref.show_hidden;
 
 		self.search = Some(tokio::spawn(async move {
-			let rx = if opt.via == SearchOptVia::Rg {
+			let rx = if opt.via == SearchOptVia::Rg || opt.via == SearchOptVia::Rga {
 				external::rg(external::RgOpt {
+					rga: SearchOptVia::Rga == opt.via,
 					cwd: cwd.clone(),
 					hidden,
 					subject: opt.subject.into_owned(),

--- a/yazi-plugin/src/external/mod.rs
+++ b/yazi-plugin/src/external/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(fd highlighter rg);
+yazi_macro::mod_flat!(fd highlighter rg rga);

--- a/yazi-plugin/src/external/rg.rs
+++ b/yazi-plugin/src/external/rg.rs
@@ -7,13 +7,15 @@ use yazi_shared::url::Url;
 
 pub struct RgOpt {
 	pub cwd:     Url,
+	pub rga:     bool,
 	pub hidden:  bool,
 	pub subject: String,
 	pub args:    Vec<String>,
 }
 
 pub fn rg(opt: RgOpt) -> Result<UnboundedReceiver<File>> {
-	let mut child = Command::new("rg")
+	let commandname = if opt.rga { "rga" } else { "rg" };
+	let mut child = Command::new(commandname)
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
 		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(opt.args)

--- a/yazi-plugin/src/external/rga.rs
+++ b/yazi-plugin/src/external/rga.rs
@@ -5,15 +5,15 @@ use tokio::{io::{AsyncBufReadExt, BufReader}, process::Command, sync::mpsc::{sel
 use yazi_fs::File;
 use yazi_shared::url::Url;
 
-pub struct RgOpt {
+pub struct RgaOpt {
 	pub cwd:     Url,
 	pub hidden:  bool,
 	pub subject: String,
 	pub args:    Vec<String>,
 }
 
-pub fn rg(opt: RgOpt) -> Result<UnboundedReceiver<File>> {
-	let mut child = Command::new("rg")
+pub fn rga(opt: RgaOpt) -> Result<UnboundedReceiver<File>> {
+	let mut child = Command::new("rga")
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
 		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(opt.args)

--- a/yazi-proxy/src/options/search.rs
+++ b/yazi-proxy/src/options/search.rs
@@ -35,9 +35,9 @@ impl TryFrom<CmdCow> for SearchOpt {
 pub enum SearchOptVia {
 	// TODO: remove `None` in the future
 	None,
-	Rga,
 	Rg,
 	Fd,
+	Rga,
 }
 
 impl From<&str> for SearchOptVia {

--- a/yazi-proxy/src/options/search.rs
+++ b/yazi-proxy/src/options/search.rs
@@ -35,6 +35,7 @@ impl TryFrom<CmdCow> for SearchOpt {
 pub enum SearchOptVia {
 	// TODO: remove `None` in the future
 	None,
+	Rga,
 	Rg,
 	Fd,
 }
@@ -44,6 +45,7 @@ impl From<&str> for SearchOptVia {
 		match value {
 			"rg" => Self::Rg,
 			"fd" => Self::Fd,
+			"rga" => Self::Rga,
 			_ => Self::None,
 		}
 	}
@@ -53,6 +55,7 @@ impl Display for SearchOptVia {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str(match self {
 			Self::Rg => "rg",
+			Self::Rga => "rga",
 			Self::Fd => "fd",
 			Self::None => "none",
 		})

--- a/yazi-proxy/src/options/search.rs
+++ b/yazi-proxy/src/options/search.rs
@@ -55,8 +55,8 @@ impl Display for SearchOptVia {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str(match self {
 			Self::Rg => "rg",
-			Self::Rga => "rga",
 			Self::Fd => "fd",
+			Self::Rga => "rga",
 			Self::None => "none",
 		})
 	}


### PR DESCRIPTION
ripgrep-all supports all options which are currently used for ripgrep. 
In the future, this could get spun out into  external/rga.rs, but as of now it would be a complete copy of rg.rs with even more duplicated code in the search function. 
I do not know if making use of features which ripgrep-all does not have is at all on any roadmap, so I went for the simpler solution. 