### PR TITLE
feat: bump `trash` and `libc` versions to support NetBSD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,9 +1379,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1529,9 +1529,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2798,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "5.2.1"
+version = "5.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e5ca62c20366b4685e3e41fba17bc7c9bbdcb82e65a89d6fda2ceea5fffd2f"
+checksum = "22746c6b0c6d85d60a8f0d858f7057dfdf11297c132679f452ec908fba42b871"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ foldhash            = "0.1.4"
 futures             = "0.3.31"
 globset             = "0.4.15"
 indexmap            = { version = "2.7.1", features = [ "serde" ] }
-libc                = "0.2.169"
+libc                = "0.2.170"
 lru                 = "0.13.0"
 md-5                = "0.10.6"
 mlua                = { version = "0.10.3", features = [ "anyhow", "async", "error-send", "lua54", "macros", "serialize" ] }

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -31,4 +31,4 @@ tracing                = { workspace = true }
 libc = { workspace = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-trash = "5.2.1"
+trash = "5.2.2"


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2387

Closes https://github.com/sxyazi/yazi/issues/2387