### PR TITLE
feat: new `cf.args` to access startup arguments

### DIFF
--- a/yazi-plugin/src/config/config.rs
+++ b/yazi-plugin/src/config/config.rs
@@ -1,7 +1,8 @@
 use mlua::{IntoLua, Lua, LuaSerdeExt, SerializeOptions, Value};
+use yazi_boot::ARGS;
 use yazi_config::{MANAGER, PREVIEW, THEME};
 
-use crate::Composer;
+use crate::{Composer, url::Url};
 
 pub const OPTS: SerializeOptions =
 	SerializeOptions::new().serialize_none_to_null(false).serialize_unit_to_null(false);
@@ -14,9 +15,20 @@ impl<'a> Config<'a> {
 	pub fn compose(lua: &Lua) -> mlua::Result<Value> {
 		Composer::make(lua, 5, |lua, key| {
 			match key {
+				b"args" => Self::args(lua)?,
 				b"manager" => Self::manager(lua)?,
 				b"plugin" => super::Plugin::compose(lua)?,
 				b"preview" => Self::preview(lua)?,
+				_ => return Ok(Value::Nil),
+			}
+			.into_lua(lua)
+		})
+	}
+
+	fn args(lua: &Lua) -> mlua::Result<Value> {
+		Composer::make(lua, 5, |lua, key| {
+			match key {
+				b"chooser_file" => ARGS.chooser_file.as_ref().map(Url::from).into_lua(lua)?,
 				_ => return Ok(Value::Nil),
 			}
 			.into_lua(lua)


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2263

Closes https://github.com/sxyazi/yazi/issues/2263

With this PR, you can get the `--chooser-file` the user passed when starting Yazi and do anything you want:

```lua
if cf.args.chooser_file then
  -- ...
end
```