### PR TITLE
refactor: rename `cf` to `rt`

### DIFF
--- a/yazi-fm/src/app/commands/accept_payload.rs
+++ b/yazi-fm/src/app/commands/accept_payload.rs
@@ -27,11 +27,11 @@ impl App {
 		_ = Lives::scope(&self.cx, || {
 			let body = payload.body.into_lua(&LUA)?;
 			for (id, cb) in handlers {
-				LUA.named_registry_value::<RtRefMut>("rt")?.push(&id);
+				LUA.named_registry_value::<RtRefMut>("ir")?.push(&id);
 				if let Err(e) = cb.call::<()>(body.clone()) {
 					error!("Failed to run `{kind}` event handler in your `{id}` plugin: {e}");
 				}
-				LUA.named_registry_value::<RtRefMut>("rt")?.pop();
+				LUA.named_registry_value::<RtRefMut>("ir")?.pop();
 			}
 			Ok(())
 		});

--- a/yazi-fm/src/app/commands/plugin.rs
+++ b/yazi-fm/src/app/commands/plugin.rs
@@ -55,11 +55,11 @@ impl App {
 			return self.cx.tasks.plugin_micro(opt);
 		}
 
-		match LUA.named_registry_value::<RtRefMut>("rt") {
+		match LUA.named_registry_value::<RtRefMut>("ir") {
 			Ok(mut r) => r.push(&opt.id),
 			Err(e) => return warn!("{e}"),
 		}
-		defer! { _ = LUA.named_registry_value::<RtRefMut>("rt").map(|mut r| r.pop()) }
+		defer! { _ = LUA.named_registry_value::<RtRefMut>("ir").map(|mut r| r.pop()) }
 
 		let plugin = match LOADER.load_with(&LUA, &opt.id, chunk) {
 			Ok(t) => t,

--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -68,7 +68,7 @@ function Entity:found()
 end
 
 function Entity:symlink()
-	if not cf.manager.show_symlink then
+	if not rt.manager.show_symlink then
 		return ""
 	end
 

--- a/yazi-plugin/preset/components/tab.lua
+++ b/yazi-plugin/preset/components/tab.lua
@@ -10,7 +10,7 @@ function Tab:new(area, tab)
 end
 
 function Tab:layout()
-	local ratio = cf.manager.ratio
+	local ratio = rt.manager.ratio
 	self._chunks = ui.Layout()
 		:direction(ui.Layout.HORIZONTAL)
 		:constraints({

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -31,10 +31,10 @@ end
 
 function M:spot_base(job)
 	local url, cha = job.file.url, job.file.cha
-	local spotter = cf.plugin.spotter(url, job.mime)
-	local previewer = cf.plugin.previewer(url, job.mime)
-	local fetchers = cf.plugin.fetchers(job.file, job.mime)
-	local preloaders = cf.plugin.preloaders(url, job.mime)
+	local spotter = rt.plugin.spotter(url, job.mime)
+	local previewer = rt.plugin.previewer(url, job.mime)
+	local fetchers = rt.plugin.fetchers(job.file, job.mime)
+	local preloaders = rt.plugin.preloaders(url, job.mime)
 
 	for i, v in ipairs(fetchers) do
 		fetchers[i] = v.cmd

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -13,7 +13,7 @@ function M:peek(job)
 		return
 	end
 
-	ya.sleep(math.max(0, cf.preview.image_delay / 1000 + start - os.clock()))
+	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 	ya.image_show(cache, job.area)
 	ya.preview_widgets(job, {})
 end

--- a/yazi-plugin/preset/plugins/image.lua
+++ b/yazi-plugin/preset/plugins/image.lua
@@ -6,7 +6,7 @@ function M:peek(job)
 		url = job.file.url
 	end
 
-	ya.sleep(math.max(0, cf.preview.image_delay / 1000 + start - os.clock()))
+	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 	ya.image_show(url, job.area)
 	ya.preview_widgets(job, {})
 end

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -31,9 +31,9 @@ function M:peek(job)
 	if job.skip > 0 and i < job.skip + limit then
 		ya.manager_emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
-		lines = lines:gsub("\t", string.rep(" ", cf.preview.tab_size))
+		lines = lines:gsub("\t", string.rep(" ", rt.preview.tab_size))
 		ya.preview_widgets(job, {
-			ui.Text.parse(lines):area(job.area):wrap(cf.preview.wrap == "yes" and ui.Text.WRAP or ui.Text.WRAP_NO),
+			ui.Text.parse(lines):area(job.area):wrap(rt.preview.wrap == "yes" and ui.Text.WRAP or ui.Text.WRAP_NO),
 		})
 	end
 end

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -11,7 +11,7 @@ function M:peek(job)
 		return
 	end
 
-	ya.sleep(math.max(0, cf.preview.image_delay / 1000 + start - os.clock()))
+	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 	ya.image_show(cache, job.area)
 	ya.preview_widgets(job, {})
 end
@@ -31,9 +31,9 @@ function M:preload(job)
 			tostring(job.file.url),
 			"-flatten",
 			"-resize",
-			string.format("%dx%d^", cf.preview.max_width, cf.preview.max_height),
+			string.format("%dx%d^", rt.preview.max_width, rt.preview.max_height),
 			"-quality",
-			cf.preview.image_quality,
+			rt.preview.image_quality,
 			"-auto-orient",
 			"JPG:" .. tostring(cache),
 		})

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -11,7 +11,7 @@ function M:peek(job)
 		return
 	end
 
-	ya.sleep(math.max(0, cf.preview.image_delay / 1000 + start - os.clock()))
+	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 	ya.image_show(cache, job.area)
 	ya.preview_widgets(job, {})
 end
@@ -36,8 +36,8 @@ function M:preload(job)
 			"-f", job.skip + 1,
 			"-l", job.skip + 1,
 			"-singlefile",
-			"-jpeg", "-jpegopt", "quality=" .. cf.preview.image_quality,
-			"-scale-to-x", cf.preview.max_width, "-scale-to-y", "-1",
+			"-jpeg", "-jpegopt", "quality=" .. rt.preview.image_quality,
+			"-scale-to-x", rt.preview.max_width, "-scale-to-y", "-1",
 			tostring(job.file.url),
 			tostring(cache),
 		})

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -11,7 +11,7 @@ function M:peek(job)
 		return
 	end
 
-	ya.sleep(math.max(0, cf.preview.image_delay / 1000 + start - os.clock()))
+	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 	ya.image_show(cache, job.area)
 	ya.preview_widgets(job, {})
 end
@@ -51,7 +51,7 @@ function M:preload(job)
 	end
 
 	local ss = math.floor(meta.format.duration * percent / 100)
-	local qv = 31 - math.floor(cf.preview.image_quality * 0.3)
+	local qv = 31 - math.floor(rt.preview.image_quality * 0.3)
 	-- stylua: ignore
 	local status, err = Command("ffmpeg"):args({
 		"-v", "quiet", "-threads", 1, "-hwaccel", "auto",
@@ -60,7 +60,7 @@ function M:preload(job)
 		"-i", tostring(job.file.url),
 		"-vframes", 1,
 		"-q:v", qv,
-		"-vf", string.format("scale=-1:'min(%d,ih)':flags=fast_bilinear", cf.preview.max_height),
+		"-vf", string.format("scale=-1:'min(%d,ih)':flags=fast_bilinear", rt.preview.max_height),
 		"-f", "image2",
 		"-y", tostring(cache),
 	}):status()

--- a/yazi-plugin/src/config/mod.rs
+++ b/yazi-plugin/src/config/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(config plugin theme);
+yazi_macro::mod_flat!(plugin runtime theme);

--- a/yazi-plugin/src/config/runtime.rs
+++ b/yazi-plugin/src/config/runtime.rs
@@ -7,11 +7,11 @@ use crate::{Composer, url::Url};
 pub const OPTS: SerializeOptions =
 	SerializeOptions::new().serialize_none_to_null(false).serialize_unit_to_null(false);
 
-pub struct Config<'a> {
+pub struct Runtime<'a> {
 	lua: &'a Lua,
 }
 
-impl<'a> Config<'a> {
+impl<'a> Runtime<'a> {
 	pub fn compose(lua: &Lua) -> mlua::Result<Value> {
 		Composer::make(lua, 5, |lua, key| {
 			match key {

--- a/yazi-plugin/src/isolate/isolate.rs
+++ b/yazi-plugin/src/isolate/isolate.rs
@@ -5,15 +5,15 @@ use crate::runtime::Runtime;
 
 pub fn slim_lua(name: &str) -> mlua::Result<Lua> {
 	let lua = Lua::new();
-	lua.set_named_registry_value("rt", Runtime::new(name))?;
-	crate::config::Config::new(&lua).install_preview()?;
+	lua.set_named_registry_value("ir", Runtime::new(name))?;
+	crate::config::Runtime::new(&lua).install_preview()?;
 
 	// Base
 	let globals = lua.globals();
 	globals.raw_set("ui", crate::elements::compose(&lua)?)?;
 	globals.raw_set("ya", crate::utils::compose(&lua, true)?)?;
 	globals.raw_set("fs", crate::fs::compose(&lua)?)?;
-	globals.raw_set("cf", crate::config::Config::compose(&lua)?)?;
+	globals.raw_set("rt", crate::config::Runtime::compose(&lua)?)?;
 	globals.raw_set("th", crate::config::Theme::compose(&lua)?)?;
 
 	crate::bindings::Cha::install(&lua)?;

--- a/yazi-plugin/src/loader/require.rs
+++ b/yazi-plugin/src/loader/require.rs
@@ -15,9 +15,9 @@ impl Require {
 				let s = &id.to_str()?;
 				futures::executor::block_on(LOADER.ensure(s)).into_lua_err()?;
 
-				lua.named_registry_value::<RtRefMut>("rt")?.push(s);
+				lua.named_registry_value::<RtRefMut>("ir")?.push(s);
 				let mod_ = LOADER.load(lua, s);
-				lua.named_registry_value::<RtRefMut>("rt")?.pop();
+				lua.named_registry_value::<RtRefMut>("ir")?.pop();
 
 				Self::create_mt(lua, s, mod_?, true)
 			})?,
@@ -31,9 +31,9 @@ impl Require {
 				let s = &id.to_str()?;
 				LOADER.ensure(s).await.into_lua_err()?;
 
-				lua.named_registry_value::<RtRefMut>("rt")?.push(s);
+				lua.named_registry_value::<RtRefMut>("ir")?.push(s);
 				let mod_ = LOADER.load(&lua, s);
-				lua.named_registry_value::<RtRefMut>("rt")?.pop();
+				lua.named_registry_value::<RtRefMut>("ir")?.pop();
 
 				Self::create_mt(&lua, s, mod_?, false)
 			})?,
@@ -73,9 +73,9 @@ impl Require {
 		if sync {
 			lua.create_function(move |lua, args: MultiValue| {
 				let (mod_, args) = Self::split_mod_and_args(lua, &id, args)?;
-				lua.named_registry_value::<RtRefMut>("rt")?.push(&id);
+				lua.named_registry_value::<RtRefMut>("ir")?.push(&id);
 				let result = mod_.call_function::<MultiValue>(&f, args);
-				lua.named_registry_value::<RtRefMut>("rt")?.pop();
+				lua.named_registry_value::<RtRefMut>("ir")?.pop();
 				result
 			})
 		} else {
@@ -83,9 +83,9 @@ impl Require {
 				let (id, f) = (id.clone(), f.clone());
 				async move {
 					let (mod_, args) = Self::split_mod_and_args(&lua, &id, args)?;
-					lua.named_registry_value::<RtRefMut>("rt")?.push(&id);
+					lua.named_registry_value::<RtRefMut>("ir")?.push(&id);
 					let result = mod_.call_async_function::<MultiValue>(&f, args).await;
-					lua.named_registry_value::<RtRefMut>("rt")?.pop();
+					lua.named_registry_value::<RtRefMut>("ir")?.pop();
 					result
 				}
 			})

--- a/yazi-plugin/src/lua.rs
+++ b/yazi-plugin/src/lua.rs
@@ -17,8 +17,8 @@ pub(super) fn init_lua() -> Result<()> {
 }
 
 fn stage_1(lua: &'static Lua) -> Result<()> {
-	lua.set_named_registry_value("rt", Runtime::default())?;
-	crate::config::Config::new(lua).install_manager()?.install_theme()?;
+	lua.set_named_registry_value("ir", Runtime::default())?;
+	crate::config::Runtime::new(lua).install_manager()?.install_theme()?;
 
 	// Base
 	let globals = lua.globals();
@@ -26,7 +26,7 @@ fn stage_1(lua: &'static Lua) -> Result<()> {
 	globals.raw_set("ya", crate::utils::compose(lua, false)?)?;
 	globals.raw_set("fs", crate::fs::compose(lua)?)?;
 	globals.raw_set("ps", crate::pubsub::compose(lua)?)?;
-	globals.raw_set("cf", crate::config::Config::compose(lua)?)?;
+	globals.raw_set("rt", crate::config::Runtime::compose(lua)?)?;
 	globals.raw_set("th", crate::config::Theme::compose(lua)?)?;
 
 	crate::Error::install(lua)?;

--- a/yazi-plugin/src/macros.rs
+++ b/yazi-plugin/src/macros.rs
@@ -124,7 +124,7 @@ macro_rules! impl_file_methods {
 #[macro_export]
 macro_rules! deprecate {
 	($lua:ident, $tt:tt) => {{
-		let id = match $lua.named_registry_value::<$crate::RtRef>("rt")?.current() {
+		let id = match $lua.named_registry_value::<$crate::RtRef>("ir")?.current() {
 			Some(id) => &format!("`{id}.yazi` plugin"),
 			None => "`init.lua` config",
 		};

--- a/yazi-plugin/src/pubsub/pubsub.rs
+++ b/yazi-plugin/src/pubsub/pubsub.rs
@@ -22,7 +22,7 @@ impl Pubsub {
 
 	pub(super) fn sub(lua: &Lua) -> mlua::Result<Function> {
 		lua.create_function(|lua, (kind, f): (mlua::String, Function)| {
-			let rt = lua.named_registry_value::<RtRef>("rt")?;
+			let rt = lua.named_registry_value::<RtRef>("ir")?;
 			let Some(cur) = rt.current() else {
 				return Err("`sub()` must be called in a sync plugin").into_lua_err();
 			};
@@ -35,7 +35,7 @@ impl Pubsub {
 
 	pub(super) fn sub_remote(lua: &Lua) -> mlua::Result<Function> {
 		lua.create_function(|lua, (kind, f): (mlua::String, Function)| {
-			let rt = lua.named_registry_value::<RtRef>("rt")?;
+			let rt = lua.named_registry_value::<RtRef>("ir")?;
 			let Some(cur) = rt.current() else {
 				return Err("`sub_remote()` must be called in a sync plugin").into_lua_err();
 			};
@@ -48,7 +48,7 @@ impl Pubsub {
 
 	pub(super) fn unsub(lua: &Lua) -> mlua::Result<Function> {
 		lua.create_function(|lua, kind: mlua::String| {
-			if let Some(cur) = lua.named_registry_value::<RtRef>("rt")?.current() {
+			if let Some(cur) = lua.named_registry_value::<RtRef>("ir")?.current() {
 				Ok(yazi_dds::Pubsub::unsub(cur, &kind.to_str()?))
 			} else {
 				Err("`unsub()` must be called in a sync plugin").into_lua_err()
@@ -58,7 +58,7 @@ impl Pubsub {
 
 	pub(super) fn unsub_remote(lua: &Lua) -> mlua::Result<Function> {
 		lua.create_function(|lua, kind: mlua::String| {
-			if let Some(cur) = lua.named_registry_value::<RtRef>("rt")?.current() {
+			if let Some(cur) = lua.named_registry_value::<RtRef>("ir")?.current() {
 				Ok(yazi_dds::Pubsub::unsub_remote(cur, &kind.to_str()?))
 			} else {
 				Err("`unsub_remote()` must be called in a sync plugin").into_lua_err()

--- a/yazi-plugin/src/utils/sync.rs
+++ b/yazi-plugin/src/utils/sync.rs
@@ -12,12 +12,12 @@ impl Utils {
 	pub(super) fn sync(lua: &Lua, isolate: bool) -> mlua::Result<Function> {
 		if isolate {
 			lua.create_function(|lua, ()| {
-				let Some(block) = lua.named_registry_value::<RtRefMut>("rt")?.next_block() else {
+				let Some(block) = lua.named_registry_value::<RtRefMut>("ir")?.next_block() else {
 					return Err("`ya.sync()` must be called in a plugin").into_lua_err();
 				};
 
 				lua.create_async_function(move |lua, args: MultiValue| async move {
-					let Some(cur) = lua.named_registry_value::<RtRef>("rt")?.current_owned() else {
+					let Some(cur) = lua.named_registry_value::<RtRef>("ir")?.current_owned() else {
 						return Err("block spawned by `ya.sync()` must be called in a plugin").into_lua_err();
 					};
 					Sendable::list_to_values(&lua, Self::retrieve(cur, block, args).await?)
@@ -25,7 +25,7 @@ impl Utils {
 			})
 		} else {
 			lua.create_function(|lua, f: Function| {
-				let mut rt = lua.named_registry_value::<RtRefMut>("rt")?;
+				let mut rt = lua.named_registry_value::<RtRefMut>("ir")?;
 				if !rt.put_block(f.clone()) {
 					return Err("`ya.sync()` must be called in a plugin").into_lua_err();
 				}
@@ -84,7 +84,7 @@ impl Utils {
 		let callback: PluginCallback = {
 			let id_ = id.clone();
 			Box::new(move |lua, plugin| {
-				let Some(block) = lua.named_registry_value::<RtRef>("rt")?.get_block(&id_, calls) else {
+				let Some(block) = lua.named_registry_value::<RtRef>("ir")?.get_block(&id_, calls) else {
 					return Err("sync block not found".into_lua_err());
 				};
 


### PR DESCRIPTION
`cf` was introduced in https://github.com/sxyazi/yazi/pull/2389, and this PR renames it to `rt`. 

`cf` was introduced yesterday (Feb 23, 2025), and it was not included in any releases, so it should not break anything.