### PR TITLE
fix: align the behavior of the end-of-options marker (`--`) with that of the shell

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -133,7 +133,10 @@ macro_rules! impl_emit_body {
 		impl $name {
 			#[allow(dead_code)]
 			pub(super) fn body(self) -> Result<String> {
-				Ok(serde_json::to_string(&(self.name, Cmd::parse_args(self.args.into_iter(), false)?))?)
+				Ok(serde_json::to_string(&(
+					self.name,
+					Cmd::parse_args(self.args.into_iter(), None, false)?,
+				))?)
 			}
 		}
 	};

--- a/yazi-core/src/tab/commands/search.rs
+++ b/yazi-core/src/tab/commands/search.rs
@@ -37,7 +37,7 @@ impl Tab {
 	}
 
 	pub fn search_do(&mut self, opt: impl TryInto<SearchOpt>) {
-		let Ok(opt) = opt.try_into() else {
+		let Ok(opt): Result<SearchOpt, _> = opt.try_into() else {
 			return error!("Failed to parse search option for `search_do`");
 		};
 

--- a/yazi-proxy/src/options/plugin.rs
+++ b/yazi-proxy/src/options/plugin.rs
@@ -27,16 +27,8 @@ impl TryFrom<CmdCow> for PluginOpt {
 		};
 
 		let args = if let Some(s) = c.second_str() {
-			Cmd::parse_args(yazi_shared::shell::split_unix(s)?.into_iter(), true)?
-		} else if let Some(s) = c.str("args") {
-			crate::deprecate!(
-				format!("The `args` parameter of the `plugin` command has been deprecated. Please use the second positional argument of `plugin` instead.
-
-For example, replace `plugin test --args=foobar` with `plugin test foobar`, for your `plugin {}` command.
-
-See #2299 for more information: https://github.com/sxyazi/yazi/pull/2299", id)
-			);
-			Cmd::parse_args(yazi_shared::shell::split_unix(s)?.into_iter(), true)?
+			let (words, last) = yazi_shared::shell::split_unix(s, true)?;
+			Cmd::parse_args(words.into_iter(), last, true)?
 		} else {
 			Default::default()
 		};

--- a/yazi-proxy/src/options/search.rs
+++ b/yazi-proxy/src/options/search.rs
@@ -24,7 +24,9 @@ impl TryFrom<CmdCow> for SearchOpt {
 			via,
 			subject,
 			// TODO: use second positional argument instead of `args` parameter
-			args: yazi_shared::shell::split_unix(c.str("args").unwrap_or_default()).map_err(|_| ())?,
+			args: yazi_shared::shell::split_unix(c.str("args").unwrap_or_default(), false)
+				.map_err(|_| ())?
+				.0,
 			args_raw: c.take_str("args").unwrap_or_default(),
 		})
 	}

--- a/yazi-shared/src/shell/mod.rs
+++ b/yazi-shared/src/shell/mod.rs
@@ -42,8 +42,8 @@ pub fn escape_os_str(s: &OsStr) -> Cow<OsStr> {
 }
 
 #[inline]
-pub fn split_unix(s: &str) -> anyhow::Result<Vec<String>> {
-	unix::split(s).map_err(|()| anyhow::anyhow!("missing closing quote"))
+pub fn split_unix(s: &str, eoo: bool) -> anyhow::Result<(Vec<String>, Option<String>)> {
+	unix::split(s, eoo).map_err(|()| anyhow::anyhow!("missing closing quote"))
 }
 
 #[cfg(windows)]
@@ -52,7 +52,7 @@ pub fn split_windows(s: &str) -> anyhow::Result<Vec<String>> { Ok(windows::split
 pub fn split_native(s: &str) -> anyhow::Result<Vec<String>> {
 	#[cfg(unix)]
 	{
-		split_unix(s)
+		Ok(split_unix(s, false)?.0)
 	}
 	#[cfg(windows)]
 	{

--- a/yazi-shared/src/shell/unix.rs
+++ b/yazi-shared/src/shell/unix.rs
@@ -46,7 +46,7 @@ fn allowed(b: u8) -> bool {
 	matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'=' | b'/' | b',' | b'.' | b'+')
 }
 
-pub fn split(s: &str) -> Result<Vec<String>, ()> {
+pub fn split(s: &str, eoo: bool) -> Result<(Vec<String>, Option<String>), ()> {
 	enum State {
 		/// Within a delimiter.
 		Delimiter,
@@ -74,9 +74,8 @@ pub fn split(s: &str) -> Result<Vec<String>, ()> {
 
 	macro_rules! flush {
 		() => {
-			if word == "--" {
-				words.push(chars.collect());
-				break;
+			if word == "--" && eoo {
+				return Ok((words, Some(chars.collect())));
 			}
 			words.push(mem::take(&mut word));
 		};
@@ -176,7 +175,7 @@ pub fn split(s: &str) -> Result<Vec<String>, ()> {
 		}
 	}
 
-	Ok(words)
+	Ok((words, None))
 }
 
 #[cfg(test)]


### PR DESCRIPTION

Fixes https://github.com/sxyazi/yazi/issues/2429