### PR TITLE
ci: add snap publishing workflow

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -187,6 +187,14 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Push snap to latest/candidate channel
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: |
+          for x in *.snap; do
+            snapcraft push -v --release latest/candidate $x
+          done
+
       - name: Draft
         uses: softprops/action-gh-release@v1
         with:
@@ -220,6 +228,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag --force nightly && git push --force origin tag nightly
+
+      - name: Push snap to latest/edge channel
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: |
+          for x in *.snap; do
+            snapcraft push -v --release latest/edge $x
+          done
 
       - name: Nightly
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -187,14 +187,6 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Push snap to latest/candidate channel
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
-        run: |
-          for x in *.snap; do
-            snapcraft push -v --release latest/candidate $x
-          done
-
       - name: Draft
         uses: softprops/action-gh-release@v1
         with:
@@ -203,6 +195,12 @@ jobs:
             yazi-*.zip
             yazi-*.snap
           generate_release_notes: true
+
+      - name: Push snap to candidate channel
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: |
+          parallel 'snapcraft push -v --release latest/candidate {}' ::: *.snap
 
   nightly:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -229,14 +227,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag --force nightly && git push --force origin tag nightly
 
-      - name: Push snap to latest/edge channel
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
-        run: |
-          for x in *.snap; do
-            snapcraft push -v --release latest/edge $x
-          done
-
       - name: Nightly
         uses: softprops/action-gh-release@v1
         with:
@@ -248,3 +238,9 @@ jobs:
           name: Nightly Build
           body: ${{ env.NIGHTLY_BODY }}
           target_commitish: ${{ github.sha }}
+
+      - name: Push snap to edge channel
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: |
+          parallel 'snapcraft push -v --release latest/edge {}' ::: *.snap

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,3 +18,8 @@ jobs:
           identifier: sxyazi.yazi
           installers-regex: 'yazi-(x86_64|aarch64)-pc-windows-msvc\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
+
+      - name: Promote snap to latest/stable
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+        run: snapcraft promote yazi --from-channel latest/candidate --to-channel latest/stable --yes


### PR DESCRIPTION
This commit adds snap publishing and promotion to the CI process.

For nightly releases, upload the built snaps to the 'latest/edge' channel, enabling users to track nightly builds with:

```bash
snap install yazi --classic --channel latest/edge
```

For draft releases, upload the built snaps to the 'latest/candidate' channel.

And finally, when a release is published, promote the snaps that are in the 'latest/candidate' channel to 'latest/stable'.

Before this is published, a secret named `SNAPCRAFT_TOKEN` needs to be set, which you can generate with something like this:

```bash
snapcraft export-login credentials.txt \
  --snaps="yazi" \
  --acls package_access,package_push,package_update,package_release \
  --channels "latest/stable,latest/candidate,latest/beta,latest/edge" \
  --expires "2099-12-31"
```