### PR TITLE
fix: always show the size in the status bar even in empty directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Yazi (means "duck") is a terminal file manager written in Rust, based on non-blo
 - 🌟 **Built-in Code Highlighting and Image Decoding**: Combined with the pre-loading mechanism, greatly accelerates image and normal file loading.
 - 🔌 **Concurrent Plugin System**: UI plugins (rewriting most of the UI), functional plugins, custom previewer/preloader/spotter/fetcher; Just some pieces of Lua.
 - 📡 **Data Distribution Service**: Built on a client-server architecture (no additional server process required), integrated with a Lua-based publish-subscribe model, achieving cross-instance communication and state persistence.
-- 📦 **Package Manager**: Install plugins and themes with one command, keeping them up to date, or pin them to a specific version.
+- 📦 **Package Manager**: Install plugins and themes with one command, keeping them up-to-date, or pin them to a specific version.
 - 🧰 Integration with ripgrep, fd, fzf, zoxide
 - 💫 Vim-like input/pick/confirm/which/notify component, auto-completion for cd paths
 - 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, code, directories, etc.)

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -48,13 +48,11 @@ end
 
 function Status:size()
 	local h = self._current.hovered
-	if not h then
-		return ""
-	end
+	local size = h and (h:size() or h.cha.len) or 0
 
 	local style = self:style()
 	return ui.Line {
-		ui.Span(" " .. ya.readable_size(h:size() or h.cha.len) .. " "):style(style.alt),
+		ui.Span(" " .. ya.readable_size(size) .. " "):style(style.alt),
 		ui.Span(th.status.sep_left.close):fg(style.alt.bg),
 	}
 end


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2448

Now, for empty directories, it will show "0B". I think that makes sense since an empty directory doesn't have any files with a zero size