### PR TITLE
perf: lazy compile and cache lua plugins as binary bytecode

### DIFF
--- a/scripts/validate-form/main.js
+++ b/scripts/validate-form/main.js
@@ -4,7 +4,7 @@ const RE_DEPENDENCIES = /Dependencies\s+[/a-z]+\s*:\s/gm
 const RE_CHECKLIST = /#{3}\s+Checklist\s+(?:^-\s+\[x]\s+.+?(?:\n|\r\n|$)){2}/gm
 
 function bugReportBody(creator, content, hash) {
-	if (RE_CHECKLIST.test(content) && new RegExp(` \\(${hash}[a-z]? `).test(content)) {
+	if (RE_DEPENDENCIES.test(content) && RE_CHECKLIST.test(content) && new RegExp(` \\(${hash}[a-z]? `).test(content)) {
 		return null
 	}
 

--- a/yazi-fm/src/logs.rs
+++ b/yazi-fm/src/logs.rs
@@ -14,7 +14,7 @@ pub(super) struct Logs;
 impl Logs {
 	pub(super) fn start() -> anyhow::Result<()> {
 		let level = LOG_LEVEL.get();
-		if LOG_LEVEL.get().is_none() {
+		if level.is_none() {
 			return Ok(());
 		}
 

--- a/yazi-plugin/src/isolate/entry.rs
+++ b/yazi-plugin/src/isolate/entry.rs
@@ -1,4 +1,4 @@
-use mlua::{ExternalError, ExternalResult, ObjectLike, Table};
+use mlua::{ExternalResult, ObjectLike};
 use tokio::runtime::Handle;
 use yazi_dds::Sendable;
 use yazi_proxy::options::PluginOpt;
@@ -11,14 +11,9 @@ pub async fn entry(opt: PluginOpt) -> mlua::Result<()> {
 
 	tokio::task::spawn_blocking(move || {
 		let lua = slim_lua(&opt.id)?;
-		let plugin: Table = if let Some(c) = LOADER.read().get(opt.id.as_ref()) {
-			lua.load(c.as_bytes()).set_name(opt.id.as_ref()).call(())?
-		} else {
-			return Err("unloaded plugin".into_lua_err());
-		};
+		let plugin = LOADER.load_once(&lua, &opt.id)?;
 
 		let job = lua.create_table_from([("args", Sendable::args_to_table(&lua, opt.args)?)])?;
-
 		Handle::current().block_on(plugin.call_async_method("entry", job))
 	})
 	.await

--- a/yazi-plugin/src/isolate/peek.rs
+++ b/yazi-plugin/src/isolate/peek.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use mlua::{ExternalError, HookTriggers, IntoLua, ObjectLike, Table, VmState};
+use mlua::{ExternalError, HookTriggers, IntoLua, ObjectLike, VmState};
 use tokio::{runtime::Handle, select};
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -84,12 +84,7 @@ fn peek_async(
 				},
 			);
 
-			let plugin: Table = if let Some(c) = LOADER.read().get(&cmd.name) {
-				lua.load(c.as_bytes()).set_name(&cmd.name).call(())?
-			} else {
-				return Err("unloaded plugin".into_lua_err());
-			};
-
+			let plugin = LOADER.load_once(&lua, &cmd.name)?;
 			let job = lua.create_table_from([
 				("area", Rect::from(LAYOUT.get().preview).into_lua(&lua)?),
 				("args", Sendable::args_to_table_ref(&lua, &cmd.args)?.into_lua(&lua)?),

--- a/yazi-plugin/src/isolate/preload.rs
+++ b/yazi-plugin/src/isolate/preload.rs
@@ -1,4 +1,4 @@
-use mlua::{ExternalError, ExternalResult, IntoLua, ObjectLike, Table};
+use mlua::{ExternalResult, IntoLua, ObjectLike};
 use tokio::runtime::Handle;
 use yazi_config::LAYOUT;
 use yazi_dds::Sendable;
@@ -15,11 +15,7 @@ pub async fn preload(
 
 	tokio::task::spawn_blocking(move || {
 		let lua = slim_lua(&cmd.name)?;
-		let plugin: Table = if let Some(b) = LOADER.read().get(&cmd.name) {
-			lua.load(b.as_bytes()).set_name(&cmd.name).call(())?
-		} else {
-			return Err("unloaded plugin".into_lua_err());
-		};
+		let plugin = LOADER.load_once(&lua, &cmd.name)?;
 
 		let job = lua.create_table_from([
 			("area", Rect::from(LAYOUT.get().preview).into_lua(&lua)?),

--- a/yazi-plugin/src/isolate/spot.rs
+++ b/yazi-plugin/src/isolate/spot.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use mlua::{ExternalError, ExternalResult, HookTriggers, IntoLua, ObjectLike, Table, VmState};
+use mlua::{ExternalError, ExternalResult, HookTriggers, IntoLua, ObjectLike, VmState};
 use tokio::{runtime::Handle, select};
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -35,18 +35,14 @@ pub fn spot(
 				},
 			);
 
-			let plugin: Table = if let Some(b) = LOADER.read().get(&cmd.name) {
-				lua.load(b.as_bytes()).set_name(&cmd.name).call(())?
-			} else {
-				return Err("unloaded plugin".into_lua_err());
-			};
-
+			let plugin = LOADER.load_once(&lua, &cmd.name)?;
 			let job = lua.create_table_from([
 				("args", Sendable::args_to_table_ref(&lua, &cmd.args)?.into_lua(&lua)?),
 				("file", File(file).into_lua(&lua)?),
 				("mime", mime.into_lua(&lua)?),
 				("skip", skip.into_lua(&lua)?),
 			])?;
+
 			if ct2.is_cancelled() { Ok(()) } else { plugin.call_async_method("spot", job).await }
 		};
 

--- a/yazi-plugin/src/loader/chunk.rs
+++ b/yazi-plugin/src/loader/chunk.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
 
+use mlua::{AsChunk, ChunkMode};
 use yazi_shared::natsort;
 
 pub struct Chunk {
+	pub mode:       ChunkMode,
 	pub bytes:      Cow<'static, [u8]>,
 	pub since:      String,
 	pub sync_peek:  bool,
@@ -10,9 +12,6 @@ pub struct Chunk {
 }
 
 impl Chunk {
-	#[inline]
-	pub fn as_bytes(&self) -> &[u8] { &self.bytes }
-
 	#[inline]
 	pub fn compatible(&self) -> bool {
 		let s = yazi_boot::actions::Actions::version();
@@ -46,8 +45,13 @@ impl Chunk {
 
 impl From<Cow<'static, [u8]>> for Chunk {
 	fn from(b: Cow<'static, [u8]>) -> Self {
-		let mut chunk =
-			Self { bytes: b, since: String::new(), sync_entry: false, sync_peek: false };
+		let mut chunk = Self {
+			mode:       ChunkMode::Text,
+			bytes:      b,
+			since:      String::new(),
+			sync_entry: false,
+			sync_peek:  false,
+		};
 		chunk.analyze();
 		chunk
 	}
@@ -59,4 +63,10 @@ impl From<&'static [u8]> for Chunk {
 
 impl From<Vec<u8>> for Chunk {
 	fn from(b: Vec<u8>) -> Self { Self::from(Cow::Owned(b)) }
+}
+
+impl<'a> AsChunk<'a> for &'a Chunk {
+	fn source(self) -> std::io::Result<Cow<'a, [u8]>> { Ok(Cow::Borrowed(&self.bytes)) }
+
+	fn mode(&self) -> Option<ChunkMode> { Some(self.mode) }
 }


### PR DESCRIPTION
This PR aims to improve the loading performance of Lua plugins. 

After this PR, all plugins (preset and custom) will be lazily compiled and cached as a binary bytecode representation upon first use, and will subsequently be loaded directly from the binary cache rather than being recompiled from the textual source code, thereby improving the overall performance of the plugin system.