### PR TITLE
feat: allow bulk renaming to include trailing content in addition to the required new names

### DIFF
--- a/yazi-core/src/mgr/commands/bulk_rename.rs
+++ b/yazi-core/src/mgr/commands/bulk_rename.rs
@@ -26,12 +26,16 @@ impl Mgr {
 		tokio::spawn(async move {
 			let tmp = YAZI.preview.tmpfile("bulk");
 			let s = old.iter().map(|o| o.as_os_str()).collect::<Vec<_>>().join(OsStr::new("\n"));
+			const DIVIDER: &str = "\n<↑ After ↑> <↓ Before ↓>\n";
+
+			let content = [&s, OsStr::new(&format!("{}", DIVIDER)), &s].join(OsStr::new(""));
+
 			OpenOptions::new()
 				.write(true)
 				.create_new(true)
 				.open(&tmp)
 				.await?
-				.write_all(s.as_encoded_bytes())
+				.write_all(content.as_encoded_bytes())
 				.await?;
 
 			defer! { tokio::spawn(fs::remove_file(tmp.clone())); }
@@ -45,7 +49,10 @@ impl Mgr {
 			defer!(AppProxy::resume());
 			AppProxy::stop().await;
 
-			let new: Vec<_> = fs::read_to_string(&tmp).await?.lines().map(PathBuf::from).collect();
+			let content = fs::read_to_string(&tmp).await?;
+
+			let new: Vec<_> =
+				content.split(DIVIDER).next().unwrap_or("").lines().map(PathBuf::from).collect();
 			Self::bulk_rename_do(root, old, new).await
 		});
 	}

--- a/yazi-core/src/mgr/commands/bulk_rename.rs
+++ b/yazi-core/src/mgr/commands/bulk_rename.rs
@@ -52,11 +52,13 @@ impl Mgr {
 
 	async fn bulk_rename_do(root: PathBuf, old: Vec<PathBuf>, new: Vec<PathBuf>) -> Result<()> {
 		terminal_clear(TTY.writer())?;
-		if old.len() != new.len() {
-			TTY.writer().write_all(b"Number of old and new differ, press ENTER to exit")?;
+		if old.len() > new.len() {
+			TTY.writer().write_all(b"Number of old is greater than new, press ENTER to exit")?;
 			TTY.reader().read_exact(&mut [0])?;
 			return Ok(());
 		}
+
+		let new = if new.len() > old.len() { new.into_iter().take(old.len()).collect() } else { new };
 
 		let (old, new) = old.into_iter().zip(new).filter(|(o, n)| o != n).unzip();
 		let todo = Self::prioritized_paths(old, new);


### PR DESCRIPTION
When handling numerous filenames, it's better to give indication to original filenames. I've added the original filenames below, separated by a divider, without changing the code related to renaming.