### PR TITLE
feat: allow repositioning the cursor in the `rename` DDS event

### DIFF
--- a/yazi-core/src/mgr/commands/rename.rs
+++ b/yazi-core/src/mgr/commands/rename.rs
@@ -84,7 +84,6 @@ impl Mgr {
 			ok_or_not_found(fs::rename(p_new.join(&o), &new).await)?;
 			FilesOp::Deleting(p_new.clone(), HashSet::from_iter([UrnBuf::from(o)])).emit();
 		}
-		Pubsub::pub_from_rename(tab, &old, &new);
 
 		let file = File::from(new.clone()).await?;
 		if p_new == p_old {
@@ -94,7 +93,9 @@ impl Mgr {
 			FilesOp::Upserting(p_new, HashMap::from_iter([(n_new, file)])).emit();
 		}
 
-		Ok(TabProxy::reveal(&new))
+		TabProxy::reveal(&new);
+		Pubsub::pub_from_rename(tab, &old, &new);
+		Ok(())
 	}
 
 	fn empty_url_part(url: &Url, by: &str) -> String {


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2520

Closes https://github.com/sxyazi/yazi/issues/2520

---

Now you will be able to have something like this to place the cursor on the next file after renaming:

```lua
return {
  setup = function()
    ps.sub("rename", function()
      ya.mgr_emit("arrow", { "next" })
    end)
  end,
}
```

DDS docs: https://yazi-rs.github.io/docs/dds