### PR TITLE
feat: new `symlink_target` to style the target of symbolic links

### DIFF
--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -29,6 +29,9 @@ preview_hovered = { underline = true }
 find_keyword  = { fg = "yellow", bold = true, italic = true, underline = true }
 find_position = { fg = "magenta", bg = "reset", bold = true, italic = true }
 
+# Symlink
+symlink_target = { italic = true }
+
 # Marker
 marker_copied   = { fg = "lightgreen",  bg = "lightgreen" }
 marker_cut      = { fg = "lightred",    bg = "lightred" }

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -29,6 +29,9 @@ preview_hovered = { underline = true }
 find_keyword  = { fg = "yellow", bold = true, italic = true, underline = true }
 find_position = { fg = "magenta", bg = "reset", bold = true, italic = true }
 
+# Symlink
+symlink_target = { italic = true }
+
 # Marker
 marker_copied   = { fg = "lightgreen",  bg = "lightgreen" }
 marker_cut      = { fg = "lightred",    bg = "lightred" }

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -44,6 +44,9 @@ pub struct Mgr {
 	find_keyword:  Style,
 	find_position: Style,
 
+	// Symlink
+	symlink_target: Style,
+
 	// Marker
 	marker_copied:   Style,
 	marker_cut:      Style,

--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -73,7 +73,7 @@ function Entity:symlink()
 	end
 
 	local to = self._file.link_to
-	return to and ui.Span(string.format(" -> %s", to)):italic() or ""
+	return to and ui.Span(string.format(" -> %s", to)):style(th.mgr.symlink_target) or ""
 end
 
 function Entity:redraw()


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2516

Closes https://github.com/sxyazi/yazi/issues/2516