### PR TITLE
refactor!: remove unnecessary `tasks_show` and `close_input` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -1036,9 +1036,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
-version = "0.25.5"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1711,9 +1711,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
 dependencies = [
  "base64",
  "indexmap",

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -19,7 +19,7 @@ anyhow      = { workspace = true }
 base64      = { workspace = true }
 color_quant = "1.1.0"
 crossterm   = { workspace = true }
-image       = { version = "0.25.5", default-features = false, features = [ "avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "webp" ] }
+image       = { version = "0.25.6", default-features = false, features = [ "avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "webp" ] }
 ratatui     = { workspace = true }
 scopeguard  = { workspace = true }
 tokio       = { workspace = true }

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -149,7 +149,7 @@ keymap = [
 	{ on = "}", run = "tab_swap 1",  desc = "Swap current tab with next tab" },
 
 	# Tasks
-	{ on = "w", run = "tasks_show", desc = "Show task manager" },
+	{ on = "w", run = "tasks:show", desc = "Show task manager" },
 
 	# Help
 	{ on = "~",    run = "help", desc = "Open help" },
@@ -330,7 +330,7 @@ keymap = [
 keymap = [
 	{ on = "<C-c>",   run = "close",                                      desc = "Cancel completion" },
 	{ on = "<Tab>",   run = "close --submit",                             desc = "Submit the completion" },
-	{ on = "<Enter>", run = [ "close --submit", "close_input --submit" ], desc = "Submit the completion and input" },
+	{ on = "<Enter>", run = [ "close --submit", "input:close --submit" ], desc = "Complete and submit the input" },
 
 	{ on = "<A-k>", run = "arrow -1", desc = "Move cursor up" },
 	{ on = "<A-j>", run = "arrow 1",  desc = "Move cursor down" },

--- a/yazi-core/src/tasks/commands/close.rs
+++ b/yazi-core/src/tasks/commands/close.rs
@@ -1,0 +1,28 @@
+use yazi_macro::render;
+use yazi_shared::event::CmdCow;
+
+use crate::tasks::Tasks;
+
+struct Opt;
+
+impl From<CmdCow> for Opt {
+	fn from(_: CmdCow) -> Self { Self }
+}
+impl From<()> for Opt {
+	fn from(_: ()) -> Self { Self }
+}
+
+impl Tasks {
+	#[yazi_codegen::command]
+	pub fn close(&mut self, _: Opt) {
+		if !self.visible {
+			return;
+		}
+
+		self.visible = false;
+		self.summaries = Vec::new();
+
+		self.arrow(0);
+		render!();
+	}
+}

--- a/yazi-core/src/tasks/commands/mod.rs
+++ b/yazi-core/src/tasks/commands/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(arrow cancel inspect open_with process_exec toggle);
+yazi_macro::mod_flat!(arrow cancel close inspect open_with process_exec show);

--- a/yazi-core/src/tasks/commands/show.rs
+++ b/yazi-core/src/tasks/commands/show.rs
@@ -14,14 +14,15 @@ impl From<()> for Opt {
 
 impl Tasks {
 	#[yazi_codegen::command]
-	pub fn toggle(&mut self, _: Opt) {
-		self.visible = !self.visible;
-
+	pub fn show(&mut self, _: Opt) {
 		if self.visible {
-			self.summaries = self.paginate();
-			self.arrow(0);
+			return;
 		}
 
+		self.visible = true;
+		self.summaries = self.paginate();
+
+		self.arrow(0);
 		render!();
 	}
 }

--- a/yazi-fm/src/executor.rs
+++ b/yazi-fm/src/executor.rs
@@ -141,8 +141,6 @@ impl<'a> Executor<'a> {
 		on!(TABS, swap);
 
 		match cmd.name.as_str() {
-			// Tasks
-			"tasks_show" => self.app.cx.tasks.toggle(()),
 			// Help
 			"help" => self.app.cx.help.toggle(Layer::Mgr),
 			// Plugin
@@ -165,7 +163,8 @@ impl<'a> Executor<'a> {
 			};
 		}
 
-		on!(toggle, "close");
+		on!(show);
+		on!(close);
 		on!(arrow);
 		on!(inspect);
 		on!(cancel);
@@ -309,7 +308,6 @@ impl<'a> Executor<'a> {
 		on!(arrow);
 
 		match cmd.name.as_str() {
-			"close_input" => self.app.cx.input.close(cmd),
 			// Help
 			"help" => self.app.cx.help.toggle(Layer::Cmp),
 			// Plugin


### PR DESCRIPTION
The `tasks_show` and `close_input` commands were introduced for cross-layer command invocation:

- `[manager]` calls the `[tasks]`'s `show` command to open the task manager
- `[cmp]` calls the `[input]`'s `close` command to close the input after completion

With https://github.com/sxyazi/yazi/pull/2399, Yazi now supports cross-layer command invocation in a more comprehensive and unified manner, making these two commands unnecessary.

## ⚠️ Breaking changes

`tasks_show` has been replaced by `tasks:show`:

```diff
# keymap.toml
- { on = "w", run = "tasks_show" },
+ { on = "w", run = "tasks:show" },
```

`close_input` has been replaced by `input:close`:

```diff
# keymap.toml
- { on = "<Enter>", run = [ "close --submit", "close_input --submit" ] },
+ { on = "<Enter>", run = [ "close --submit", "input:close --submit" ] },
```

