### PR TITLE
perf!: faster image preview with optimized `magick` arguments

### DIFF
--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -98,7 +98,8 @@ spotters = [
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
 	# Image
-	{ mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
+	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
+	{ mime = "image/svg+xml", run = "svg" },
 	{ mime = "image/*", run = "image" },
 	# Video
 	{ mime = "video/*", run = "video" },
@@ -107,7 +108,8 @@ spotters = [
 ]
 preloaders = [
 	# Image
-	{ mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
+	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
+	{ mime = "image/svg+xml", run = "svg" },
 	{ mime = "image/*", run = "image" },
 	# Video
 	{ mime = "video/*", run = "video" },
@@ -125,7 +127,8 @@ previewers = [
 	# JSON
 	{ mime = "application/{json,ndjson}", run = "json" },
 	# Image
-	{ mime = "image/{avif,hei?,jxl,svg+xml}", run = "magick" },
+	{ mime = "image/{avif,hei?,jxl}", run = "magick" },
+	{ mime = "image/svg+xml", run = "svg" },
 	{ mime = "image/*", run = "image" },
 	# Video
 	{ mime = "video/*", run = "video" },

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -29,7 +29,7 @@ function M:preload(job)
 		"-auto-orient",
 		"-strip",
 		"-sample",
-		string.format("%dx", rt.preview.max_width),
+		string.format("%dx%d>", rt.preview.max_width, rt.preview.max_height),
 		"-flatten",
 		"-quality",
 		rt.preview.image_quality,

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,15 +25,14 @@ function M:preload(job)
 	end
 
 	local cmd = Command("magick"):args {
-		"-density",
-		200,
 		tostring(job.file.url),
+		"-auto-orient",
+		"-strip",
+		"-sample",
+		string.format("%dx", rt.preview.max_width),
 		"-flatten",
-		"-resize",
-		string.format("%dx%d^", rt.preview.max_width, rt.preview.max_height),
 		"-quality",
 		rt.preview.image_quality,
-		"-auto-orient",
 		"JPG:" .. tostring(cache),
 	}
 

--- a/yazi-plugin/preset/plugins/svg.lua
+++ b/yazi-plugin/preset/plugins/svg.lua
@@ -24,19 +24,16 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_env()
-	if job.args.flatten then
-		cmd = cmd:arg("-flatten")
-	end
-
 	-- stylua: ignore
-	local status, err = cmd:args {
-		tostring(job.file.url), "-auto-orient", "-strip",
-		"-sample", string.format("%dx%d>", rt.preview.max_width, rt.preview.max_height),
+	local cmd = require("magick").with_env():args {
+		"-density", 200,
+		tostring(job.file.url), "-strip",
+		"-sample", string.format("%dx%d^", rt.preview.max_width, rt.preview.max_height),
 		"-quality", rt.preview.image_quality,
 		string.format("JPG:%s", cache),
-	}:status()
+	}
 
+	local status, err = cmd:status()
 	if status then
 		return status.success
 	else
@@ -45,13 +42,5 @@ function M:preload(job)
 end
 
 function M:spot(job) require("file"):spot(job) end
-
-function M.with_env()
-	local cmd = Command("magick"):env("MAGICK_THREAD_LIMIT", 1)
-	if rt.tasks.image_alloc > 0 then
-		cmd = cmd:env("MAGICK_MEMORY_LIMIT", rt.tasks.image_alloc)
-	end
-	return cmd
-end
 
 return M

--- a/yazi-plugin/preset/plugins/svg.lua
+++ b/yazi-plugin/preset/plugins/svg.lua
@@ -28,7 +28,7 @@ function M:preload(job)
 	local cmd = require("magick").with_env():args {
 		"-density", 200,
 		tostring(job.file.url), "-strip",
-		"-sample", string.format("%dx%d^", rt.preview.max_width, rt.preview.max_height),
+		"-resize", string.format("%dx%d^", rt.preview.max_width, rt.preview.max_height),
 		"-quality", rt.preview.image_quality,
 		string.format("JPG:%s", cache),
 	}

--- a/yazi-plugin/src/loader/loader.rs
+++ b/yazi-plugin/src/loader/loader.rs
@@ -42,6 +42,7 @@ impl Default for Loader {
 			("noop".to_owned(), preset!("plugins/noop").into()),
 			("pdf".to_owned(), preset!("plugins/pdf").into()),
 			("session".to_owned(), preset!("plugins/session").into()),
+			("svg".to_owned(), preset!("plugins/svg").into()),
 			("video".to_owned(), preset!("plugins/video").into()),
 			("zoxide".to_owned(), preset!("plugins/zoxide").into()),
 		]);


### PR DESCRIPTION
This should noticeably speed up previews and thumbnail generation when using `magick`. Also, the size of the thumbnail files should be smaller, especially when images have a landscape orientation.

Some numbers:

**AVIF**

Before:
```
Benchmark 1: taskset -c 19 magick -density 200 IMG_001.avif -flatten -resize 600x900^ -quality 75 -auto-orient JPG:IMG_001_th
  Time (mean ± σ):      4.148 s ±  0.002 s    [User: 3.953 s, System: 0.156 s]
  Range (min … max):    4.144 s …  4.151 s    10 runs
```
After:
```
Benchmark 1: taskset -c 19 magick IMG_001.avif -auto-orient -strip -sample 600x -flatten -quality 75 JPG:IMG_001_th
  Time (mean ± σ):     844.7 ms ±   2.0 ms    [User: 740.8 ms, System: 93.8 ms]
  Range (min … max):   841.8 ms … 848.3 ms    10 runs
```

**HEIF**

Before:
```
Benchmark 1: taskset -c 19 magick -density 200 IMG_001.heic -flatten -resize 600x900^ -quality 75 -auto-orient JPG:IMG_001_th
  Time (mean ± σ):      5.810 s ±  0.003 s    [User: 5.582 s, System: 0.174 s]
  Range (min … max):    5.806 s …  5.812 s    10 runs
```
After:
```
Benchmark 1: taskset -c 19 magick IMG_001.heic -auto-orient -strip -sample 600x -flatten -quality 75 JPG:IMG_001_th
  Time (mean ± σ):      2.518 s ±  0.002 s    [User: 2.380 s, System: 0.113 s]
  Range (min … max):    2.514 s …  2.520 s    10 runs
```

**JPEG XL**

Before:
```
Benchmark 1: taskset -c 19 magick -density 200 IMG_001.jxl -flatten -resize 600x900^ -quality 75 -auto-orient JPG:IMG_001_th
  Time (mean ± σ):      4.993 s ±  0.013 s    [User: 4.828 s, System: 0.119 s]
  Range (min … max):    4.956 s …  5.002 s    10 runs
```
After:
```
Benchmark 1: taskset -c 19 magick IMG_001.jxl -auto-orient -strip -sample 600x -flatten -quality 75 JPG:IMG_001_th
  Time (mean ± σ):      1.704 s ±  0.005 s    [User: 1.627 s, System: 0.060 s]
  Range (min … max):    1.691 s …  1.711 s    10 runs
```

## ⚠️ Breaking changes

### New `svg` plugin as the previewer, preloader, and spotter for SVG files

Unlike typical image formats, SVG is a vector format. 

This PR separates it from the `magick` and moves it into a new `svg` plugin, so that SVG-specific parameters do not affect magick's performance, and magick-specific parameters do not affect SVG's performance, thus improving the performance of both.

```diff
- { mime = "image/svg+xml", run = "magick" },
+ { mime = "image/svg+xml", run = "svg" },
```

This also makes it possible in the future to migrate the SVG backend from `magick` to other more specialized tools (such as [`resvg`](https://github.com/linebender/resvg)) without affecting the `magick` plugin – `magick` renders certain SVGs incorrectly and has suboptimal performance.

### Disable the `-flatten` parameter for `magick` by default

The `-flatten` parameter is used to support multi-layer images, but it has a [significant impact on performance](https://github.com/sxyazi/yazi/pull/2533#issuecomment-2752132633), and multi-layer images are not common across all image formats. 

A new `--flatten` has been introduced to enable it manually:

```diff
- { name = "*.xcf", run = "magick" }
+ { name = "*.xcf", run = "magick --flatten" }
```