### PR TITLE
feat!: support `arrow prev` and `arrow next` for more components

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Rustfmt
-        run: cargo +nightly fmt --all -- --check
+        run: rustfmt +nightly --check **/*.rs
 
   stylua:
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ansi-to-tui         = "7.0.0"
 anyhow              = "1.0.97"
 base64              = "0.22.1"
 bitflags            = "2.9.0"
-clap                = { version = "4.5.32", features = [ "derive" ] }
+clap                = { version = "4.5.34", features = [ "derive" ] }
 core-foundation-sys = "0.8.7"
 crossterm           = { version = "0.28.1", features = [ "event-stream" ] }
 dirs                = "6.0.0"

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -13,11 +13,11 @@ keymap = [
 	{ on = "<C-z>", run = "suspend",            desc = "Suspend the process" },
 
 	# Hopping
-	{ on = "k", run = "arrow prev", desc = "Go to previous file" },
-	{ on = "j", run = "arrow next", desc = "Go to next file" },
+	{ on = "k", run = "arrow prev", desc = "Previous file" },
+	{ on = "j", run = "arrow next", desc = "Next file" },
 
-	{ on = "<Up>",   run = "arrow prev", desc = "Go to previous file" },
-	{ on = "<Down>", run = "arrow next", desc = "Go to next file" },
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous file" },
+	{ on = "<Down>", run = "arrow next", desc = "Next file" },
 
 	{ on = "<C-u>", run = "arrow -50%",  desc = "Move cursor up half page" },
 	{ on = "<C-d>", run = "arrow 50%",   desc = "Move cursor down half page" },
@@ -29,8 +29,8 @@ keymap = [
 	{ on = "<PageUp>",     run = "arrow -100%", desc = "Move cursor up one page" },
 	{ on = "<PageDown>",   run = "arrow 100%",  desc = "Move cursor down one page" },
 
-	{ on = [ "g", "g" ], run = "arrow top", desc = "Move cursor to the top" },
-	{ on = "G",          run = "arrow bot", desc = "Move cursor to the bottom" },
+	{ on = [ "g", "g" ], run = "arrow top", desc = "Go to top" },
+	{ on = "G",          run = "arrow bot", desc = "Go to bottom" },
 
 	# Navigation
 	{ on = "h", run = "leave", desc = "Back to the parent directory" },
@@ -105,8 +105,8 @@ keymap = [
 	# Find
 	{ on = "/", run = "find --smart",            desc = "Find next file" },
 	{ on = "?", run = "find --previous --smart", desc = "Find previous file" },
-	{ on = "n", run = "find_arrow",              desc = "Go to next found" },
-	{ on = "N", run = "find_arrow --previous",   desc = "Go to previous found" },
+	{ on = "n", run = "find_arrow",              desc = "Next found" },
+	{ on = "N", run = "find_arrow --previous",   desc = "Previous found" },
 
 	# Sorting
 	{ on = [ ",", "m" ], run = [ "sort mtime --reverse=no", "linemode mtime" ], desc = "Sort by modified time" },
@@ -164,11 +164,11 @@ keymap = [
 	{ on = "<C-c>", run = "close", desc = "Close task manager" },
 	{ on = "w",     run = "close", desc = "Close task manager" },
 
-	{ on = "k", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "j", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "k", run = "arrow prev", desc = "Previous task" },
+	{ on = "j", run = "arrow next", desc = "Next task" },
 
-	{ on = "<Up>",   run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<Down>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous task" },
+	{ on = "<Down>", run = "arrow next", desc = "Next task" },
 
 	{ on = "<Enter>", run = "inspect", desc = "Inspect the task" },
 	{ on = "x",       run = "cancel",  desc = "Cancel the task" },
@@ -186,15 +186,15 @@ keymap = [
 	{ on = "<C-c>", run = "close", desc = "Close the spot" },
 	{ on = "<Tab>", run = "close", desc = "Close the spot" },
 
-	{ on = "k", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "j", run = "arrow 1",  desc = "Move cursor down" },
-	{ on = "h", run = "swipe -1", desc = "Swipe to previous file" },
-	{ on = "l", run = "swipe 1",  desc = "Swipe to next file" },
+	{ on = "k", run = "arrow prev", desc = "Previous line" },
+	{ on = "j", run = "arrow next", desc = "Next line" },
+	{ on = "h", run = "swipe prev", desc = "Swipe to previous file" },
+	{ on = "l", run = "swipe next", desc = "Swipe to next file" },
 
-	{ on = "<Up>",    run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<Down>",  run = "arrow 1",  desc = "Move cursor down" },
-	{ on = "<Left>",  run = "swipe -1", desc = "Swipe to next file" },
-	{ on = "<Right>", run = "swipe 1",  desc = "Swipe to previous file" },
+	{ on = "<Up>",    run = "arrow prev", desc = "Previous line" },
+	{ on = "<Down>",  run = "arrow next", desc = "Next line" },
+	{ on = "<Left>",  run = "swipe prev", desc = "Swipe to previous file" },
+	{ on = "<Right>", run = "swipe next", desc = "Swipe to next file" },
 
 	# Copy
 	{ on = [ "c", "c" ], run = "copy cell", desc = "Copy selected cell" },
@@ -212,11 +212,11 @@ keymap = [
 	{ on = "<C-c>",   run = "close",          desc = "Cancel pick" },
 	{ on = "<Enter>", run = "close --submit", desc = "Submit the pick" },
 
-	{ on = "k", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "j", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "k", run = "arrow prev", desc = "Previous option" },
+	{ on = "j", run = "arrow next", desc = "Next option" },
 
-	{ on = "<Up>",   run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<Down>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous option" },
+	{ on = "<Down>", run = "arrow next", desc = "Next option" },
 
 	# Help
 	{ on = "~",    run = "help", desc = "Open help" },
@@ -314,11 +314,11 @@ keymap = [
 	{ on = "n", run = "close",          desc = "Cancel the confirm" },
 	{ on = "y", run = "close --submit", desc = "Submit the confirm" },
 
-	{ on = "k", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "j", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "k", run = "arrow prev", desc = "Previous line" },
+	{ on = "j", run = "arrow next", desc = "Next line" },
 
-	{ on = "<Up>",   run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<Down>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous line" },
+	{ on = "<Down>", run = "arrow next", desc = "Next line" },
 
 	# Help
 	{ on = "~",    run = "help", desc = "Open help" },
@@ -332,14 +332,14 @@ keymap = [
 	{ on = "<Tab>",   run = "close --submit",                             desc = "Submit the completion" },
 	{ on = "<Enter>", run = [ "close --submit", "input:close --submit" ], desc = "Complete and submit the input" },
 
-	{ on = "<A-k>", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<A-j>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<A-k>", run = "arrow prev", desc = "Previous item" },
+	{ on = "<A-j>", run = "arrow next", desc = "Next item" },
 
-	{ on = "<Up>",   run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<Down>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous item" },
+	{ on = "<Down>", run = "arrow next", desc = "Next item" },
 
-	{ on = "<C-p>", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<C-n>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<C-p>", run = "arrow prev", desc = "Previous item" },
+	{ on = "<C-n>", run = "arrow next", desc = "Next item" },
 
 	# Help
 	{ on = "~",    run = "help", desc = "Open help" },
@@ -354,11 +354,11 @@ keymap = [
 	{ on = "<C-c>", run = "close",  desc = "Hide the help" },
 
 	# Navigation
-	{ on = "k", run = "arrow -1", desc = "Move cursor up" },
-	{ on = "j", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "k", run = "arrow prev", desc = "Previous line" },
+	{ on = "j", run = "arrow next", desc = "Next line" },
 
-	{ on = "<Up>",   run = "arrow -1", desc = "Move cursor up" },
-	{ on = "<Down>", run = "arrow 1",  desc = "Move cursor down" },
+	{ on = "<Up>",   run = "arrow prev", desc = "Previous line" },
+	{ on = "<Down>", run = "arrow next", desc = "Next line" },
 
 	# Filtering
 	{ on = "f", run = "filter", desc = "Apply a filter for the help items" },

--- a/yazi-core/src/cmp/commands/arrow.rs
+++ b/yazi-core/src/cmp/commands/arrow.rs
@@ -17,11 +17,6 @@ impl From<CmdCow> for Opt {
 impl Cmp {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
-		let len = self.cands.len();
-		if len == 0 {
-			return;
-		}
-
 		let new = opt.step.add(self.cursor, self.cands.len(), self.limit());
 		if new > self.cursor {
 			self.next(new);
@@ -31,25 +26,28 @@ impl Cmp {
 	}
 
 	fn next(&mut self, new: usize) {
-		let len = self.cands.len();
 		let old = self.cursor;
-		self.cursor = new.min(len - 1);
+		self.cursor = new;
 
-		let limit = self.limit();
-		if self.cursor >= len.min(self.offset + limit) {
-			self.offset = len.saturating_sub(limit).min(self.offset + self.cursor - old);
-		}
+		let (len, limit) = (self.cands.len(), self.limit());
+		self.offset = if self.cursor < len.min(self.offset + limit) {
+			self.offset.min(len.saturating_sub(1))
+		} else {
+			len.saturating_sub(limit).min(self.offset + self.cursor - old)
+		};
 
 		render!(old != self.cursor);
 	}
 
 	fn prev(&mut self, new: usize) {
 		let old = self.cursor;
-		self.cursor = new.min(self.cands.len().saturating_sub(1));
+		self.cursor = new;
 
-		if self.cursor < self.offset {
-			self.offset = self.offset.saturating_sub(old - self.cursor);
-		}
+		self.offset = if self.cursor < self.offset {
+			self.offset.saturating_sub(old - self.cursor)
+		} else {
+			self.offset.min(self.cands.len().saturating_sub(1))
+		};
 
 		render!(old != self.cursor);
 	}

--- a/yazi-core/src/cmp/commands/arrow.rs
+++ b/yazi-core/src/cmp/commands/arrow.rs
@@ -1,34 +1,39 @@
+use yazi_fs::Step;
 use yazi_macro::render;
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::cmp::Cmp;
 
 struct Opt {
-	step: isize,
+	step: Step,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { step: c.first().and_then(Data::as_isize).unwrap_or(0) } }
+	fn from(c: CmdCow) -> Self {
+		Self { step: c.first().and_then(|d| d.try_into().ok()).unwrap_or_default() }
+	}
 }
 
 impl Cmp {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
-		if opt.step > 0 {
-			self.next(opt.step as usize);
-		} else {
-			self.prev(opt.step.unsigned_abs());
-		}
-	}
-
-	fn next(&mut self, step: usize) {
 		let len = self.cands.len();
 		if len == 0 {
 			return;
 		}
 
+		let new = opt.step.add(self.cursor, self.cands.len(), self.limit());
+		if new > self.cursor {
+			self.next(new);
+		} else {
+			self.prev(new);
+		}
+	}
+
+	fn next(&mut self, new: usize) {
+		let len = self.cands.len();
 		let old = self.cursor;
-		self.cursor = (self.cursor + step).min(len - 1);
+		self.cursor = new.min(len - 1);
 
 		let limit = self.limit();
 		if self.cursor >= len.min(self.offset + limit) {
@@ -38,9 +43,9 @@ impl Cmp {
 		render!(old != self.cursor);
 	}
 
-	fn prev(&mut self, step: usize) {
+	fn prev(&mut self, new: usize) {
 		let old = self.cursor;
-		self.cursor = self.cursor.saturating_sub(step);
+		self.cursor = new.min(self.cands.len().saturating_sub(1));
 
 		if self.cursor < self.offset {
 			self.offset = self.offset.saturating_sub(old - self.cursor);

--- a/yazi-core/src/confirm/commands/arrow.rs
+++ b/yazi-core/src/confirm/commands/arrow.rs
@@ -17,15 +17,11 @@ impl From<CmdCow> for Opt {
 impl Confirm {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt, mgr: &Mgr) {
-		let width = mgr.area(self.position).width;
-		let height = self.list.line_count(width);
-		if height == 0 {
-			return;
-		}
+		let area = mgr.area(self.position);
+		let len = self.list.line_count(area.width);
 
 		let old = self.offset;
-		let new = opt.step.add(self.offset, height, height);
-		self.offset = new.min(height - 1);
+		self.offset = opt.step.add(self.offset, len, area.height as _);
 
 		render!(old != self.offset);
 	}

--- a/yazi-core/src/confirm/commands/arrow.rs
+++ b/yazi-core/src/confirm/commands/arrow.rs
@@ -1,41 +1,31 @@
+use yazi_fs::Step;
 use yazi_macro::render;
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::{confirm::Confirm, mgr::Mgr};
 
 struct Opt {
-	step: isize,
+	step: Step,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { step: c.first().and_then(Data::as_isize).unwrap_or(0) } }
+	fn from(c: CmdCow) -> Self {
+		Self { step: c.first().and_then(|d| d.try_into().ok()).unwrap_or_default() }
+	}
 }
 
 impl Confirm {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt, mgr: &Mgr) {
-		if opt.step > 0 {
-			self.next(opt.step as usize, mgr.area(self.position).width)
-		} else {
-			self.prev(opt.step.unsigned_abs())
-		}
-	}
-
-	fn next(&mut self, step: usize, width: u16) {
+		let width = mgr.area(self.position).width;
 		let height = self.list.line_count(width);
 		if height == 0 {
 			return;
 		}
 
 		let old = self.offset;
-		self.offset = (self.offset + step).min(height - 1);
-
-		render!(old != self.offset);
-	}
-
-	fn prev(&mut self, step: usize) {
-		let old = self.offset;
-		self.offset -= step.min(self.offset);
+		let new = opt.step.add(self.offset, height, height);
+		self.offset = new.min(height - 1);
 
 		render!(old != self.offset);
 	}

--- a/yazi-core/src/help/commands/arrow.rs
+++ b/yazi-core/src/help/commands/arrow.rs
@@ -1,30 +1,31 @@
+use yazi_fs::Step;
 use yazi_macro::render;
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::help::Help;
 
 struct Opt {
-	step: isize,
+	step: Step,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { step: c.first().and_then(Data::as_isize).unwrap_or(0) } }
+	fn from(c: CmdCow) -> Self {
+		Self { step: c.first().and_then(|d| d.try_into().ok()).unwrap_or_default() }
+	}
 }
+
 impl From<isize> for Opt {
-	fn from(step: isize) -> Self { Self { step } }
+	fn from(n: isize) -> Self { Self { step: n.into() } }
 }
 
 impl Help {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
-		let max = self.bindings.len().saturating_sub(1);
-		self.offset = self.offset.min(max);
-		self.cursor = self.cursor.min(max);
-
-		if opt.step > 0 {
-			self.next(opt.step as usize);
+		let new = opt.step.add(self.cursor, self.bindings.len(), Self::limit());
+		if new > self.cursor {
+			self.next(new);
 		} else {
-			self.prev(opt.step.unsigned_abs());
+			self.prev(new);
 		}
 	}
 

--- a/yazi-core/src/help/commands/arrow.rs
+++ b/yazi-core/src/help/commands/arrow.rs
@@ -28,30 +28,29 @@ impl Help {
 		}
 	}
 
-	fn next(&mut self, step: usize) {
-		let len = self.bindings.len();
-		if len == 0 {
-			return;
-		}
-
+	fn next(&mut self, new: usize) {
 		let old = self.cursor;
-		self.cursor = (self.cursor + step).min(len - 1);
+		self.cursor = new;
 
-		let limit = Self::limit();
-		if self.cursor >= (self.offset + limit).min(len).saturating_sub(5) {
-			self.offset = len.saturating_sub(limit).min(self.offset + self.cursor - old);
-		}
+		let (len, limit) = (self.bindings.len(), Self::limit());
+		self.offset = if self.cursor < (self.offset + limit).min(len).saturating_sub(5) {
+			self.offset.min(len.saturating_sub(1))
+		} else {
+			len.saturating_sub(limit).min(self.offset + self.cursor - old)
+		};
 
 		render!(old != self.cursor);
 	}
 
-	fn prev(&mut self, step: usize) {
+	fn prev(&mut self, new: usize) {
 		let old = self.cursor;
-		self.cursor = self.cursor.saturating_sub(step);
+		self.cursor = new;
 
-		if self.cursor < self.offset + 5 {
-			self.offset = self.offset.saturating_sub(old - self.cursor);
-		}
+		self.offset = if self.cursor < self.offset + 5 {
+			self.offset.saturating_sub(old - self.cursor)
+		} else {
+			self.offset.min(self.bindings.len().saturating_sub(1))
+		};
 
 		render!(old != self.cursor);
 	}

--- a/yazi-core/src/pick/commands/arrow.rs
+++ b/yazi-core/src/pick/commands/arrow.rs
@@ -1,30 +1,39 @@
+use yazi_fs::Step;
 use yazi_macro::render;
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::pick::Pick;
 
 struct Opt {
-	step: isize,
+	step: Step,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { step: c.first().and_then(Data::as_isize).unwrap_or(0) } }
+	fn from(c: CmdCow) -> Self {
+		Self { step: c.first().and_then(|d| d.try_into().ok()).unwrap_or_default() }
+	}
 }
 
 impl Pick {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
-		if opt.step > 0 { self.next(opt.step as usize) } else { self.prev(opt.step.unsigned_abs()) }
-	}
-
-	fn next(&mut self, step: usize) {
 		let len = self.items.len();
 		if len == 0 {
 			return;
 		}
 
+		let new = opt.step.add(self.cursor, len, self.limit());
+		if new > self.cursor {
+			self.next(new);
+		} else {
+			self.prev(new);
+		}
+	}
+
+	fn next(&mut self, new: usize) {
+		let len = self.items.len();
 		let old = self.cursor;
-		self.cursor = (self.cursor + step).min(len - 1);
+		self.cursor = new.min(len - 1);
 
 		let limit = self.limit();
 		if self.cursor >= len.min(self.offset + limit) {
@@ -34,9 +43,9 @@ impl Pick {
 		render!(old != self.cursor);
 	}
 
-	fn prev(&mut self, step: usize) {
+	fn prev(&mut self, new: usize) {
 		let old = self.cursor;
-		self.cursor = self.cursor.saturating_sub(step);
+		self.cursor = new.min(self.items.len().saturating_sub(1));
 
 		if self.cursor < self.offset {
 			self.offset = self.offset.saturating_sub(old - self.cursor);

--- a/yazi-core/src/pick/commands/arrow.rs
+++ b/yazi-core/src/pick/commands/arrow.rs
@@ -17,12 +17,7 @@ impl From<CmdCow> for Opt {
 impl Pick {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
-		let len = self.items.len();
-		if len == 0 {
-			return;
-		}
-
-		let new = opt.step.add(self.cursor, len, self.limit());
+		let new = opt.step.add(self.cursor, self.items.len(), self.limit());
 		if new > self.cursor {
 			self.next(new);
 		} else {
@@ -31,25 +26,28 @@ impl Pick {
 	}
 
 	fn next(&mut self, new: usize) {
-		let len = self.items.len();
 		let old = self.cursor;
-		self.cursor = new.min(len - 1);
+		self.cursor = new;
 
-		let limit = self.limit();
-		if self.cursor >= len.min(self.offset + limit) {
-			self.offset = len.saturating_sub(limit).min(self.offset + self.cursor - old);
-		}
+		let (len, limit) = (self.items.len(), self.limit());
+		self.offset = if self.cursor < len.min(self.offset + limit) {
+			self.offset.min(len.saturating_sub(1))
+		} else {
+			len.saturating_sub(limit).min(self.offset + self.cursor - old)
+		};
 
 		render!(old != self.cursor);
 	}
 
 	fn prev(&mut self, new: usize) {
 		let old = self.cursor;
-		self.cursor = new.min(self.items.len().saturating_sub(1));
+		self.cursor = new;
 
-		if self.cursor < self.offset {
-			self.offset = self.offset.saturating_sub(old - self.cursor);
-		}
+		self.offset = if self.cursor < self.offset {
+			self.offset.saturating_sub(old - self.cursor)
+		} else {
+			self.offset.min(self.items.len().saturating_sub(1))
+		};
 
 		render!(old != self.cursor);
 	}

--- a/yazi-core/src/spot/commands/swipe.rs
+++ b/yazi-core/src/spot/commands/swipe.rs
@@ -1,14 +1,16 @@
+use std::borrow::Cow;
+
 use yazi_proxy::{MgrProxy, TabProxy};
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::spot::Spot;
 
 struct Opt {
-	step: isize,
+	step: Cow<'static, str>,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { step: c.first().and_then(Data::as_isize).unwrap_or(0) } }
+	fn from(mut c: CmdCow) -> Self { Self { step: c.take_first_str().unwrap_or_default() } }
 }
 
 impl Spot {

--- a/yazi-core/src/tab/folder.rs
+++ b/yazi-core/src/tab/folder.rs
@@ -142,7 +142,7 @@ impl Folder {
 		let limit = LAYOUT.get().limit();
 		let scrolloff = (limit / 2).min(YAZI.mgr.scrolloff as usize);
 
-		self.cursor = new.min(len.saturating_sub(1));
+		self.cursor = new;
 		self.offset = if self.cursor < (self.offset + limit).min(len).saturating_sub(scrolloff) {
 			self.offset.min(len.saturating_sub(1))
 		} else {
@@ -154,16 +154,15 @@ impl Folder {
 
 	fn prev(&mut self, new: usize) -> bool {
 		let old = (self.cursor, self.offset);
-		let max = self.files.len().saturating_sub(1);
 
 		let limit = LAYOUT.get().limit();
 		let scrolloff = (limit / 2).min(YAZI.mgr.scrolloff as usize);
 
-		self.cursor = new.min(max);
+		self.cursor = new;
 		self.offset = if self.cursor < self.offset + scrolloff {
 			self.offset.saturating_sub(old.0 - self.cursor)
 		} else {
-			self.offset.min(max)
+			self.offset.min(self.files.len().saturating_sub(1))
 		};
 
 		old != (self.cursor, self.offset)

--- a/yazi-core/src/tasks/commands/arrow.rs
+++ b/yazi-core/src/tasks/commands/arrow.rs
@@ -15,22 +15,15 @@ impl From<CmdCow> for Opt {
 }
 
 impl From<isize> for Opt {
-	fn from(step: isize) -> Self { Self { step: step.into() } }
+	fn from(n: isize) -> Self { Self { step: n.into() } }
 }
 
 impl Tasks {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
-		let max = Self::limit().min(self.summaries.len());
 		let old = self.cursor;
-		let new = opt.step.add(self.cursor, max, max);
-		if new > old {
-			self.cursor += 1;
-		} else {
-			self.cursor = self.cursor.saturating_sub(1);
-		}
+		self.cursor = opt.step.add(self.cursor, self.summaries.len(), Self::limit());
 
-		self.cursor = self.cursor.min(max.saturating_sub(1));
 		render!(self.cursor != old);
 	}
 }

--- a/yazi-core/src/tasks/commands/arrow.rs
+++ b/yazi-core/src/tasks/commands/arrow.rs
@@ -1,31 +1,35 @@
+use yazi_fs::Step;
 use yazi_macro::render;
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::tasks::Tasks;
 
 struct Opt {
-	step: isize,
+	step: Step,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { step: c.first().and_then(Data::as_isize).unwrap_or(0) } }
+	fn from(c: CmdCow) -> Self {
+		Self { step: c.first().and_then(|d| d.try_into().ok()).unwrap_or_default() }
+	}
 }
 
 impl From<isize> for Opt {
-	fn from(step: isize) -> Self { Self { step } }
+	fn from(step: isize) -> Self { Self { step: step.into() } }
 }
 
 impl Tasks {
 	#[yazi_codegen::command]
 	pub fn arrow(&mut self, opt: Opt) {
+		let max = Self::limit().min(self.summaries.len());
 		let old = self.cursor;
-		if opt.step > 0 {
+		let new = opt.step.add(self.cursor, max, max);
+		if new > old {
 			self.cursor += 1;
 		} else {
 			self.cursor = self.cursor.saturating_sub(1);
 		}
 
-		let max = Self::limit().min(self.summaries.len());
 		self.cursor = self.cursor.min(max.saturating_sub(1));
 		render!(self.cursor != old);
 	}

--- a/yazi-fs/src/step.rs
+++ b/yazi-fs/src/step.rs
@@ -68,7 +68,7 @@ impl Step {
 		} else if matches!(self, Self::Prev | Self::Next) {
 			fixed.saturating_add_unsigned(pos).rem_euclid(len as _) as _
 		} else if fixed > 0 {
-			pos + fixed as usize
+			pos.saturating_add_signed(fixed).min(len - 1)
 		} else {
 			pos.saturating_sub(fixed.unsigned_abs())
 		}

--- a/yazi-plugin/src/elements/table.rs
+++ b/yazi-plugin/src/elements/table.rs
@@ -82,6 +82,9 @@ impl Table {
 		table.render(self.area.transform(trans), buf, &mut self.state);
 	}
 
+	#[inline]
+	pub(crate) fn len(&self) -> usize { self.rows.len() }
+
 	pub(crate) fn select(&mut self, idx: Option<usize>) {
 		self
 			.state

--- a/yazi-plugin/src/utils/spot.rs
+++ b/yazi-plugin/src/utils/spot.rs
@@ -32,6 +32,9 @@ impl TryFrom<Table> for SpotLock {
 }
 
 impl SpotLock {
+	#[inline]
+	pub fn len(&self) -> Option<usize> { Some(self.table()?.len()) }
+
 	pub fn select(&mut self, idx: Option<usize>) {
 		if let Some(t) = self.table_mut() {
 			t.select(idx);

--- a/yazi-proxy/src/tab.rs
+++ b/yazi-proxy/src/tab.rs
@@ -17,8 +17,8 @@ impl TabProxy {
 	}
 
 	#[inline]
-	pub fn arrow(step: isize) {
-		emit!(Call(Cmd::args("mgr:arrow", &[step])));
+	pub fn arrow(step: impl AsRef<str>) {
+		emit!(Call(Cmd::args("mgr:arrow", &[step.as_ref()])));
 	}
 
 	#[inline]


### PR DESCRIPTION
Follow up to https://github.com/sxyazi/yazi/pull/2485


## ⚠️ Breaking changes

With this PR, all components now support wraparound navigation and have it enabled by default to maintain overall interaction consistency. 

The old `arrow -1` and `arrow 1` can still be used to preserve the previous behavior.