### PR TITLE
feat!: enhance `fzf` integration

### DIFF
--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -82,8 +82,8 @@ keymap = [
 	{ on = "s",         run = "search --via=fd",             desc = "Search files by name via fd" },
 	{ on = "S",         run = "search --via=rg",             desc = "Search files by content via ripgrep" },
 	{ on = "<C-s>",     run = "escape --search",             desc = "Cancel the ongoing search" },
-	{ on = "z",         run = "plugin zoxide",               desc = "Jump to a directory via zoxide" },
-	{ on = "Z",         run = "plugin fzf",                  desc = "Jump to a file/directory via fzf" },
+	{ on = "z",         run = "plugin fzf",                  desc = "Jump to a file/directory via fzf" },
+	{ on = "Z",         run = "plugin zoxide",               desc = "Jump to a directory via zoxide" },
 
 	# Linemode
 	{ on = [ "m", "s" ], run = "linemode size",        desc = "Linemode: size" },

--- a/yazi-core/src/mgr/commands/paste.rs
+++ b/yazi-core/src/mgr/commands/paste.rs
@@ -19,7 +19,7 @@ impl Mgr {
 		if self.yanked.cut {
 			tasks.file_cut(&src, dest, opt.force);
 
-			self.tabs.iter_mut().for_each(|t| _ = t.selected.remove_many(&src, false));
+			self.tabs.iter_mut().for_each(|t| _ = t.selected.remove_many(&src));
 			self.unyank(());
 		} else {
 			tasks.file_copy(&src, dest, opt.force, opt.follow);

--- a/yazi-core/src/mgr/commands/remove.rs
+++ b/yazi-core/src/mgr/commands/remove.rs
@@ -57,7 +57,7 @@ impl Mgr {
 	#[yazi_codegen::command]
 	pub fn remove_do(&mut self, opt: Opt, tasks: &Tasks) {
 		self.tabs.iter_mut().for_each(|t| {
-			t.selected.remove_many(&opt.targets, false);
+			t.selected.remove_many(&opt.targets);
 		});
 
 		for u in &opt.targets {

--- a/yazi-core/src/tab/commands/escape.rs
+++ b/yazi-core/src/tab/commands/escape.rs
@@ -109,10 +109,9 @@ impl Tab {
 		let urls: Vec<_> =
 			indices.into_iter().filter_map(|i| self.current.files.get(i)).map(|f| &f.url).collect();
 
-		let same = !self.cwd().is_search();
 		if !select {
-			self.selected.remove_many(&urls, same);
-		} else if self.selected.add_many(&urls, same) != urls.len() {
+			self.selected.remove_many(&urls);
+		} else if self.selected.add_many(&urls) != urls.len() {
 			AppProxy::notify_warn(
 				"Escape visual mode",
 				"Some files cannot be selected, due to path nesting conflict.",

--- a/yazi-core/src/tab/commands/toggle_all.rs
+++ b/yazi-core/src/tab/commands/toggle_all.rs
@@ -1,16 +1,26 @@
 use yazi_macro::render;
 use yazi_proxy::AppProxy;
-use yazi_shared::event::CmdCow;
+use yazi_shared::{event::CmdCow, url::Url};
 
 use crate::tab::Tab;
 
 struct Opt {
+	urls:  Vec<Url>,
 	state: Option<bool>,
 }
 
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self {
+	fn from(mut c: CmdCow) -> Self {
+		let mut urls = Vec::with_capacity(c.len());
+		for i in 0..c.len() {
+			match c.take_url(i) {
+				Some(url) => urls.push(url),
+				None => break,
+			}
+		}
+
 		Self {
+			urls,
 			state: match c.str("state") {
 				Some("on") => Some(true),
 				Some("off") => Some(false),
@@ -19,27 +29,38 @@ impl From<CmdCow> for Opt {
 		}
 	}
 }
+
 impl From<Option<bool>> for Opt {
-	fn from(state: Option<bool>) -> Self { Self { state } }
+	fn from(state: Option<bool>) -> Self { Self { urls: vec![], state } }
 }
 
 impl Tab {
 	#[yazi_codegen::command]
 	pub fn toggle_all(&mut self, opt: Opt) {
-		let iter = self.current.files.iter().map(|f| &f.url);
-		let (removal, addition): (Vec<_>, Vec<_>) = match opt.state {
-			Some(true) => (vec![], iter.collect()),
-			Some(false) => (iter.collect(), vec![]),
-			None => iter.partition(|&u| self.selected.contains_key(u)),
+		use yazi_shared::Either::*;
+
+		let it = self.current.files.iter().map(|f| &f.url);
+		let either = match opt.state {
+			Some(true) if opt.urls.is_empty() => Left((vec![], it.collect())),
+			Some(true) => Right((vec![], opt.urls)),
+			Some(false) if opt.urls.is_empty() => Left((it.collect(), vec![])),
+			Some(false) => Right((opt.urls, vec![])),
+			None if opt.urls.is_empty() => Left(it.partition(|&u| self.selected.contains_key(u))),
+			None => Right(opt.urls.into_iter().partition(|u| self.selected.contains_key(u))),
 		};
 
-		let same = !self.cwd().is_search();
-		render!(self.selected.remove_many(&removal, same) > 0);
+		let warn = match either {
+			Left((removal, addition)) => {
+				render!(self.selected.remove_many(&removal) > 0);
+				render!(self.selected.add_many(&addition), > 0) != addition.len()
+			}
+			Right((removal, addition)) => {
+				render!(self.selected.remove_many(&removal) > 0);
+				render!(self.selected.add_many(&addition), > 0) != addition.len()
+			}
+		};
 
-		let added = self.selected.add_many(&addition, same);
-		render!(added > 0);
-
-		if added != addition.len() {
+		if warn {
 			AppProxy::notify_warn(
 				"Toggle all",
 				"Some files cannot be selected, due to path nesting conflict.",

--- a/yazi-macro/src/event.rs
+++ b/yazi-macro/src/event.rs
@@ -24,6 +24,13 @@ macro_rules! render {
 			render!();
 		}
 	};
+	($left:expr, > $right:expr) => {{
+		let val = $left;
+		if val > $right {
+			render!();
+		}
+		val
+	}};
 }
 
 #[macro_export]

--- a/yazi-shared/src/event/cmd.rs
+++ b/yazi-shared/src/event/cmd.rs
@@ -33,6 +33,12 @@ impl Cmd {
 		me
 	}
 
+	#[inline]
+	pub fn len(&self) -> usize { self.args.len() }
+
+	#[inline]
+	pub fn is_empty(&self) -> bool { self.args.is_empty() }
+
 	// --- With
 	#[inline]
 	pub fn with(mut self, name: impl Into<DataKey>, value: impl ToString) -> Self {


### PR DESCRIPTION
See https://github.com/sxyazi/yazi/issues/2546

Closes https://github.com/sxyazi/yazi/issues/2546

## ⚠️ Breaking change

The default behavior of the keys `z` and `Z` are swapped.

You can use custom keybinds to keep the original behavior if that's preferred:

```sh
{ on = "z", run = "plugin zoxide" },
{ on = "Z", run = "plugin fzf" },
```