### PR TITLE
refactor: deprecate `ui.Padding` and `ui.Rect:padding()`

### DIFF
--- a/yazi-plugin/src/elements/pad.rs
+++ b/yazi-plugin/src/elements/pad.rs
@@ -17,6 +17,13 @@ impl From<ratatui::widgets::Padding> for Pad {
 
 impl Pad {
 	pub fn compose(lua: &Lua, v4: bool) -> mlua::Result<Table> {
+		if !v4 {
+			crate::deprecate!(
+				lua,
+				"The `ui.Padding` has been deprecated, please use `ui.Pad` instead, in your {}"
+			);
+		}
+
 		let new = if v4 {
 			lua.create_function(|_, (_, top, right, bottom, left): (Table, u16, u16, u16, u16)| {
 				Ok(Self(ratatui::widgets::Padding::new(left, right, top, bottom)))

--- a/yazi-plugin/src/elements/rect.rs
+++ b/yazi-plugin/src/elements/rect.rs
@@ -72,7 +72,10 @@ impl UserData for Rect {
 	fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
 		methods.add_method("pad", |_, me, pad: Pad| Ok(me.pad(pad)));
 		// TODO: deprecate this
-		methods.add_method("padding", |_, me, pad: Pad| Ok(me.pad(pad)));
+		methods.add_method("padding", |lua, me, pad: Pad| {
+			crate::deprecate!(lua, "The `padding()` method of `ui.Rect` has been deprecated, please use `pad()` instead, in your {}");
+			Ok(me.pad(pad))
+		});
 		methods.add_method("contains", |_, me, Rect(rect)| Ok(me.contains(rect.into())));
 	}
 }


### PR DESCRIPTION
This PR deprecates `ui.Padding` in favor of the new `ui.Pad`, which uses the same [parameter order as CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/padding#syntax). This change makes it possible to further simplify syntax in the future:

```diff
- ui.Padding(left, right, top, bottom)
+ ui.Pad(top, right, bottom, left)
```

The `padding()` method of `ui.Rect` is also deprecated to align with the new `ui.Pad` naming:

```diff
- ui.Rect.default:padding(padding)
+ ui.Rect.default:pad(pad)
```

The old `ui.Padding` and `ui.Rect:padding()` are still available, but will trigger a warning.