### PR TITLE
feat: allow initializing input when opening it with commands like `rename`, `create`, `find`, `filter`, etc.

### DIFF
--- a/yazi-core/src/mgr/commands/open.rs
+++ b/yazi-core/src/mgr/commands/open.rs
@@ -6,7 +6,7 @@ use yazi_config::{YAZI, popup::PickCfg};
 use yazi_fs::File;
 use yazi_macro::emit;
 use yazi_plugin::isolate;
-use yazi_proxy::{MgrProxy, TasksProxy, options::OpenDoOpt};
+use yazi_proxy::{MgrProxy, PickProxy, TasksProxy, options::OpenDoOpt};
 use yazi_shared::{MIME_DIR, event::{CmdCow, EventQuit}, url::Url};
 
 use crate::{mgr::Mgr, tab::Folder, tasks::Tasks};
@@ -95,12 +95,10 @@ impl Mgr {
 			return;
 		}
 
+		let pick = PickProxy::show(PickCfg::open(openers.iter().map(|o| o.desc()).collect()));
 		let urls = [opt.hovered].into_iter().chain(targets.into_iter().map(|(u, _)| u)).collect();
 		tokio::spawn(async move {
-			let result =
-				yazi_proxy::PickProxy::show(PickCfg::open(openers.iter().map(|o| o.desc()).collect()));
-
-			if let Ok(choice) = result.await {
+			if let Ok(choice) = pick.await {
 				TasksProxy::open_with(Cow::Borrowed(openers[choice]), opt.cwd, urls);
 			}
 		});

--- a/yazi-core/src/mgr/commands/remove.rs
+++ b/yazi-core/src/mgr/commands/remove.rs
@@ -41,14 +41,14 @@ impl Mgr {
 			return self.remove_do(opt, tasks);
 		}
 
-		tokio::spawn(async move {
-			let result = ConfirmProxy::show(if opt.permanently {
-				ConfirmCfg::delete(&opt.targets)
-			} else {
-				ConfirmCfg::trash(&opt.targets)
-			});
+		let confirm = ConfirmProxy::show(if opt.permanently {
+			ConfirmCfg::delete(&opt.targets)
+		} else {
+			ConfirmCfg::trash(&opt.targets)
+		});
 
-			if result.await {
+		tokio::spawn(async move {
+			if confirm.await {
 				MgrProxy::remove_do(opt.targets, opt.permanently);
 			}
 		});

--- a/yazi-core/src/mgr/commands/rename.rs
+++ b/yazi-core/src/mgr/commands/rename.rs
@@ -53,12 +53,10 @@ impl Mgr {
 
 		let old = hovered.url_owned();
 		let tab = self.tabs.active().id;
-		tokio::spawn(async move {
-			let mut result = InputProxy::show(InputCfg::rename().with_value(name).with_cursor(cursor));
-			let Some(Ok(name)) = result.recv().await else {
-				return;
-			};
+		let mut input = InputProxy::show(InputCfg::rename().with_value(name).with_cursor(cursor));
 
+		tokio::spawn(async move {
+			let Some(Ok(name)) = input.recv().await else { return };
 			if name.is_empty() {
 				return;
 			}

--- a/yazi-core/src/tab/commands/cd.rs
+++ b/yazi-core/src/tab/commands/cd.rs
@@ -77,10 +77,10 @@ impl Tab {
 	}
 
 	fn cd_interactive(&mut self) {
-		tokio::spawn(async move {
-			let rx = InputProxy::show(InputCfg::cd());
+		let input = InputProxy::show(InputCfg::cd());
 
-			let rx = Debounce::new(UnboundedReceiverStream::new(rx), Duration::from_millis(50));
+		tokio::spawn(async move {
+			let rx = Debounce::new(UnboundedReceiverStream::new(input), Duration::from_millis(50));
 			pin!(rx);
 
 			while let Some(result) = rx.next().await {

--- a/yazi-core/src/tab/commands/filter.rs
+++ b/yazi-core/src/tab/commands/filter.rs
@@ -30,10 +30,10 @@ impl From<CmdCow> for Opt {
 impl Tab {
 	#[yazi_codegen::command]
 	pub fn filter(&mut self, opt: Opt) {
-		tokio::spawn(async move {
-			let rx = InputProxy::show(InputCfg::filter());
+		let input = InputProxy::show(InputCfg::filter());
 
-			let rx = Debounce::new(UnboundedReceiverStream::new(rx), Duration::from_millis(50));
+		tokio::spawn(async move {
+			let rx = Debounce::new(UnboundedReceiverStream::new(input), Duration::from_millis(50));
 			pin!(rx);
 
 			while let Some(result) = rx.next().await {

--- a/yazi-core/src/tab/commands/find.rs
+++ b/yazi-core/src/tab/commands/find.rs
@@ -25,10 +25,10 @@ impl From<CmdCow> for Opt {
 impl Tab {
 	#[yazi_codegen::command]
 	pub fn find(&mut self, opt: Opt) {
-		tokio::spawn(async move {
-			let rx = InputProxy::show(InputCfg::find(opt.prev));
+		let input = InputProxy::show(InputCfg::find(opt.prev));
 
-			let rx = Debounce::new(UnboundedReceiverStream::new(rx), Duration::from_millis(50));
+		tokio::spawn(async move {
+			let rx = Debounce::new(UnboundedReceiverStream::new(input), Duration::from_millis(50));
 			pin!(rx);
 
 			while let Some(Ok(s)) | Some(Err(InputError::Typed(s))) = rx.next().await {

--- a/yazi-proxy/src/options/search.rs
+++ b/yazi-proxy/src/options/search.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Display};
+use std::borrow::Cow;
 
 use yazi_shared::event::CmdCow;
 
@@ -35,31 +35,27 @@ impl TryFrom<CmdCow> for SearchOpt {
 // Via
 #[derive(PartialEq, Eq)]
 pub enum SearchOptVia {
-	// TODO: remove `None` in the future
-	None,
 	Rg,
-	Fd,
 	Rga,
+	Fd,
 }
 
 impl From<&str> for SearchOptVia {
 	fn from(value: &str) -> Self {
 		match value {
 			"rg" => Self::Rg,
-			"fd" => Self::Fd,
 			"rga" => Self::Rga,
-			_ => Self::None,
+			_ => Self::Fd,
 		}
 	}
 }
 
-impl Display for SearchOptVia {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.write_str(match self {
+impl AsRef<str> for SearchOptVia {
+	fn as_ref(&self) -> &str {
+		match self {
 			Self::Rg => "rg",
-			Self::Fd => "fd",
 			Self::Rga => "rga",
-			Self::None => "none",
-		})
+			Self::Fd => "fd",
+		}
 	}
 }

--- a/yazi-proxy/src/tab.rs
+++ b/yazi-proxy/src/tab.rs
@@ -25,7 +25,9 @@ impl TabProxy {
 	pub fn search_do(opt: SearchOpt) {
 		emit!(Call(
 			// TODO: use second positional argument instead of `args` parameter
-			Cmd::args("mgr:search_do", &[opt.subject]).with("via", opt.via).with("args", opt.args_raw)
+			Cmd::args("mgr:search_do", &[opt.subject])
+				.with("via", opt.via.as_ref())
+				.with("args", opt.args_raw)
 		));
 	}
 }


### PR DESCRIPTION
With this PR, you will be able to initialize the input components when running `create`, `rename`, `cd`, `filter`, `find`, `search`, and `shell` commands, for example:

```sh
{ on = "r", run = [ "rename", "input:escape" ] }
```

This will open the rename input box and exit insert mode, meaning the default state will be normal mode.