### PR TITLE
feat: new `ui.Text:scroll()` API for setting text to scroll horizontally or vertically

### DIFF
--- a/yazi-plugin/src/utils/preview.rs
+++ b/yazi-plugin/src/utils/preview.rs
@@ -52,6 +52,7 @@ impl Utils {
 				area,
 				inner,
 				wrap: if YAZI.preview.wrap == PreviewWrap::Yes { WRAP } else { WRAP_NO },
+				scroll: Default::default(),
 			})];
 
 			emit!(Call(Cmd::new("mgr:update_peeked").with_any("lock", lock)));


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2531

Closes https://github.com/sxyazi/yazi/issues/2531

---

```lua
local x, y = 10, 0
ui.Text("Never say never"):scroll(x, y)
```