### PR TITLE
fix: don't fail on videos with embedded images

### DIFF
--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -58,7 +58,7 @@ function M:preload(job)
 		"-skip_frame", "nokey", "-ss", ss,
 		"-an", "-sn", "-dn",
 		"-i", tostring(job.file.url),
-		"-map", "0:v", "-vframes", 1,
+		"-vframes", 1,
 		"-q:v", qv,
 		"-vf", string.format("scale=-1:'min(%d,ih)':flags=fast_bilinear", rt.preview.max_height),
 		"-f", "image2",


### PR DESCRIPTION
Currently, ffmpeg fails if video file contains embedded image.

```
[vf#0:1 @ 0x56848b4f5000] No filtered frames for output stream, trying to initialize anyway.
[mjpeg @ 0x75b41c45da40] Non full-range YUV is non-standard, set strict_std_compliance to at most unofficial to use it.
[mjpeg @ 0x56848b4e0280] ff_frame_thread_encoder_init failed
[vost#0:1/mjpeg @ 0x56848b4dffc0] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.
[vf#0:1 @ 0x56848b4e6f40] Task finished with error code: -22 (Invalid argument)
[vf#0:1 @ 0x56848b4e6f40] Terminating thread with return code -22 (Invalid argument)
[vost#0:1/mjpeg @ 0x56848b4dffc0] Could not open encoder before EOF
[vost#0:1/mjpeg @ 0x56848b4dffc0] Task finished with error code: -22 (Invalid argument)
[vost#0:1/mjpeg @ 0x56848b4dffc0] Terminating thread with return code -22 (Invalid argument)
[out#0/image2 @ 0x56848b29f240] Nothing was written into output file, because at least one of its streams received no packets.
```