### PR TITLE
feat: limit memory usage for previewing large images

### DIFF
--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -84,7 +84,7 @@ micro_workers    = 10
 macro_workers    = 10
 bizarre_retry    = 3
 image_alloc      = 536870912  # 512MB
-image_bound      = [ 0, 0 ]
+image_bound      = [ 5000, 5000 ]
 suppress_preload = false
 
 [plugin]

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -49,7 +49,7 @@ function M:spot(job) require("file"):spot(job) end
 function M.with_env()
 	local cmd = Command("magick"):env("MAGICK_THREAD_LIMIT", 1)
 	if rt.tasks.image_alloc > 0 then
-		cmd = cmd:env("MAGICK_MEMORY_LIMIT", rt.tasks.image_alloc)
+		cmd = cmd:env("MAGICK_MEMORY_LIMIT", rt.tasks.image_alloc):env("MAGICK_DISK_LIMIT", "1MiB")
 	end
 	return cmd
 end

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -24,7 +24,7 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_env()
+	local cmd = M.with_limit()
 	if job.args.flatten then
 		cmd = cmd:arg("-flatten")
 	end
@@ -46,10 +46,17 @@ end
 
 function M:spot(job) require("file"):spot(job) end
 
-function M.with_env()
-	local cmd = Command("magick"):env("MAGICK_THREAD_LIMIT", 1)
+function M.with_limit()
+	local cmd = Command("magick"):args { "-limit", "thread", 1 }
 	if rt.tasks.image_alloc > 0 then
-		cmd = cmd:env("MAGICK_MEMORY_LIMIT", rt.tasks.image_alloc):env("MAGICK_DISK_LIMIT", "1MiB")
+		cmd = cmd:args({ "-limit", "memory", rt.tasks.image_alloc }):args { "-limit", "disk", "1MiB" }
+	end
+	ya.dbg(rt.tasks.image_bound)
+	if rt.tasks.image_bound[1] > 0 then
+		cmd = cmd:args { "-limit", "width", rt.tasks.image_bound[1] }
+	end
+	if rt.tasks.image_bound[2] > 0 then
+		cmd = cmd:args { "-limit", "height", rt.tasks.image_bound[2] }
 	end
 	return cmd
 end

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -51,7 +51,6 @@ function M.with_limit()
 	if rt.tasks.image_alloc > 0 then
 		cmd = cmd:args({ "-limit", "memory", rt.tasks.image_alloc }):args { "-limit", "disk", "1MiB" }
 	end
-	ya.dbg(rt.tasks.image_bound)
 	if rt.tasks.image_bound[1] > 0 then
 		cmd = cmd:args { "-limit", "width", rt.tasks.image_bound[1] }
 	end


### PR DESCRIPTION
~Fixes https://github.com/sxyazi/yazi/issues/2598~ This limits the memory available to `magick`, but regardless, `magick` tries to scale the image anyway and fails. This is very wasteful, therefore it is not a solution.