### PR TITLE
feat: allow custom exit code with `quit --code`

### DIFF
--- a/yazi-core/src/mgr/commands/close.rs
+++ b/yazi-core/src/mgr/commands/close.rs
@@ -1,16 +1,24 @@
-use yazi_shared::event::CmdCow;
+use yazi_shared::event::{CmdCow, Data};
 
 use crate::{mgr::{Mgr, commands::quit}, tasks::Tasks};
 
 #[derive(Default)]
 struct Opt {
 	no_cwd_file: bool,
+	exit_code:   i32,
 }
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self { Self { no_cwd_file: c.bool("no-cwd-file") } }
+	fn from(c: CmdCow) -> Self {
+		Self {
+			no_cwd_file: c.bool("no-cwd-file"),
+			exit_code:   c.get("exit_code").and_then(Data::as_i32).unwrap_or_default(),
+		}
+	}
 }
 impl From<Opt> for quit::Opt {
-	fn from(value: Opt) -> Self { Self { no_cwd_file: value.no_cwd_file } }
+	fn from(value: Opt) -> Self {
+		Self { no_cwd_file: value.no_cwd_file, exit_code: value.exit_code }
+	}
 }
 
 impl Mgr {

--- a/yazi-core/src/mgr/commands/close.rs
+++ b/yazi-core/src/mgr/commands/close.rs
@@ -1,24 +1,12 @@
-use yazi_shared::event::{CmdCow, Data};
+use yazi_shared::event::CmdCow;
 
 use crate::{mgr::{Mgr, commands::quit}, tasks::Tasks};
 
 #[derive(Default)]
-struct Opt {
-	no_cwd_file: bool,
-	exit_code:   i32,
-}
+struct Opt(quit::Opt);
+
 impl From<CmdCow> for Opt {
-	fn from(c: CmdCow) -> Self {
-		Self {
-			no_cwd_file: c.bool("no-cwd-file"),
-			exit_code:   c.get("exit_code").and_then(Data::as_i32).unwrap_or_default(),
-		}
-	}
-}
-impl From<Opt> for quit::Opt {
-	fn from(value: Opt) -> Self {
-		Self { no_cwd_file: value.no_cwd_file, exit_code: value.exit_code }
-	}
+	fn from(c: CmdCow) -> Self { Self(c.into()) }
 }
 
 impl Mgr {
@@ -27,6 +15,6 @@ impl Mgr {
 		if self.tabs.len() > 1 {
 			return self.tabs.close(self.tabs.cursor);
 		}
-		self.quit(opt, tasks);
+		self.quit(opt.0, tasks);
 	}
 }

--- a/yazi-core/src/mgr/commands/open.rs
+++ b/yazi-core/src/mgr/commands/open.rs
@@ -1,20 +1,18 @@
-use std::{borrow::Cow, ffi::OsString};
+use std::borrow::Cow;
 
 use tracing::error;
-use yazi_boot::ARGS;
 use yazi_config::{YAZI, popup::PickCfg};
 use yazi_fs::File;
-use yazi_macro::emit;
 use yazi_plugin::isolate;
 use yazi_proxy::{MgrProxy, PickProxy, TasksProxy, options::OpenDoOpt};
-use yazi_shared::{MIME_DIR, event::{CmdCow, EventQuit}, url::Url};
+use yazi_shared::{MIME_DIR, event::CmdCow, url::Url};
 
 use crate::{mgr::Mgr, tab::Folder, tasks::Tasks};
 
 #[derive(Clone, Copy)]
-struct Opt {
-	interactive: bool,
-	hovered:     bool,
+pub(super) struct Opt {
+	pub(super) interactive: bool,
+	pub(super) hovered:     bool,
 }
 
 impl From<CmdCow> for Opt {
@@ -119,20 +117,5 @@ impl Mgr {
 			|| find(self.parent())
 			|| find(self.hovered_folder())
 			|| find(self.active().history.get(&p))
-	}
-
-	fn quit_with_selected(opt: Opt, selected: &[&Url]) -> bool {
-		if opt.interactive || ARGS.chooser_file.is_none() {
-			return false;
-		}
-
-		let paths = selected.iter().fold(OsString::new(), |mut s, &u| {
-			s.push(u.as_os_str());
-			s.push("\n");
-			s
-		});
-
-		emit!(Quit(EventQuit { selected: Some(paths), ..Default::default() }));
-		true
 	}
 }

--- a/yazi-core/src/mgr/commands/quit.rs
+++ b/yazi-core/src/mgr/commands/quit.rs
@@ -1,32 +1,39 @@
-use std::time::Duration;
+use std::{ffi::OsString, time::Duration};
 
 use tokio::{select, time};
+use yazi_boot::ARGS;
 use yazi_config::popup::ConfirmCfg;
 use yazi_macro::emit;
 use yazi_proxy::ConfirmProxy;
-use yazi_shared::event::{CmdCow, Data, EventQuit};
+use yazi_shared::{event::{CmdCow, Data, EventQuit}, url::Url};
 
 use crate::{mgr::Mgr, tasks::Tasks};
 
 #[derive(Default)]
 pub(super) struct Opt {
+	pub(super) code:        i32,
 	pub(super) no_cwd_file: bool,
-	pub(super) exit_code:   i32,
 }
+
 impl From<CmdCow> for Opt {
 	fn from(c: CmdCow) -> Self {
 		Self {
+			code:        c.get("code").and_then(Data::as_i32).unwrap_or_default(),
 			no_cwd_file: c.bool("no-cwd-file"),
-			exit_code:   c.get("exit_code").and_then(Data::as_i32).unwrap_or_default(),
 		}
+	}
+}
+
+impl From<Opt> for EventQuit {
+	fn from(value: Opt) -> Self {
+		EventQuit { code: value.code, no_cwd_file: value.no_cwd_file, ..Default::default() }
 	}
 }
 
 impl Mgr {
 	#[yazi_codegen::command]
 	pub fn quit(&self, opt: Opt, tasks: &Tasks) {
-		let opt =
-			EventQuit { no_cwd_file: opt.no_cwd_file, exit_code: opt.exit_code, ..Default::default() };
+		let event = opt.into();
 
 		let ongoing = tasks.ongoing().clone();
 		let (left, left_names) = {
@@ -35,7 +42,7 @@ impl Mgr {
 		};
 
 		if left == 0 {
-			emit!(Quit(opt));
+			emit!(Quit(event));
 			return;
 		}
 
@@ -48,13 +55,13 @@ impl Mgr {
 						i += 1;
 						if i > 40 { break }
 						else if ongoing.lock().is_empty() {
-							emit!(Quit(opt));
+							emit!(Quit(event));
 							return;
 						}
 					}
 					b = &mut rx => {
 						if b.unwrap_or(false) {
-							emit!(Quit(opt));
+							emit!(Quit(event));
 						}
 						return;
 					}
@@ -62,8 +69,23 @@ impl Mgr {
 			}
 
 			if rx.await.unwrap_or(false) {
-				emit!(Quit(opt));
+				emit!(Quit(event));
 			}
 		});
+	}
+
+	pub(super) fn quit_with_selected(opt: super::open::Opt, selected: &[&Url]) -> bool {
+		if opt.interactive || ARGS.chooser_file.is_none() {
+			return false;
+		}
+
+		let paths = selected.iter().fold(OsString::new(), |mut s, &u| {
+			s.push(u.as_os_str());
+			s.push("\n");
+			s
+		});
+
+		emit!(Quit(EventQuit { selected: Some(paths), ..Default::default() }));
+		true
 	}
 }

--- a/yazi-fm/src/app/commands/quit.rs
+++ b/yazi-fm/src/app/commands/quit.rs
@@ -19,7 +19,7 @@ impl App {
 			self.selected_to_file(selected);
 		}
 
-		Term::goodbye(|| opt.exit_code);
+		Term::goodbye(|| opt.code);
 	}
 
 	fn cwd_to_file(&self) {

--- a/yazi-fm/src/app/commands/quit.rs
+++ b/yazi-fm/src/app/commands/quit.rs
@@ -19,7 +19,7 @@ impl App {
 			self.selected_to_file(selected);
 		}
 
-		Term::goodbye(|| false);
+		Term::goodbye(|| opt.exit_code);
 	}
 
 	fn cwd_to_file(&self) {

--- a/yazi-fm/src/panic.rs
+++ b/yazi-fm/src/panic.rs
@@ -10,7 +10,7 @@ impl Panic {
 		std::panic::set_hook(Box::new(move |info| {
 			Term::goodbye(|| {
 				hook(info);
-				true as i32
+				1
 			});
 		}));
 	}

--- a/yazi-fm/src/panic.rs
+++ b/yazi-fm/src/panic.rs
@@ -10,7 +10,7 @@ impl Panic {
 		std::panic::set_hook(Box::new(move |info| {
 			Term::goodbye(|| {
 				hook(info);
-				true
+				true as i32
 			});
 		}));
 	}

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -89,7 +89,7 @@ impl Term {
 		Ok(disable_raw_mode()?)
 	}
 
-	pub(super) fn goodbye(f: impl FnOnce() -> bool) -> ! {
+	pub(super) fn goodbye(f: impl FnOnce() -> i32) -> ! {
 		if CSI_U.swap(false, Ordering::Relaxed) {
 			PopKeyboardEnhancementFlags.write_ansi(&mut TTY.writer()).ok();
 		}
@@ -111,7 +111,7 @@ impl Term {
 
 		disable_raw_mode().ok();
 
-		std::process::exit(f() as i32);
+		std::process::exit(f());
 	}
 
 	pub(super) fn draw(&mut self, f: impl FnOnce(&mut Frame)) -> io::Result<CompletedFrame> {

--- a/yazi-shared/src/event/data.rs
+++ b/yazi-shared/src/event/data.rs
@@ -182,6 +182,7 @@ macro_rules! impl_number_as {
 impl_integer_as!(usize, as_usize);
 impl_integer_as!(isize, as_isize);
 impl_integer_as!(i16, as_i16);
+impl_integer_as!(i32, as_i32);
 
 impl_number_as!(f64, as_f64);
 

--- a/yazi-shared/src/event/event.rs
+++ b/yazi-shared/src/event/event.rs
@@ -24,6 +24,7 @@ pub enum Event {
 #[derive(Debug, Default)]
 pub struct EventQuit {
 	pub no_cwd_file: bool,
+	pub exit_code:   i32,
 	pub selected:    Option<OsString>,
 }
 

--- a/yazi-shared/src/event/event.rs
+++ b/yazi-shared/src/event/event.rs
@@ -23,8 +23,8 @@ pub enum Event {
 
 #[derive(Debug, Default)]
 pub struct EventQuit {
+	pub code:        i32,
 	pub no_cwd_file: bool,
-	pub exit_code:   i32,
 	pub selected:    Option<OsString>,
 }
 


### PR DESCRIPTION
Hi! Very cool project, I recently started using it and have a (not too obscure in my opinion) use case: When integrating yazi with other tools, it is useful to be able to return with a non-zero exit code. An example for this is the pager for https://github.com/aurutils/aurutils 

I don't think it is possible to do this via a plugin (except for maybe somehow purposefully panicking from lua), so I added an option to the quit command.

Hope this is helpful.