### PR TITLE
feat: new `ya.emit()` API

### DIFF
--- a/yazi-plugin/preset/components/current.lua
+++ b/yazi-plugin/preset/components/current.lua
@@ -56,12 +56,12 @@ function Current:click(event, up)
 		return
 	end
 
-	ya.mgr_emit("arrow", { y + f.offset - f.hovered.idx })
+	ya.emit("arrow", { y + f.offset - f.hovered.idx })
 	if event.is_right then
-		ya.mgr_emit("open", {})
+		ya.emit("open", {})
 	end
 end
 
-function Current:scroll(event, step) ya.mgr_emit("arrow", { step }) end
+function Current:scroll(event, step) ya.emit("arrow", { step }) end
 
 function Current:touch(event, step) end

--- a/yazi-plugin/preset/components/parent.lua
+++ b/yazi-plugin/preset/components/parent.lua
@@ -36,9 +36,9 @@ function Parent:click(event, up)
 	local y = event.y - self._area.y + 1
 	local window = self._folder and self._folder.window or {}
 	if window[y] then
-		ya.mgr_emit("reveal", { window[y].url })
+		ya.emit("reveal", { window[y].url })
 	else
-		ya.mgr_emit("leave", {})
+		ya.emit("leave", {})
 	end
 end
 

--- a/yazi-plugin/preset/components/preview.lua
+++ b/yazi-plugin/preset/components/preview.lua
@@ -23,12 +23,12 @@ function Preview:click(event, up)
 	local y = event.y - self._area.y + 1
 	local window = self._folder and self._folder.window or {}
 	if window[y] then
-		ya.mgr_emit("reveal", { window[y].url })
+		ya.emit("reveal", { window[y].url })
 	else
-		ya.mgr_emit("enter", {})
+		ya.emit("enter", {})
 	end
 end
 
-function Preview:scroll(event, step) ya.mgr_emit("seek", { step }) end
+function Preview:scroll(event, step) ya.emit("seek", { step }) end
 
 function Preview:touch(event, step) end

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -33,7 +33,7 @@ function M:peek(job)
 	end
 
 	if job.skip > 0 and bound < job.skip + limit then
-		ya.mgr_emit("peek", { math.max(0, bound - limit), only_if = job.file.url, upper_bound = true })
+		ya.emit("peek", { math.max(0, bound - limit), only_if = job.file.url, upper_bound = true })
 	else
 		ya.preview_widgets(job, {
 			ui.Text(paths):area(job.area),

--- a/yazi-plugin/preset/plugins/code.lua
+++ b/yazi-plugin/preset/plugins/code.lua
@@ -3,7 +3,7 @@ local M = {}
 function M:peek(job)
 	local err, bound = ya.preview_code(job)
 	if bound then
-		ya.mgr_emit("peek", { bound, only_if = job.file.url, upper_bound = true })
+		ya.emit("peek", { bound, only_if = job.file.url, upper_bound = true })
 	elseif err and not err:find("cancelled", 1, true) then
 		require("empty").msg(job, err)
 	end
@@ -18,7 +18,7 @@ function M:seek(job)
 	local step = math.floor(job.units * job.area.h / 10)
 	step = step == 0 and ya.clamp(-1, job.units, 1) or step
 
-	ya.mgr_emit("peek", {
+	ya.emit("peek", {
 		math.max(0, cx.active.preview.skip + step),
 		only_if = job.file.url,
 	})

--- a/yazi-plugin/preset/plugins/dds.lua
+++ b/yazi-plugin/preset/plugins/dds.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M:setup()
-	ps.sub_remote("dds-emit", function(cmd) ya.mgr_emit(cmd[1], cmd[2]) end)
+	ps.sub_remote("dds-emit", function(cmd) ya.emit(cmd[1], cmd[2]) end)
 end
 
 return M

--- a/yazi-plugin/preset/plugins/empty.lua
+++ b/yazi-plugin/preset/plugins/empty.lua
@@ -41,7 +41,7 @@ function M:peek(job)
 	end
 
 	if job.skip > 0 and i < job.skip + limit then
-		ya.mgr_emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
+		ya.emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
 		ya.preview_widgets(job, { ui.Text(lines):area(job.area) })
 	end

--- a/yazi-plugin/preset/plugins/extract.lua
+++ b/yazi-plugin/preset/plugins/extract.lua
@@ -6,7 +6,7 @@ function M:setup()
 	ps.sub_remote("extract", function(args)
 		local noisy = #args == 1 and ' "" --noisy' or ' ""'
 		for _, arg in ipairs(args) do
-			ya.mgr_emit("plugin", { self._id, ya.quote(arg, true) .. noisy })
+			ya.emit("plugin", { self._id, ya.quote(arg, true) .. noisy })
 		end
 	end)
 end

--- a/yazi-plugin/preset/plugins/folder.lua
+++ b/yazi-plugin/preset/plugins/folder.lua
@@ -10,7 +10,7 @@ function M:peek(job)
 
 	local bound = math.max(0, #folder.files - job.area.h)
 	if job.skip > bound then
-		return ya.mgr_emit("peek", { bound, only_if = job.file.url, upper_bound = true })
+		return ya.emit("peek", { bound, only_if = job.file.url, upper_bound = true })
 	end
 
 	if #folder.files == 0 then
@@ -37,7 +37,7 @@ function M:seek(job)
 	if folder and folder.cwd == job.file.url then
 		local step = math.floor(job.units * job.area.h / 10)
 		local bound = math.max(0, #folder.files - job.area.h)
-		ya.mgr_emit("peek", {
+		ya.emit("peek", {
 			ya.clamp(0, cx.active.preview.skip + step, bound),
 			only_if = job.file.url,
 		})

--- a/yazi-plugin/preset/plugins/fzf.lua
+++ b/yazi-plugin/preset/plugins/fzf.lua
@@ -9,7 +9,7 @@ local state = ya.sync(function()
 end)
 
 function M:entry()
-	ya.mgr_emit("escape", { visual = true })
+	ya.emit("escape", { visual = true })
 
 	local _permit = ya.hide()
 	local cwd, selected = state()
@@ -22,10 +22,10 @@ function M:entry()
 	local urls = M.split_urls(cwd, output)
 	if #urls == 1 then
 		local cha = #selected == 0 and fs.cha(urls[1])
-		ya.mgr_emit(cha and cha.is_dir and "cd" or "reveal", { urls[1] })
+		ya.emit(cha and cha.is_dir and "cd" or "reveal", { urls[1] })
 	elseif #urls > 1 then
 		urls.state = #selected > 0 and "off" or "on"
-		ya.mgr_emit("toggle_all", urls)
+		ya.emit("toggle_all", urls)
 	end
 end
 

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -29,7 +29,7 @@ function M:peek(job)
 
 	child:start_kill()
 	if job.skip > 0 and i < job.skip + limit then
-		ya.mgr_emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
+		ya.emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
 		lines = lines:gsub("\t", string.rep(" ", rt.preview.tab_size))
 		ya.preview_widgets(job, {

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -27,7 +27,7 @@ function M:fetch(job)
 			return
 		end
 		if next(updates) then
-			ya.mgr_emit("update_mimes", { updates = updates })
+			ya.emit("update_mimes", { updates = updates })
 			updates, last = {}, ya.time()
 		end
 	end

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -20,7 +20,7 @@ function M:seek(job)
 	local h = cx.active.current.hovered
 	if h and h.url == job.file.url then
 		local step = ya.clamp(-1, job.units, 1)
-		ya.mgr_emit("peek", { math.max(0, cx.active.preview.skip + step), only_if = job.file.url })
+		ya.emit("peek", { math.max(0, cx.active.preview.skip + step), only_if = job.file.url })
 	end
 end
 
@@ -49,7 +49,7 @@ function M:preload(job)
 	elseif not output.status.success then
 		local pages = tonumber(output.stderr:match("the last page %((%d+)%)")) or 0
 		if job.skip > 0 and pages > 0 then
-			ya.mgr_emit("peek", { math.max(0, pages - 1), only_if = job.file.url, upper_bound = true })
+			ya.emit("peek", { math.max(0, pages - 1), only_if = job.file.url, upper_bound = true })
 		end
 		return true, Err("Failed to convert PDF to image, stderr: %s", output.stderr)
 	end

--- a/yazi-plugin/preset/plugins/session.lua
+++ b/yazi-plugin/preset/plugins/session.lua
@@ -1,6 +1,6 @@
 local function setup(_, opts)
 	if opts.sync_yanked then
-		ps.sub_remote("@yank", function(body) ya.mgr_emit("update_yanked", { cut = body.cut, urls = body }) end)
+		ps.sub_remote("@yank", function(body) ya.emit("update_yanked", { cut = body.cut, urls = body }) end)
 	end
 end
 

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -19,7 +19,7 @@ end
 function M:seek(job)
 	local h = cx.active.current.hovered
 	if h and h.url == job.file.url then
-		ya.mgr_emit("peek", {
+		ya.emit("peek", {
 			math.max(0, cx.active.preview.skip + job.units),
 			only_if = job.file.url,
 		})
@@ -47,7 +47,7 @@ function M:preload(job)
 	local pic = M.has_pic(meta)
 	local percent = (pic and 0 or 5) + job.skip
 	if percent > 95 then
-		ya.mgr_emit("peek", { pic and 95 or 90, only_if = job.file.url, upper_bound = true })
+		ya.emit("peek", { pic and 95 or 90, only_if = job.file.url, upper_bound = true })
 		return false
 	end
 

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -66,7 +66,7 @@ local function setup(_, opts)
 		ps.sub(
 			"cd",
 			function()
-				ya.mgr_emit("shell", {
+				ya.emit("shell", {
 					cwd = fs.cwd(),
 					orphan = true,
 					"zoxide add " .. ya.quote(tostring(cx.active.current.cwd)),
@@ -113,7 +113,7 @@ local function entry()
 
 	local target = output.stdout:gsub("\n$", "")
 	if target ~= "" then
-		ya.mgr_emit("cd", { target })
+		ya.emit("cd", { target })
 	end
 end
 

--- a/yazi-plugin/src/utils/call.rs
+++ b/yazi-plugin/src/utils/call.rs
@@ -38,8 +38,21 @@ impl Utils {
 		})
 	}
 
+	pub(super) fn emit(lua: &Lua) -> mlua::Result<Function> {
+		lua.create_function(|_, (name, args): (mlua::String, Table)| {
+			let mut cmd = Cmd::new_or(&name.to_str()?, Layer::Mgr)?;
+			cmd.args = Sendable::table_to_args(args)?;
+			Ok(emit!(Call(cmd)))
+		})
+	}
+
+	// TODO: remove
 	pub(super) fn app_emit(lua: &Lua) -> mlua::Result<Function> {
-		lua.create_function(|_, (name, args): (String, Table)| {
+		lua.create_function(|lua, (name, args): (String, Table)| {
+			crate::deprecate!(
+				lua,
+				"`ya.app_emit()` is deprecated, use `ya.emit()` instead, in your {}\n\nSee #2653 for more details: https://github.com/sxyazi/yazi/pull/2653"
+			);
 			emit!(Call(Cmd { name, args: Sendable::table_to_args(args)?, layer: Layer::App }));
 			Ok(())
 		})
@@ -52,8 +65,13 @@ impl Utils {
 		})
 	}
 
+	// TODO: remove
 	pub(super) fn input_emit(lua: &Lua) -> mlua::Result<Function> {
-		lua.create_function(|_, (name, args): (String, Table)| {
+		lua.create_function(|lua, (name, args): (String, Table)| {
+			crate::deprecate!(
+				lua,
+				"`ya.input_emit()` is deprecated, use `ya.emit()` instead, in your {}\n\nSee #2653 for more details: https://github.com/sxyazi/yazi/pull/2653"
+			);
 			emit!(Call(Cmd { name, args: Sendable::table_to_args(args)?, layer: Layer::Input }));
 			Ok(())
 		})

--- a/yazi-plugin/src/utils/utils.rs
+++ b/yazi-plugin/src/utils/utils.rs
@@ -17,6 +17,7 @@ pub fn compose(lua: &Lua, isolate: bool) -> mlua::Result<Value> {
 			// Call
 			b"render" => Utils::render(lua)?,
 			b"redraw_with" => Utils::redraw_with(lua)?,
+			b"emit" => Utils::emit(lua)?,
 			b"app_emit" => Utils::app_emit(lua)?,
 			b"mgr_emit" => Utils::mgr_emit(lua)?,
 			b"manager_emit" => Utils::mgr_emit(lua)?, // TODO: remove this in the future

--- a/yazi-shared/src/event/cmd.rs
+++ b/yazi-shared/src/event/cmd.rs
@@ -15,12 +15,17 @@ pub struct Cmd {
 
 impl Cmd {
 	pub fn new(s: &str) -> Self {
+		Self::new_or(s, Default::default())
+			.unwrap_or_else(|_| Self { name: "null".to_owned(), ..Default::default() })
+	}
+
+	pub fn new_or(s: &str, default: Layer) -> Result<Self> {
 		let (layer, name) = match s.split_once(':') {
-			Some((l, n)) => (Layer::from_str(l).unwrap_or_default(), n),
-			None => (Layer::default(), s),
+			Some((l, n)) => (l.parse()?, n),
+			None => (default, s),
 		};
 
-		Self { name: name.to_owned(), args: Default::default(), layer }
+		Ok(Self { name: name.to_owned(), args: Default::default(), layer })
 	}
 
 	pub fn args(name: &str, args: &[impl ToString]) -> Self {


### PR DESCRIPTION
This PR introduces a new `ya.emit()` API to address:

- The existing `ya.mgr_emit()` API can only emit events to `[manager]`.
- The existing `ya.app_emit()` and `ya.input_emit()` can be used to emit events to `[app]` and `[input]`, but they are private and undocumented APIs.
- There is no available API to send events to `[tasks]`, `[spot]`, `[pick]`, `[confirm]`, `[cmp]`, or `[help]`.

The first parameter of `ya.emit()` is the event ID in the format `component:event`, where the `component:` part is optional and defaults to `[manager]`, for example:

```lua
ya.emit("arrow", { 1 })  -- Emit an "arrow" event to [manager]
ya.emit("cmp:arrow", { 1 })  -- Emit an "arrow" event to [cmp]
```

The second parameter is the parameters for the event.

## Deprecated

### `ya.mgr_emit()` is deprecated

`ya.emit()` can be used as a direct replacement for `ya.mgr_emit()`:

```diff
- ya.mgr_emit("arrow", { 1 })
+ ya.emit("arrow", { 1 })
```

Since `ya.mgr_emit()` is a public and widely used API, it will remain available for a long time and will later include a deprecation warning before eventually being removed.

### `ya.app_emit()` and `ya.input_emit()` are deprecated

`ya.app_emit()` and `ya.input_emit()` are private and undocumented APIs. However, since they have been around for a long time, this PR marks them as deprecated and they will be removed in the future.

```diff
- ya.app_emit("resize", {})
+ ya.emit("app:resize", {})
```

```diff
- ya.input_emit("close", {})
+ ya.emit("input:close", {})
```