### PR TITLE
perf: double directory size calculation speed

### DIFF
--- a/yazi-config/src/keymap/key.rs
+++ b/yazi-config/src/keymap/key.rs
@@ -198,6 +198,6 @@ impl Display for Key {
 			_ => "Unknown",
 		};
 
-		write!(f, "{}>", code)
+		write!(f, "{code}>")
 	}
 }

--- a/yazi-fs/src/calculator.rs
+++ b/yazi-fs/src/calculator.rs
@@ -1,0 +1,96 @@
+use std::{collections::VecDeque, fs::ReadDir, future::poll_fn, mem, path::{Path, PathBuf}, pin::Pin, task::{Poll, ready}, time::{Duration, Instant}};
+
+use tokio::task::JoinHandle;
+use yazi_shared::Either;
+
+type Task = Either<PathBuf, ReadDir>;
+
+pub enum SizeCalculator {
+	Idle((VecDeque<Task>, Option<u64>)),
+	Pending(JoinHandle<(VecDeque<Task>, Option<u64>)>),
+}
+
+impl SizeCalculator {
+	pub async fn new(path: impl AsRef<Path>) -> std::io::Result<Self> {
+		let p = path.as_ref().to_owned();
+		tokio::task::spawn_blocking(|| {
+			let mut buf = VecDeque::from([Either::Right(std::fs::read_dir(p)?)]);
+			let size = Self::next_chunk(&mut buf);
+			Ok(Self::Idle((buf, size)))
+		})
+		.await?
+	}
+
+	pub async fn total(path: impl AsRef<Path>) -> std::io::Result<u64> {
+		let mut it = Self::new(path).await?;
+		let mut total = 0;
+		while let Some(n) = it.next().await? {
+			total += n;
+		}
+		Ok(total)
+	}
+
+	pub async fn next(&mut self) -> std::io::Result<Option<u64>> {
+		poll_fn(|cx| {
+			loop {
+				match self {
+					Self::Idle((buf, size)) => {
+						if let Some(s) = size.take() {
+							return Poll::Ready(Ok(Some(s)));
+						} else if buf.is_empty() {
+							return Poll::Ready(Ok(None));
+						}
+
+						let mut buf = mem::take(buf);
+						*self = Self::Pending(tokio::task::spawn_blocking(move || {
+							let size = Self::next_chunk(&mut buf);
+							(buf, size)
+						}));
+					}
+					Self::Pending(handle) => {
+						*self = Self::Idle(ready!(Pin::new(handle).poll(cx))?);
+					}
+				}
+			}
+		})
+		.await
+	}
+
+	fn next_chunk(buf: &mut VecDeque<Either<PathBuf, ReadDir>>) -> Option<u64> {
+		let (mut i, mut size, now) = (0, 0, Instant::now());
+		macro_rules! pop_and_continue {
+			() => {{
+				buf.pop_front();
+				if buf.is_empty() {
+					return Some(size);
+				}
+				continue;
+			}};
+		}
+
+		while i < 5000 && now.elapsed() < Duration::from_millis(50) {
+			i += 1;
+			let front = buf.front_mut()?;
+
+			if let Either::Left(p) = front {
+				*front = match std::fs::read_dir(p) {
+					Ok(it) => Either::Right(it),
+					Err(_) => pop_and_continue!(),
+				};
+			}
+
+			let Some(next) = front.right_mut()?.next() else {
+				pop_and_continue!();
+			};
+
+			let Ok(ent) = next else { continue };
+			let Ok(ft) = ent.file_type() else { continue };
+			if ft.is_dir() {
+				buf.push_back(Either::Left(ent.path()));
+			} else {
+				size += ent.metadata().map(|m| m.len()).unwrap_or(0);
+			}
+		}
+		Some(size)
+	}
+}

--- a/yazi-fs/src/lib.rs
+++ b/yazi-fs/src/lib.rs
@@ -2,7 +2,7 @@
 
 yazi_macro::mod_pub!(cha mounts);
 
-yazi_macro::mod_flat!(cwd file files filter fns op path sorter sorting stage step xdg);
+yazi_macro::mod_flat!(calculator cwd file files filter fns op path sorter sorting stage step xdg);
 
 pub fn init() {
 	CWD.init(<_>::default());

--- a/yazi-scheduler/src/prework/prework.rs
+++ b/yazi-scheduler/src/prework/prework.rs
@@ -6,7 +6,7 @@ use parking_lot::{Mutex, RwLock};
 use tokio::sync::mpsc;
 use tracing::error;
 use yazi_config::Priority;
-use yazi_fs::{FilesOp, calculate_size};
+use yazi_fs::{FilesOp, SizeCalculator};
 use yazi_plugin::isolate;
 use yazi_shared::{event::CmdCow, url::Url};
 
@@ -73,7 +73,7 @@ impl Prework {
 				self.prog.send(TaskProg::Adv(task.id, 1, 0))?;
 			}
 			PreworkOp::Size(task) => {
-				let length = calculate_size(&task.target).await;
+				let length = SizeCalculator::total(&task.target).await?;
 				task.throttle.done((task.target, length), |buf| {
 					{
 						let mut loading = self.size_loading.write();


### PR DESCRIPTION
This PR greatly improves directory computation performance by dividing the task into chunks and reusing existing threads. Directory sorting and file trashing will be observably twice as fast.

By leveraging chunking, it now can produce real-time directory statistics reports. This means that for a large directory, you will be able to see the process of size changes in real-time, which is beneficial for the upcoming `fs.dir_size()` API.

The new implementation is still async cancelable, which is important for using `fs.dir_size()` in spotters, as it will allow canceling a still-incomplete directory computation when quickly switching between files, thereby avoiding wasted resources.

## Benchmark

```rust
let p = std::path::Path::new("/tmp/yazi");

let now = std::time::Instant::now();
yazi_fs::calculate_size(p).await;
println!("Old: elapsed {:?}", now.elapsed());

let now = std::time::Instant::now();
yazi_fs::SizeCalculator::total(p).await?;
println!("New: elapsed {:?}", now.elapsed());
```

Run the benchmark script against a 10.16GB folder 5 times in release mode:

```sh
Old: elapsed 759.877791ms
New: elapsed 364.802583ms

Old: elapsed 734.5155ms
New: elapsed 360.103375ms

Old: elapsed 734.124167ms
New: elapsed 365.662458ms

Old: elapsed 733.27325ms
New: elapsed 365.694042ms

Old: elapsed 743.394875ms
New: elapsed 364.455083ms
```