### PR TITLE
feat: calculate real-time directory size in spotter

### DIFF
--- a/yazi-binding/src/lib.rs
+++ b/yazi-binding/src/lib.rs
@@ -1,3 +1,3 @@
 mod macros;
 
-yazi_macro::mod_flat!(error id stage url);
+yazi_macro::mod_flat!(error id stage url urn);

--- a/yazi-binding/src/url.rs
+++ b/yazi-binding/src/url.rs
@@ -2,7 +2,7 @@ use std::{ops::Deref, path::Path};
 
 use mlua::{AnyUserData, ExternalError, FromLua, Lua, MetaMethod, UserData, UserDataFields, UserDataMethods, UserDataRef, Value};
 
-use crate::cached_field;
+use crate::{Urn, cached_field};
 
 pub type UrlRef = UserDataRef<Url>;
 
@@ -12,6 +12,7 @@ pub struct Url {
 	v_name:   Option<Value>,
 	v_stem:   Option<Value>,
 	v_ext:    Option<Value>,
+	v_urn:    Option<Value>,
 	v_base:   Option<Value>,
 	v_parent: Option<Value>,
 	v_frag:   Option<Value>,
@@ -39,6 +40,7 @@ impl Url {
 			v_name:   None,
 			v_stem:   None,
 			v_ext:    None,
+			v_urn:    None,
 			v_base:   None,
 			v_parent: None,
 			v_frag:   None,
@@ -83,6 +85,7 @@ impl UserData for Url {
 			me.extension().map(|s| lua.create_string(s.as_encoded_bytes())).transpose()
 		});
 		cached_field!(fields, parent, |_, me| Ok(me.parent_url().map(Self::new)));
+		cached_field!(fields, urn, |_, me| Ok(Urn::new(me.urn_owned())));
 		cached_field!(fields, base, |_, me| {
 			Ok(if me.base().as_os_str().is_empty() { None } else { Some(Self::new(me.base())) })
 		});

--- a/yazi-binding/src/urn.rs
+++ b/yazi-binding/src/urn.rs
@@ -1,0 +1,32 @@
+use std::ops::Deref;
+
+use mlua::{ExternalError, FromLua, Lua, UserData, Value};
+
+pub struct Urn {
+	inner: yazi_shared::url::UrnBuf,
+}
+
+impl Deref for Urn {
+	type Target = yazi_shared::url::UrnBuf;
+
+	fn deref(&self) -> &Self::Target { &self.inner }
+}
+
+impl From<Urn> for yazi_shared::url::UrnBuf {
+	fn from(value: Urn) -> Self { value.inner }
+}
+
+impl Urn {
+	pub fn new(urn: yazi_shared::url::UrnBuf) -> Self { Self { inner: urn } }
+}
+
+impl FromLua for Urn {
+	fn from_lua(value: Value, _: &Lua) -> mlua::Result<Self> {
+		Ok(match value {
+			Value::UserData(ud) => ud.take()?,
+			_ => Err("Expected a Urn".into_lua_err())?,
+		})
+	}
+}
+
+impl UserData for Urn {}

--- a/yazi-core/src/mgr/commands/update_mimes.rs
+++ b/yazi-core/src/mgr/commands/update_mimes.rs
@@ -20,7 +20,7 @@ impl TryFrom<CmdCow> for Opt {
 
 impl Mgr {
 	pub fn update_mimes(&mut self, opt: impl TryInto<Opt>, tasks: &Tasks) {
-		let Ok(opt) = opt.try_into() else {
+		let Ok(opt): Result<Opt, _> = opt.try_into() else {
 			return error!("invalid arguments for update_mimes");
 		};
 

--- a/yazi-core/src/spot/commands/close.rs
+++ b/yazi-core/src/spot/commands/close.rs
@@ -1,4 +1,3 @@
-use yazi_macro::render;
 use yazi_shared::event::CmdCow;
 
 use crate::spot::Spot;
@@ -14,8 +13,5 @@ impl From<()> for Opt {
 
 impl Spot {
 	#[yazi_codegen::command]
-	pub fn close(&mut self, _: Opt) {
-		self.abort();
-		render!(self.lock.take().is_some());
-	}
+	pub fn close(&mut self, _: Opt) { self.reset(); }
 }

--- a/yazi-core/src/spot/spot.rs
+++ b/yazi-core/src/spot/spot.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use tokio_util::sync::CancellationToken;
 use yazi_config::YAZI;
 use yazi_fs::File;
+use yazi_macro::render;
 use yazi_plugin::{isolate, utils::SpotLock};
 use yazi_shared::url::Url;
 
@@ -35,6 +36,12 @@ impl Spot {
 
 	#[inline]
 	pub fn abort(&mut self) { self.ct.take().map(|ct| ct.cancel()); }
+
+	#[inline]
+	pub fn reset(&mut self) {
+		self.abort();
+		render!(self.lock.take().is_some());
+	}
 
 	#[inline]
 	pub fn same_url(&self, url: &Url) -> bool { self.lock.as_ref().is_some_and(|l| *url == l.url) }

--- a/yazi-core/src/tab/commands/update_spotted.rs
+++ b/yazi-core/src/tab/commands/update_spotted.rs
@@ -19,10 +19,10 @@ impl TryFrom<CmdCow> for Opt {
 impl Tab {
 	pub fn update_spotted(&mut self, opt: impl TryInto<Opt>) {
 		let Some(hovered) = self.hovered().map(|h| &h.url) else {
-			return self.preview.reset();
+			return self.spot.reset();
 		};
 
-		let Ok(opt) = opt.try_into() else {
+		let Ok(mut opt): Result<Opt, _> = opt.try_into() else {
 			return;
 		};
 
@@ -30,7 +30,14 @@ impl Tab {
 			return;
 		}
 
-		self.spot.skip = opt.lock.selected().unwrap_or_default();
+		if self.spot.lock.as_ref().is_none_or(|l| l.id != opt.lock.id) {
+			self.spot.skip = opt.lock.selected().unwrap_or_default();
+		} else if let Some(s) = opt.lock.selected() {
+			self.spot.skip = s;
+		} else {
+			opt.lock.select(Some(self.spot.skip));
+		}
+
 		self.spot.lock = Some(opt.lock);
 		render!();
 	}

--- a/yazi-fs/src/files.rs
+++ b/yazi-fs/src/files.rs
@@ -129,7 +129,11 @@ impl Files {
 		}
 	}
 
-	pub fn update_size(&mut self, sizes: HashMap<UrnBuf, u64>) {
+	pub fn update_size(&mut self, mut sizes: HashMap<UrnBuf, u64>) {
+		if sizes.len() <= 50 {
+			sizes.retain(|k, v| self.sizes.get(k) != Some(v));
+		}
+
 		if sizes.is_empty() {
 			return;
 		}

--- a/yazi-plugin/preset/plugins/folder.lua
+++ b/yazi-plugin/preset/plugins/folder.lua
@@ -44,6 +44,50 @@ function M:seek(job)
 	end
 end
 
-function M:spot(job) require("file"):spot(job) end
+function M:spot(job)
+	self.size, self.last = 0, 0
+
+	local url = job.file.url
+	local it = fs.calc_size(url)
+	while true do
+		local next = it:recv()
+		if next then
+			self.size = self.size + next
+			self:spot_multi(job, false)
+		else
+			break
+		end
+	end
+
+	local op = fs.op("size", { url = url.parent, sizes = { [url.urn] = self.size } })
+	ya.emit("update_files", { op = op })
+
+	self:spot_multi(job, true)
+end
+
+function M:spot_multi(job, force)
+	local now = ya.time()
+	if not force and now < self.last + 0.1 then
+		return
+	end
+
+	local rows = {
+		ui.Row({ "Folder" }):style(ui.Style():fg("green")),
+		ui.Row { "  Size:", ya.readable_size(self.size) .. (force and "" or " (?)") },
+		ui.Row {},
+	}
+
+	ya.spot_table(
+		job,
+		ui.Table(ya.list_merge(rows, require("file"):spot_base(job)))
+			:area(ui.Pos { "center", w = 60, h = 20 })
+			:row(self.last == 0 and 1 or nil)
+			:col(1)
+			:col_style(th.spot.tbl_col)
+			:cell_style(th.spot.tbl_cell)
+			:widths { ui.Constraint.Length(14), ui.Constraint.Fill(1) }
+	)
+	self.last = now
+end
 
 return M

--- a/yazi-plugin/preset/ya.lua
+++ b/yazi-plugin/preset/ya.lua
@@ -33,7 +33,8 @@ function ya.readable_size(size)
 		size = size / 1024
 		i = i + 1
 	end
-	return string.format("%.1f%s", size, units[i]):gsub("[.,]0", "", 1)
+	local s = string.format("%.1f%s", size, units[i]):gsub("[.,]0", "", 1)
+	return s
 end
 
 function ya.readable_path(path)

--- a/yazi-plugin/src/fs/fs.rs
+++ b/yazi-plugin/src/fs/fs.rs
@@ -30,6 +30,7 @@ fn op(lua: &Lua) -> mlua::Result<Function> {
 	lua.create_function(|lua, (name, t): (mlua::String, Table)| match name.as_bytes().as_ref() {
 		b"part" => super::FilesOp::part(lua, t),
 		b"done" => super::FilesOp::done(lua, t),
+		b"size" => super::FilesOp::size(lua, t),
 		_ => Err("Unknown operation".into_lua_err())?,
 	})
 }

--- a/yazi-plugin/src/fs/op.rs
+++ b/yazi-plugin/src/fs/op.rs
@@ -1,5 +1,5 @@
 use mlua::{IntoLua, Lua, Table};
-use yazi_binding::{Id, Url};
+use yazi_binding::{Id, Url, Urn};
 
 use crate::{bindings::Cha, file::File};
 
@@ -27,6 +27,19 @@ impl FilesOp {
 		let url: Url = t.raw_get("url")?;
 
 		Ok(Self(yazi_fs::FilesOp::Done(url.into(), *cha, *id)))
+	}
+
+	pub(super) fn size(_: &Lua, t: Table) -> mlua::Result<Self> {
+		let url: Url = t.raw_get("url")?;
+		let sizes: Table = t.raw_get("sizes")?;
+
+		Ok(Self(yazi_fs::FilesOp::Size(
+			url.into(),
+			sizes
+				.pairs::<Urn, u64>()
+				.map(|r| r.map(|(urn, size)| (urn.into(), size)))
+				.collect::<mlua::Result<_>>()?,
+		)))
 	}
 }
 

--- a/yazi-plugin/src/isolate/peek.rs
+++ b/yazi-plugin/src/isolate/peek.rs
@@ -34,9 +34,9 @@ pub fn peek(
 			_ = ct_.cancelled() => {},
 			Ok(b) = LOADER.ensure(&cmd.name, |c| c.sync_peek) => {
 				if b {
-					peek_sync(cmd, file, mime, skip);
+					peek_sync( cmd, file, mime, skip);
 				} else {
-					peek_async(cmd, file, mime, skip, ct_);
+					peek_async( cmd, file, mime, skip, ct_);
 				}
 			},
 			else => {}

--- a/yazi-plugin/src/isolate/spot.rs
+++ b/yazi-plugin/src/isolate/spot.rs
@@ -4,11 +4,14 @@ use mlua::{ExternalError, ExternalResult, HookTriggers, IntoLua, ObjectLike, VmS
 use tokio::{runtime::Handle, select};
 use tokio_util::sync::CancellationToken;
 use tracing::error;
+use yazi_binding::Id;
 use yazi_dds::Sendable;
-use yazi_shared::event::Cmd;
+use yazi_shared::{Ids, event::Cmd};
 
 use super::slim_lua;
 use crate::{file::File, loader::LOADER};
+
+static IDS: Ids = Ids::new();
 
 pub fn spot(
 	cmd: &'static Cmd,
@@ -37,6 +40,7 @@ pub fn spot(
 
 			let plugin = LOADER.load_once(&lua, &cmd.name)?;
 			let job = lua.create_table_from([
+				("id", Id(IDS.next()).into_lua(&lua)?),
 				("args", Sendable::args_to_table_ref(&lua, &cmd.args)?.into_lua(&lua)?),
 				("file", File::new(file).into_lua(&lua)?),
 				("mime", mime.into_lua(&lua)?),

--- a/yazi-plugin/src/utils/spot.rs
+++ b/yazi-plugin/src/utils/spot.rs
@@ -1,7 +1,7 @@
 use mlua::{AnyUserData, Function, Lua, Table};
 use yazi_config::THEME;
 use yazi_macro::emit;
-use yazi_shared::event::Cmd;
+use yazi_shared::{Id, event::Cmd};
 
 use super::Utils;
 use crate::{elements::Renderable, file::FileRef};
@@ -11,6 +11,7 @@ pub struct SpotLock {
 	pub cha:  yazi_fs::cha::Cha,
 	pub mime: String,
 
+	pub id:   Id,
 	pub skip: usize,
 	pub data: Vec<Renderable>,
 }
@@ -25,6 +26,7 @@ impl TryFrom<Table> for SpotLock {
 			cha:  file.cha,
 			mime: t.raw_get("mime")?,
 
+			id:   *t.raw_get::<yazi_binding::Id>("id")?,
 			skip: t.raw_get("skip")?,
 			data: Default::default(),
 		})

--- a/yazi-shared/src/event/data.rs
+++ b/yazi-shared/src/event/data.rs
@@ -2,7 +2,7 @@ use std::{any::Any, borrow::Cow, collections::HashMap};
 
 use serde::{Deserialize, Serialize, de};
 
-use crate::{Id, OrderedFloat, url::Url};
+use crate::{Id, OrderedFloat, url::{Url, UrnBuf}};
 
 // --- Data
 #[derive(Debug, Serialize, Deserialize)]
@@ -18,6 +18,8 @@ pub enum Data {
 	Id(Id),
 	#[serde(skip_deserializing)]
 	Url(Url),
+	#[serde(skip_deserializing)]
+	Urn(UrnBuf),
 	#[serde(skip)]
 	Bytes(Vec<u8>),
 	#[serde(skip)]
@@ -106,6 +108,11 @@ pub enum DataKey {
 	Integer(i64),
 	Number(OrderedFloat),
 	String(Cow<'static, str>),
+	Id(Id),
+	#[serde(skip_deserializing)]
+	Url(Url),
+	#[serde(skip_deserializing)]
+	Urn(UrnBuf),
 }
 
 impl DataKey {

--- a/yazi-shared/src/url/urn.rs
+++ b/yazi-shared/src/url/urn.rs
@@ -1,5 +1,7 @@
 use std::{borrow::{Borrow, Cow}, ffi::OsStr, ops::Deref, path::{Path, PathBuf}};
 
+use serde::Serialize;
+
 #[derive(Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct Urn(Path);
@@ -48,7 +50,7 @@ impl PartialEq<Cow<'_, OsStr>> for &Urn {
 }
 
 // --- UrnBuf
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize)]
 pub struct UrnBuf(PathBuf);
 
 impl Borrow<Urn> for UrnBuf {


### PR DESCRIPTION
Follow up to https://github.com/sxyazi/yazi/pull/2683, https://github.com/sxyazi/yazi/pull/2691

An implementation of the feature request: https://github.com/sxyazi/yazi/issues/842, https://github.com/sxyazi/yazi/issues/2649

Closes https://github.com/sxyazi/yazi/issues/842
Closes https://github.com/sxyazi/yazi/issues/2649

---

This PR adds directory sizes to the `folder` spotter, the size is computed dynamically in real time and asynchronously, which means:

- Every time a user clicks `<Tab>` on a directory, the latest size is calculated.
- For large directories, real-time changes in size are reported to the user, with "(?)" appended at the end to indicate that the calculation is in progress.
- If the user closes the spotter or switches directories with the left/right arrow keys, any ongoing calculations will be canceled to avoid wasting resources.

Also, the computed directory size will be updated to the file list:

- If the user sets `linemode = size`, the latest size will be shown on the right of the file line.
- If the user sets `sort_by = size`, the file list will be sorted with the latest sizes (if necessary).


https://github.com/user-attachments/assets/568ca1b2-5858-4f38-a053-a099dffa3b1c

