### PR TITLE
feat: show error when image preview fails

### DIFF
--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -35,7 +35,7 @@ function M:peek(job)
 	if job.skip > 0 and bound < job.skip + limit then
 		ya.emit("peek", { math.max(0, bound - limit), only_if = job.file.url, upper_bound = true })
 	else
-		ya.preview_widgets(job, {
+		ya.preview_widget(job, {
 			ui.Text(paths):area(job.area),
 			ui.Text(sizes):area(job.area):align(ui.Text.RIGHT),
 		})

--- a/yazi-plugin/preset/plugins/empty.lua
+++ b/yazi-plugin/preset/plugins/empty.lua
@@ -1,10 +1,6 @@
 local M = {}
 
-function M.msg(job, s)
-	ya.preview_widgets(job, {
-		ui.Text(ui.Line(s):reverse()):area(job.area):wrap(ui.Text.WRAP),
-	})
-end
+function M.msg(job, s) ya.preview_widget(job, ui.Text(ui.Line(s):reverse()):area(job.area):wrap(ui.Text.WRAP)) end
 
 function M:peek(job)
 	local path = tostring(job.file.url)
@@ -43,7 +39,7 @@ function M:peek(job)
 	if job.skip > 0 and i < job.skip + limit then
 		ya.emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
-		ya.preview_widgets(job, { ui.Text(lines):area(job.area) })
+		ya.preview_widget(job, ui.Text(lines):area(job.area))
 	end
 end
 

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -11,7 +11,7 @@ function M:peek(job)
 		text = ui.Text(string.format("Failed to start `%s`, error: %s", cmd, err))
 	end
 
-	ya.preview_widgets(job, { text:area(job.area):wrap(ui.Text.WRAP) })
+	ya.preview_widget(job, text:area(job.area):wrap(ui.Text.WRAP))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/folder.lua
+++ b/yazi-plugin/preset/plugins/folder.lua
@@ -16,9 +16,7 @@ function M:peek(job)
 	if #folder.files == 0 then
 		local done, err = folder.stage()
 		local s = not done and "Loading..." or not err and "No items" or string.format("Error: %s", err)
-		return ya.preview_widgets(job, {
-			ui.Text(s):area(job.area):align(ui.Text.CENTER),
-		})
+		return ya.preview_widget(job, ui.Text(s):area(job.area):align(ui.Text.CENTER))
 	end
 
 	local entities = {}
@@ -26,7 +24,7 @@ function M:peek(job)
 		entities[#entities + 1] = Entity:new(f):redraw()
 	end
 
-	ya.preview_widgets(job, {
+	ya.preview_widget(job, {
 		ui.List(entities):area(job.area),
 		table.unpack(Marker:new(job.area, folder):redraw()),
 	})

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -14,8 +14,9 @@ function M:peek(job)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
-	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
+
+	local _, err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, err and ui.Text(tostring(err)):wrap(ui.Text.WRAP))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/image.lua
+++ b/yazi-plugin/preset/plugins/image.lua
@@ -7,8 +7,9 @@ function M:peek(job)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
-	ya.image_show(url, job.area)
-	ya.preview_widgets(job, {})
+
+	local _, err = ya.image_show(url, job.area)
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -32,9 +32,10 @@ function M:peek(job)
 		ya.emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
 		lines = lines:gsub("\t", string.rep(" ", rt.preview.tab_size))
-		ya.preview_widgets(job, {
-			ui.Text.parse(lines):area(job.area):wrap(rt.preview.wrap == "yes" and ui.Text.WRAP or ui.Text.WRAP_NO),
-		})
+		ya.preview_widget(
+			job,
+			ui.Text.parse(lines):area(job.area):wrap(rt.preview.wrap == "yes" and ui.Text.WRAP or ui.Text.WRAP_NO)
+		)
 	end
 end
 

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -12,8 +12,9 @@ function M:peek(job)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
-	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
+
+	local _, err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, err and ui.Text(tostring(err)):wrap(ui.Text.WRAP))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -12,8 +12,9 @@ function M:peek(job)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
-	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
+
+	local _, err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, err and ui.Text(tostring(err)):wrap(ui.Text.WRAP))
 end
 
 function M:seek(job)

--- a/yazi-plugin/preset/plugins/svg.lua
+++ b/yazi-plugin/preset/plugins/svg.lua
@@ -12,8 +12,9 @@ function M:peek(job)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
-	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
+
+	local _, err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, err and ui.Text(tostring(err)):wrap(ui.Text.WRAP))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -12,8 +12,9 @@ function M:peek(job)
 	end
 
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
-	ya.image_show(cache, job.area)
-	ya.preview_widgets(job, {})
+
+	local _, err = ya.image_show(cache, job.area)
+	ya.preview_widget(job, err and ui.Text(tostring(err)):wrap(ui.Text.WRAP))
 end
 
 function M:seek(job)

--- a/yazi-plugin/src/bindings/calculator.rs
+++ b/yazi-plugin/src/bindings/calculator.rs
@@ -7,7 +7,7 @@ impl UserData for SizeCalculator {
 	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
 		methods.add_async_method_mut("recv", |lua, mut me, ()| async move {
 			match me.0.next().await {
-				Ok(value) => (value, Value::Nil).into_lua_multi(&lua),
+				Ok(value) => value.into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});

--- a/yazi-plugin/src/bindings/chan.rs
+++ b/yazi-plugin/src/bindings/chan.rs
@@ -8,7 +8,7 @@ impl UserData for MpscTx {
 	fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
 		methods.add_async_method("send", |lua, me, value: Value| async move {
 			match me.0.send(value).await {
-				Ok(()) => (true, Value::Nil).into_lua_multi(&lua),
+				Ok(()) => true.into_lua_multi(&lua),
 				Err(e) => (false, Error::Custom(e.to_string())).into_lua_multi(&lua),
 			}
 		});
@@ -32,7 +32,7 @@ pub struct MpscUnboundedRx(pub tokio::sync::mpsc::UnboundedReceiver<Value>);
 impl UserData for MpscUnboundedTx {
 	fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
 		methods.add_method("send", |lua, me, value: Value| match me.0.send(value) {
-			Ok(()) => (true, Value::Nil).into_lua_multi(lua),
+			Ok(()) => true.into_lua_multi(lua),
 			Err(e) => (false, Error::Custom(e.to_string())).into_lua_multi(lua),
 		});
 	}
@@ -59,7 +59,7 @@ impl UserData for OneshotTx {
 				return Err("Oneshot sender already used".into_lua_err());
 			};
 			match tx.send(value) {
-				Ok(()) => (true, Value::Nil).into_lua_multi(lua),
+				Ok(()) => true.into_lua_multi(lua),
 				Err(_) => (false, Error::Custom("Oneshot receiver closed".to_string())).into_lua_multi(lua),
 			}
 		});
@@ -73,7 +73,7 @@ impl UserData for OneshotRx {
 				return Err("Oneshot receiver already used".into_lua_err());
 			};
 			match rx.await {
-				Ok(value) => (value, Value::Nil).into_lua_multi(&lua),
+				Ok(value) => value.into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Custom(e.to_string())).into_lua_multi(&lua),
 			}
 		});

--- a/yazi-plugin/src/elements/text.rs
+++ b/yazi-plugin/src/elements/text.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use ansi_to_tui::IntoText;
-use mlua::{ExternalError, ExternalResult, IntoLua, Lua, MetaMethod, Table, UserData, Value};
+use mlua::{ExternalError, ExternalResult, IntoLua, Lua, MetaMethod, ObjectLike, Table, UserData, Value};
 use ratatui::widgets::Widget;
 
 use super::{Area, Line, Span};

--- a/yazi-plugin/src/fs/fs.rs
+++ b/yazi-plugin/src/fs/fs.rs
@@ -37,7 +37,7 @@ fn op(lua: &Lua) -> mlua::Result<Function> {
 
 fn cwd(lua: &Lua) -> mlua::Result<Function> {
 	lua.create_function(|lua, ()| match std::env::current_dir() {
-		Ok(p) => (Url::new(p), Value::Nil).into_lua_multi(lua),
+		Ok(p) => Url::new(p).into_lua_multi(lua),
 		Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(lua),
 	})
 }
@@ -51,7 +51,7 @@ fn cha(lua: &Lua) -> mlua::Result<Function> {
 		};
 
 		match meta {
-			Ok(m) => (Cha::from(m), Value::Nil).into_lua_multi(&lua),
+			Ok(m) => Cha::from(m).into_lua_multi(&lua),
 			Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 		}
 	})
@@ -60,7 +60,7 @@ fn cha(lua: &Lua) -> mlua::Result<Function> {
 fn write(lua: &Lua) -> mlua::Result<Function> {
 	lua.create_async_function(|lua, (url, data): (UrlRef, mlua::String)| async move {
 		match fs::write(&*url, data.as_bytes()).await {
-			Ok(()) => (true, Value::Nil).into_lua_multi(&lua),
+			Ok(()) => true.into_lua_multi(&lua),
 			Err(e) => (false, Error::Io(e)).into_lua_multi(&lua),
 		}
 	})
@@ -75,7 +75,7 @@ fn create(lua: &Lua) -> mlua::Result<Function> {
 		};
 
 		match result {
-			Ok(()) => (true, Value::Nil).into_lua_multi(&lua),
+			Ok(()) => true.into_lua_multi(&lua),
 			Err(e) => (false, Error::Io(e)).into_lua_multi(&lua),
 		}
 	})
@@ -92,7 +92,7 @@ fn remove(lua: &Lua) -> mlua::Result<Function> {
 		};
 
 		match result {
-			Ok(()) => (true, Value::Nil).into_lua_multi(&lua),
+			Ok(()) => true.into_lua_multi(&lua),
 			Err(e) => (false, Error::Io(e)).into_lua_multi(&lua),
 		}
 	})
@@ -150,7 +150,7 @@ fn read_dir(lua: &Lua) -> mlua::Result<Function> {
 			tbl.raw_push(f)?;
 		}
 
-		(tbl, Value::Nil).into_lua_multi(&lua)
+		tbl.into_lua_multi(&lua)
 	})
 }
 
@@ -177,7 +177,7 @@ fn expand_url(lua: &Lua) -> mlua::Result<Function> {
 fn unique_name(lua: &Lua) -> mlua::Result<Function> {
 	lua.create_async_function(|lua, url: UrlRef| async move {
 		match yazi_fs::unique_name(url.clone(), async { false }).await {
-			Ok(u) => (Url::new(u), Value::Nil).into_lua_multi(&lua),
+			Ok(u) => Url::new(u).into_lua_multi(&lua),
 			Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 		}
 	})

--- a/yazi-plugin/src/process/child.rs
+++ b/yazi-plugin/src/process/child.rs
@@ -139,7 +139,7 @@ impl UserData for Child {
 				return Err("stdin is not piped".into_lua_err());
 			};
 			match stdin.write_all(&src.as_bytes()).await {
-				Ok(()) => (true, Value::Nil).into_lua_multi(&lua),
+				Ok(()) => true.into_lua_multi(&lua),
 				Err(e) => (false, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});
@@ -148,32 +148,32 @@ impl UserData for Child {
 				return Err("stdin is not piped".into_lua_err());
 			};
 			match stdin.flush().await {
-				Ok(()) => (true, Value::Nil).into_lua_multi(&lua),
+				Ok(()) => true.into_lua_multi(&lua),
 				Err(e) => (false, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});
 
 		methods.add_async_method_mut("wait", |lua, mut me, ()| async move {
 			match me.wait().await {
-				Ok(status) => (Status::new(status), Value::Nil).into_lua_multi(&lua),
+				Ok(status) => Status::new(status).into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});
 		methods.add_async_function("wait_with_output", |lua, ud: AnyUserData| async move {
 			match ud.take::<Self>()?.wait_with_output().await {
-				Ok(output) => (Output::new(output), Value::Nil).into_lua_multi(&lua),
+				Ok(output) => Output::new(output).into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});
 		methods.add_async_method_mut("try_wait", |lua, mut me, ()| async move {
 			match me.inner.try_wait() {
-				Ok(Some(status)) => (Status::new(status), Value::Nil).into_lua_multi(&lua),
-				Ok(None) => (Value::Nil, Value::Nil).into_lua_multi(&lua),
+				Ok(Some(status)) => Status::new(status).into_lua_multi(&lua),
+				Ok(None) => Value::Nil.into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});
 		methods.add_method_mut("start_kill", |lua, me, ()| match me.inner.start_kill() {
-			Ok(_) => (true, Value::Nil).into_lua_multi(lua),
+			Ok(_) => true.into_lua_multi(lua),
 			Err(e) => (false, Error::Io(e)).into_lua_multi(lua),
 		});
 

--- a/yazi-plugin/src/process/command.rs
+++ b/yazi-plugin/src/process/command.rs
@@ -176,18 +176,18 @@ impl UserData for Command {
 			Ok(ud)
 		});
 		methods.add_method_mut("spawn", |lua, me, ()| match me.spawn() {
-			Ok(child) => (child, Value::Nil).into_lua_multi(lua),
+			Ok(child) => child.into_lua_multi(lua),
 			Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(lua),
 		});
 		methods.add_async_method_mut("output", |lua, mut me, ()| async move {
 			match me.output().await {
-				Ok(output) => (Output::new(output), Value::Nil).into_lua_multi(&lua),
+				Ok(output) => Output::new(output).into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});
 		methods.add_async_method_mut("status", |lua, mut me, ()| async move {
 			match me.status().await {
-				Ok(status) => (Status::new(status), Value::Nil).into_lua_multi(&lua),
+				Ok(status) => Status::new(status).into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Io(e)).into_lua_multi(&lua),
 			}
 		});

--- a/yazi-plugin/src/utils/json.rs
+++ b/yazi-plugin/src/utils/json.rs
@@ -8,7 +8,7 @@ impl Utils {
 	pub(super) fn json_encode(lua: &Lua) -> mlua::Result<Function> {
 		lua.create_async_function(|lua, value: Value| async move {
 			match serde_json::to_string(&value) {
-				Ok(s) => (s, Value::Nil).into_lua_multi(&lua),
+				Ok(s) => s.into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Serde(e)).into_lua_multi(&lua),
 			}
 		})
@@ -17,7 +17,7 @@ impl Utils {
 	pub(super) fn json_decode(lua: &Lua) -> mlua::Result<Function> {
 		lua.create_async_function(|lua, s: mlua::String| async move {
 			match serde_json::from_slice::<serde_json::Value>(&s.as_bytes()) {
-				Ok(v) => (lua.to_value_with(&v, OPTS)?, Value::Nil).into_lua_multi(&lua),
+				Ok(v) => lua.to_value_with(&v, OPTS)?.into_lua_multi(&lua),
 				Err(e) => (Value::Nil, Error::Serde(e)).into_lua_multi(&lua),
 			}
 		})

--- a/yazi-plugin/src/utils/layer.rs
+++ b/yazi-plugin/src/utils/layer.rs
@@ -59,10 +59,9 @@ impl Utils {
 			if debounce < 0.0 {
 				Err("negative debounce duration".into_lua_err())
 			} else if debounce == 0.0 {
-				(InputRx::new(rx), Value::Nil).into_lua_multi(&lua)
+				InputRx::new(rx).into_lua_multi(&lua)
 			} else {
-				(InputRx::new(Debounce::new(rx, Duration::from_secs_f64(debounce))), Value::Nil)
-					.into_lua_multi(&lua)
+				InputRx::new(Debounce::new(rx, Duration::from_secs_f64(debounce))).into_lua_multi(&lua)
 			}
 		})
 	}

--- a/yazi-plugin/src/utils/utils.rs
+++ b/yazi-plugin/src/utils/utils.rs
@@ -44,7 +44,8 @@ pub fn compose(lua: &Lua, isolate: bool) -> mlua::Result<Value> {
 
 			// Preview
 			b"preview_code" => Utils::preview_code(lua)?,
-			b"preview_widgets" => Utils::preview_widgets(lua)?,
+			b"preview_widget" => Utils::preview_widget(lua)?,
+			b"preview_widgets" => Utils::preview_widget(lua)?, // TODO: remove this in the future
 
 			// Process
 			b"proc_info" => Utils::proc_info(lua)?,


### PR DESCRIPTION
Before this change, when `ya.image_info()` and `ya.image_show()` failed, there was no way to determine the reason for the failure. 

With this PR, a new second return value has been added to them, in the event of a failure, it will carry an [`Error`](https://yazi-rs.github.io/docs/plugins/types/#shared.error) userdata that provides the caller with the error message.

All built-in image previewers in Yazi have been updated to support this, that is, when an image preview fails, the error will be displayed in the preview pane so that the user knows what went wrong.

## Deprecated API

`ya.preview_widgets()` has been deprecated and replaced by the new `ya.preview_widget()`:

```diff
- ya.preview_widgets(job, { ui.Text("..."):area(job.area) })
+ ya.preview_widget(job, { ui.Text("..."):area(job.area) })
```

In addition to supporting the table parameter as the original `ya.preview_widgets()` did, the new `ya.preview_widget()` can also accept a single renderable element directly without the need to wrap it in a table:

```diff
- ya.preview_widgets(job, { ui.Text("..."):area(job.area) })
+ ya.preview_widget(job, ui.Text("..."):area(job.area))
```

Considering that `ya.preview_widgets()` has been widely used in previewers, it will continue to be available for a long time. Deprecation warnings will be added later, and it will eventually be removed.