### PR TITLE
feat: add `--hovered` to the `copy` command

### DIFF
--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -32,7 +32,7 @@ impl Tab {
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
 			if let Some(h) = self.hovered() {
-				it = Box::new([&h.url, &h.url].into_iter());
+				it = Box::new([&h.url, &h.url].into_iter()).peekable();
 			} else { return };
 		}
 		while let Some(u) = it.next() {

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, ffi::{OsStr, OsString}, path::Path};
 
 use yazi_plugin::CLIPBOARD;
-use yazi_shared::event::CmdCow;
+use yazi_shared::{event::CmdCow, url::Url};
 
 use crate::tab::Tab;
 

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -29,8 +29,12 @@ impl Tab {
 		}
 
 		let mut s = OsString::new();
-		let Some(hovered) = self.hovered() else { if opt.hovered { return } };
-		let mut it = (if opt.hovered { once(hovered) } else { self.selected_or_hovered() }).peekable();
+		let mut it = self.selected_or_hovered().peekable();
+		if opt.hovered {
+			if let Some(hovered) = self.hovered {
+				it = once(hovered).peekable();
+			} else { return };
+		}
 		while let Some(u) = it.next() {
 			s.push(match opt.type_.as_ref() {
 				"path" => opt.separator.transform(u),

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -32,7 +32,7 @@ impl Tab {
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
 			if let Some(h) = self.hovered() {
-				it = Box::new([&h.url, &h.url].into_iter()).peekable();
+				it = Box::new([&h.url, &h.url].into_iter()).peekable() as Box<dyn Iterator<Item = &Url> + '_>;
 			} else { return };
 		}
 		while let Some(u) = it.next() {

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, ffi::{OsStr, OsString}, path::Path};
 
 use yazi_plugin::CLIPBOARD;
-use yazi_shared::{event::CmdCow, url::Url};
+use yazi_shared::event::CmdCow;
 
 use crate::tab::Tab;
 
@@ -29,12 +29,13 @@ impl Tab {
 		}
 
 		let mut s = OsString::new();
-		let mut it = self.selected_or_hovered().peekable();
-		if opt.hovered {
-			if let Some(h) = self.hovered() {
-				it = (Box::new(vec![&h.url].into_iter()) as Box<dyn Iterator<Item = &Url> + '_>).peekable();
-			} else { return };
+		let mut it = if opt.hovered {
+			Box::new(self.hovered().map(|h| &h.url).into_iter())
+		} else {
+			self.selected_or_hovered()
 		}
+		.peekable();
+
 		while let Some(u) = it.next() {
 			s.push(match opt.type_.as_ref() {
 				"path" => opt.separator.transform(u),

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -31,7 +31,7 @@ impl Tab {
 		let mut s = OsString::new();
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
-			if let Some(hovered) = self.hovered {
+			if let Some(hovered) = self.hovered() {
 				it = once(hovered).peekable();
 			} else { return };
 		}

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -32,7 +32,7 @@ impl Tab {
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
 			if let Some(h) = self.hovered() {
-				it = Box::new([&h.url, &h.url].into_iter()).peekable() as Box<dyn Iterator<Item = &Url> + '_>;
+				it = Box::new([&h.url].into_iter()).peekable() as Box<dyn Iterator<Item = &Url> + '_>;
 			} else { return };
 		}
 		while let Some(u) = it.next() {

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ffi::{OsStr, OsString}, path::Path, iter::once};
+use std::{borrow::Cow, ffi::{OsStr, OsString}, path::Path};
 
 use yazi_plugin::CLIPBOARD;
 use yazi_shared::event::CmdCow;
@@ -32,7 +32,7 @@ impl Tab {
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
 			if let Some(hovered) = self.hovered() {
-				it = once(hovered).peekable();
+				it = Box::new(hovered.map(|h| vec![&h.url]).into_iter());
 			} else { return };
 		}
 		while let Some(u) = it.next() {

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -31,8 +31,8 @@ impl Tab {
 		let mut s = OsString::new();
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
-			if let Some(hovered) = self.hovered() {
-				it = Box::new(hovered.map(|h| vec![&h.url]).into_iter());
+			if let Some(h) = self.hovered() {
+				it = Box::new([&h.url, &h.url].into_iter());
 			} else { return };
 		}
 		while let Some(u) = it.next() {

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -32,7 +32,7 @@ impl Tab {
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
 			if let Some(h) = self.hovered() {
-				it = Box::new(vec![&h.url].into_iter()).peekable() as Box<dyn Iterator<Item = &Url> + '_>;
+				it = (Box::new(vec![&h.url].into_iter()) as Box<dyn Iterator<Item = &Url> + '_>).peekable();
 			} else { return };
 		}
 		while let Some(u) = it.next() {

--- a/yazi-core/src/tab/commands/copy.rs
+++ b/yazi-core/src/tab/commands/copy.rs
@@ -32,7 +32,7 @@ impl Tab {
 		let mut it = self.selected_or_hovered().peekable();
 		if opt.hovered {
 			if let Some(h) = self.hovered() {
-				it = Box::new([&h.url].into_iter()).peekable() as Box<dyn Iterator<Item = &Url> + '_>;
+				it = Box::new(vec![&h.url].into_iter()).peekable() as Box<dyn Iterator<Item = &Url> + '_>;
 			} else { return };
 		}
 		while let Some(u) = it.next() {


### PR DESCRIPTION
Similar to the `open`, `rename` and `remove` commands, the `--hovered` flag will cause the copy command to operate only on the hovered file.