### PR TITLE
fix: detach background and orphan processes from the controlling terminal with `setsid()`

### DIFF
--- a/yazi-scheduler/src/process/shell.rs
+++ b/yazi-scheduler/src/process/shell.rs
@@ -38,7 +38,7 @@ pub fn shell(opt: ShellOpt) -> Result<Child> {
 			.current_dir(opt.cwd)
 			.kill_on_drop(!opt.orphan)
 			.pre_exec(move || {
-				if opt.orphan && libc::setpgid(0, 0) < 0 {
+				if (opt.piped || opt.orphan) && libc::setsid() < 0 {
 					return Err(std::io::Error::last_os_error());
 				}
 				Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.
-->

<!--
You can use GitHub syntax to link an issue to this PR, such as `Closes #1000`, which indicates this PR will close issue #1000.
-->

Closes https://github.com/sxyazi/yazi/issues/2721

## Rationale of this PR

<!--
A clear and concise description of the rationale of this change, to help our reviewers understand your intent and why it is necessary.

If this has already been detailed in the associated issue, please skip this section.
-->
