### PR TITLE
fix: `windows-sys` missing a `Win32_Security` feature

### DIFF
--- a/yazi-term/Cargo.toml
+++ b/yazi-term/Cargo.toml
@@ -27,4 +27,4 @@ libc = { workspace = true }
 crossterm = { workspace = true, features = [ "use-dev-tty", "libc" ] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", features = [ "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Console", "Win32_System_Threading", "Win32_Security"] }
+windows-sys = { version = "0.59.0", features = [ "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Console", "Win32_System_Threading", "Win32_Security" ] }

--- a/yazi-term/Cargo.toml
+++ b/yazi-term/Cargo.toml
@@ -27,4 +27,4 @@ libc = { workspace = true }
 crossterm = { workspace = true, features = [ "use-dev-tty", "libc" ] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", features = [ "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Console", "Win32_System_Threading" ] }
+windows-sys = { version = "0.59.0", features = [ "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Console", "Win32_System_Threading","Win32_Foundation", "Win32_Security"] }

--- a/yazi-term/Cargo.toml
+++ b/yazi-term/Cargo.toml
@@ -27,4 +27,4 @@ libc = { workspace = true }
 crossterm = { workspace = true, features = [ "use-dev-tty", "libc" ] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", features = [ "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Console", "Win32_System_Threading","Win32_Foundation", "Win32_Security"] }
+windows-sys = { version = "0.59.0", features = [ "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Console", "Win32_System_Threading", "Win32_Security"] }


### PR DESCRIPTION


## Which issue does this PR close?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.
-->

<!--
You can use GitHub syntax to link an issue to this PR, such as `Closes #1000`, which indicates this PR will close issue #1000.
-->

Closes #2727

## Rationale of this PR

<!--
A clear and concise description of the rationale of this change, to help our reviewers understand your intent and why it is necessary.

If this has already been detailed in the associated issue, please skip this section.
-->
it makes yazi-cli buildable on windows