### PR TITLE
fix: avoid tmux interfering with kitty graphical sequences

### DIFF
--- a/yazi-adapter/src/drivers/kgp.rs
+++ b/yazi-adapter/src/drivers/kgp.rs
@@ -379,14 +379,14 @@ impl Kgp {
 
 	fn place(area: &Rect) -> Result<Vec<u8>> {
 		let mut buf = Vec::with_capacity(area.width as usize * area.height as usize * 3 + 50);
+		write!(buf, "\x1b[38;2;0;0;1m")?;
 		for y in 0..area.height {
-			write!(buf, "\x1b[{};{}H\x1b[38;5;1m", area.y + y + 1, area.x + 1)?;
+			write!(buf, "\x1b[{};{}H", area.y + y + 1, area.x + 1)?;
 			for x in 0..area.width {
 				write!(buf, "\u{10EEEE}")?;
 				write!(buf, "{}", *DIACRITICS.get(y as usize).unwrap_or(&DIACRITICS[0]))?;
 				write!(buf, "{}", *DIACRITICS.get(x as usize).unwrap_or(&DIACRITICS[0]))?;
 			}
-			write!(buf, "\x1b[0m")?;
 		}
 		Ok(buf)
 	}

--- a/yazi-adapter/src/emulator.rs
+++ b/yazi-adapter/src/emulator.rs
@@ -88,7 +88,7 @@ impl Emulator {
 	{
 		use std::{io::Write, thread, time::Duration};
 
-		use crossterm::{cursor::{Hide, MoveTo, RestorePosition, SavePosition, Show}, queue};
+		use crossterm::{cursor::{Hide, MoveTo, Show}, queue};
 
 		let mut w = TTY.lockout();
 

--- a/yazi-core/src/tab/commands/arrow.rs
+++ b/yazi-core/src/tab/commands/arrow.rs
@@ -28,12 +28,8 @@ impl Tab {
 
 		// Visual selection
 		if let Some((start, items)) = self.mode.visual_mut() {
-			let after = self.current.cursor;
-
-			items.clear();
-			for i in start.min(after)..=after.max(start) {
-				items.insert(i);
-			}
+			let end = self.current.cursor;
+			*items = (start.min(end)..=end.max(start)).collect();
 		}
 
 		self.hover(None);

--- a/yazi-fm/src/term.rs
+++ b/yazi-fm/src/term.rs
@@ -32,12 +32,12 @@ impl Term {
 
 		execute!(
 			TTY.writer(),
-			yazi_term::If(TMUX.get(), EnterAlternateScreen),
+			yazi_term::If(!TMUX.get(), EnterAlternateScreen),
 			Print("\x1bP$q q\x1b\\"), // Request cursor shape (DECRQSS query for DECSCUSR)
 			Print(Mux::csi("\x1b[?12$p")), // Request cursor blink status (DECSET)
 			Print("\x1b[?u"),         // Request keyboard enhancement flags (CSI u)
 			Print(Mux::csi("\x1b[0c")), // Request device attributes
-			yazi_term::If(!TMUX.get(), EnterAlternateScreen),
+			yazi_term::If(TMUX.get(), EnterAlternateScreen),
 			EnableBracketedPaste,
 			yazi_term::If(!YAZI.mgr.mouse_events.is_empty(), EnableMouseCapture),
 		)?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.
-->

<!--
You can use GitHub syntax to link an issue to this PR, such as `Closes #1000`, which indicates this PR will close issue #1000.
-->

Closes https://github.com/sxyazi/yazi/issues/2725

## Rationale of this PR

<!--
A clear and concise description of the rationale of this change, to help our reviewers understand your intent and why it is necessary.

If this has already been detailed in the associated issue, please skip this section.
-->
