### PR TITLE
refactor: deprecate the `Command:args()` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,15 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,16 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,16 +712,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -1021,16 +992,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1454,16 +1415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
 ]
 
 [[package]]
@@ -2846,12 +2797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,12 +2920,6 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3606,7 +3545,6 @@ dependencies = [
  "futures",
  "globset",
  "libc",
- "md-5",
  "mlua",
  "parking_lot",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ globset             = "0.4.16"
 indexmap            = { version = "2.9.0", features = [ "serde" ] }
 libc                = "0.2.172"
 lru                 = "0.14.0"
-md-5                = "0.10.6"
 mlua                = { version = "0.10.3", features = [ "anyhow", "async", "error-send", "lua54", "macros", "serialize" ] }
 objc                = "0.2.7"
 parking_lot         = "0.12.3"

--- a/yazi-binding/src/error.rs
+++ b/yazi-binding/src/error.rs
@@ -66,11 +66,11 @@ impl UserData for Error {
 			match (lhs, rhs) {
 				(Value::String(l), Value::UserData(r)) => {
 					let r = r.borrow::<Self>()?;
-					lua.create_string([l.as_bytes().as_ref(), r.to_string().as_bytes()].concat())
+					lua.create_string([&l.as_bytes(), r.to_string().as_bytes()].concat())
 				}
 				(Value::UserData(l), Value::String(r)) => {
 					let l = l.borrow::<Self>()?;
-					lua.create_string([l.to_string().as_bytes(), r.as_bytes().as_ref()].concat())
+					lua.create_string([l.to_string().as_bytes(), &r.as_bytes()].concat())
 				}
 				_ => Err("only string can be concatenated with Error".into_lua_err()),
 			}

--- a/yazi-binding/src/url.rs
+++ b/yazi-binding/src/url.rs
@@ -138,7 +138,7 @@ impl UserData for Url {
 			lua.create_string(me.as_os_str().as_encoded_bytes())
 		});
 		methods.add_meta_method(MetaMethod::Concat, |lua, lhs, rhs: mlua::String| {
-			lua.create_string([lhs.as_os_str().as_encoded_bytes(), rhs.as_bytes().as_ref()].concat())
+			lua.create_string([lhs.as_os_str().as_encoded_bytes(), &rhs.as_bytes()].concat())
 		});
 	}
 }

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::module_inception, clippy::unit_arg)]
+#![allow(clippy::if_same_then_else, clippy::module_inception, clippy::unit_arg)]
 
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 #[global_allocator]

--- a/yazi-plugin/Cargo.toml
+++ b/yazi-plugin/Cargo.toml
@@ -31,7 +31,6 @@ base64        = { workspace = true }
 crossterm     = { workspace = true }
 futures       = { workspace = true }
 globset       = { workspace = true }
-md-5          = { workspace = true }
 mlua          = { workspace = true }
 parking_lot   = { workspace = true }
 paste         = { workspace = true }

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -48,7 +48,7 @@ function M.spawn_7z(args)
 	local last_err = nil
 	local try = function(name)
 		local stdout = args[1] == "l" and Command.PIPED or Command.NULL
-		local child, err = Command(name):args(args):stdout(stdout):stderr(Command.PIPED):spawn()
+		local child, err = Command(name):arg(args):stdout(stdout):stderr(Command.PIPED):spawn()
 		if not child then
 			last_err = err
 		end

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M:peek(job)
 	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
-	local output, err = Command(cmd):args({ "-bL", "--", tostring(job.file.url) }):stdout(Command.PIPED):output()
+	local output, err = Command(cmd):arg({ "-bL", "--", tostring(job.file.url) }):stdout(Command.PIPED):output()
 
 	local text
 	if output then

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -27,7 +27,7 @@ function M:preload(job)
 		return true
 	end
 
-	local status, err = Command("magick"):args({
+	local status, err = Command("magick"):arg({
 		"-size",
 		"800x560",
 		"-gravity",

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M:peek(job)
 	local child = Command("jq")
-		:args({ "-b", "-C", "--tab", ".", tostring(job.file.url) })
+		:arg({ "-b", "-C", "--tab", ".", tostring(job.file.url) })
 		:stdout(Command.PIPED)
 		:stderr(Command.PIPED)
 		:spawn()

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -50,13 +50,13 @@ function M:spot(job) require("file"):spot(job) end
 function M.with_limit()
 	local cmd = Command("magick"):args { "-limit", "thread", 1 }
 	if rt.tasks.image_alloc > 0 then
-		cmd = cmd:args({ "-limit", "memory", rt.tasks.image_alloc }):args { "-limit", "disk", "1MiB" }
+		cmd:arg { "-limit", "memory", rt.tasks.image_alloc, "-limit", "disk", "1MiB" }
 	end
 	if rt.tasks.image_bound[1] > 0 then
-		cmd = cmd:args { "-limit", "width", rt.tasks.image_bound[1] }
+		cmd:arg { "-limit", "width", rt.tasks.image_bound[1] }
 	end
 	if rt.tasks.image_bound[2] > 0 then
-		cmd = cmd:args { "-limit", "height", rt.tasks.image_bound[2] }
+		cmd:arg { "-limit", "height", rt.tasks.image_bound[2] }
 	end
 	return cmd
 end

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -16,7 +16,7 @@ function M:fetch(job)
 	end
 
 	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
-	local child, err = Command(cmd):args({ "-bL", "--mime-type", "--" }):args(urls):stdout(Command.PIPED):spawn()
+	local child, err = Command(cmd):arg({ "-bL", "--mime-type", "--" }):arg(urls):stdout(Command.PIPED):spawn()
 	if not child then
 		return true, Err("Failed to start `%s`, error: %s", cmd, err)
 	end

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -33,7 +33,7 @@ function M:preload(job)
 
 	-- stylua: ignore
 	local output, err = Command("pdftoppm")
-		:args({
+		:arg({
 			"-f", job.skip + 1,
 			"-l", job.skip + 1,
 			"-singlefile",

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -53,7 +53,7 @@ function M:preload(job)
 	end
 
 	-- stylua: ignore
-	local cmd = Command("ffmpeg"):args({
+	local cmd = Command("ffmpeg"):arg({
 		"-v", "quiet", "-threads", 1, "-hwaccel", "auto",
 		"-skip_frame", "nokey",
 		"-an", "-sn", "-dn",
@@ -68,7 +68,7 @@ function M:preload(job)
 	end
 
 	-- stylua: ignore
-	local status, err = cmd:args({
+	local status, err = cmd:arg({
 		"-vframes", 1,
 		"-q:v", 31 - math.floor(rt.preview.image_quality * 0.3),
 		"-vf", string.format("scale='min(%d,iw)':'min(%d,ih)':force_original_aspect_ratio=decrease:flags=fast_bilinear", rt.preview.max_width, rt.preview.max_height),
@@ -131,7 +131,7 @@ function M.list_meta(url, entries)
 		cmd = cmd:args { "-select_streams", "v" }
 	end
 
-	local output, err = cmd:args({ "-show_entries", entries, "-of", "json=c=1", tostring(url) }):output()
+	local output, err = cmd:arg({ "-show_entries", entries, "-of", "json=c=1", tostring(url) }):output()
 	if not output then
 		return nil, Err("Failed to start `ffprobe`, error: %s", err)
 	end

--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -49,7 +49,7 @@ local function options()
 end
 
 local function empty(cwd)
-	local child = Command("zoxide"):args({ "query", "-l", "--exclude" }):arg(cwd):stdout(Command.PIPED):spawn()
+	local child = Command("zoxide"):arg({ "query", "-l", "--exclude", cwd }):stdout(Command.PIPED):spawn()
 	if not child then
 		return true
 	end
@@ -89,8 +89,7 @@ local function entry()
 
 	local _permit = ya.hide()
 	local child, err1 = Command("zoxide")
-		:args({ "query", "-i", "--exclude" })
-		:arg(st.cwd)
+		:arg({ "query", "-i", "--exclude", st.cwd })
 		:env("SHELL", "sh")
 		:env("CLICOLOR", 1)
 		:env("CLICOLOR_FORCE", 1)

--- a/yazi-plugin/src/composer.rs
+++ b/yazi-plugin/src/composer.rs
@@ -8,7 +8,7 @@ impl Composer {
 		F: Fn(&Lua, &[u8]) -> mlua::Result<Value> + 'static,
 	{
 		let index = lua.create_function(move |lua, (ts, key): (Table, mlua::String)| {
-			let v = f(lua, key.as_bytes().as_ref())?;
+			let v = f(lua, &key.as_bytes())?;
 			ts.raw_set(key, v.clone())?;
 			Ok(v)
 		})?;

--- a/yazi-plugin/src/lib.rs
+++ b/yazi-plugin/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unit_arg)]
+#![allow(clippy::if_same_then_else, clippy::unit_arg)]
 
 mod macros;
 

--- a/yazi-plugin/src/process/command.rs
+++ b/yazi-plugin/src/process/command.rs
@@ -156,7 +156,7 @@ impl UserData for Command {
 		methods.add_function_mut("args", |lua, (ud, args): (AnyUserData, Vec<mlua::String>)| {
 			crate::deprecate!(
 				lua,
-				"The `args()` method on `Command` is deprecated, use `arg()` instead in your {}\n\nSee #2653 for more details: https://github.com/sxyazi/yazi/pull/2653"
+				"The `args()` method on `Command` is deprecated, use `arg()` instead in your {}\n\nSee #2752 for more details: https://github.com/sxyazi/yazi/pull/2752"
 			);
 
 			{

--- a/yazi-plugin/src/utils/utils.rs
+++ b/yazi-plugin/src/utils/utils.rs
@@ -65,7 +65,7 @@ pub fn compose(lua: &Lua, isolate: bool) -> mlua::Result<Value> {
 			b"target_family" => Utils::target_family(lua)?,
 
 			// Text
-			b"hash" => Utils::hash(lua, false)?,
+			b"hash" => Utils::hash(lua)?,
 			b"quote" => Utils::quote(lua)?,
 			b"truncate" => Utils::truncate(lua)?,
 			b"clipboard" => Utils::clipboard(lua)?,


### PR DESCRIPTION
Initially, the `args()` method was introduced to be consistent with [Rust's `args()`](https://doc.rust-lang.org/std/process/struct.Command.html#method.args), but in practice it turned out to be not significant, since Lua's method arguments can be of any type and most of the existing APIs work the same task with different parameters passed to a same method.

So, this PR adds support for table parameter types to the existing [`arg()`](https://yazi-rs.github.io/docs/plugins/utils/#Command.arg) method (in addition to the previously supported single string parameter) and serves as a direct replacement for `args()`.

## Deprecated

```diff
- Command("ls"):args { "-a", "-l" }
+ Command("ls"):arg { "-a", "-l" }
```