### PR TITLE
feat: new `ya pkg` subcommand

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -64,7 +64,7 @@ pub(super) enum CommandPkg {
 		#[arg(index = 1, num_args = 1..)]
 		ids: Vec<String>,
 	},
-	/// Remove packages.
+	/// Delete packages.
 	#[command(arg_required_else_help = true)]
 	Delete {
 		/// The packages to delete.

--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -22,7 +22,11 @@ pub(super) enum Command {
 	/// Emit a command to be executed by the specified instance.
 	EmitTo(CommandEmitTo),
 	/// Manage packages.
-	Pack(CommandPack),
+	#[command(subcommand)]
+	Pkg(CommandPkg),
+	#[command(hide = true)]
+	/// Manage packages.
+	Pack(CommandPack), // TODO: remove
 	/// Publish a message to the current instance.
 	Pub(CommandPub),
 	/// Publish a message to the specified instance.
@@ -49,6 +53,33 @@ pub(super) struct CommandEmitTo {
 	/// The arguments of the command.
 	#[arg(allow_hyphen_values = true, trailing_var_arg = true)]
 	pub(super) args:     Vec<String>,
+}
+
+#[derive(Subcommand)]
+pub(super) enum CommandPkg {
+	/// Add packages.
+	#[command(arg_required_else_help = true)]
+	Add {
+		/// The packages to add.
+		#[arg(index = 1, num_args = 1..)]
+		ids: Vec<String>,
+	},
+	/// Remove packages.
+	#[command(arg_required_else_help = true)]
+	Delete {
+		/// The packages to delete.
+		#[arg(index = 1, num_args = 1..)]
+		ids: Vec<String>,
+	},
+	/// Install all packages.
+	#[command(arg_required_else_help = true)]
+	Install,
+	/// List all packages.
+	#[command(arg_required_else_help = true)]
+	List,
+	/// Upgrade all packages.
+	#[command(arg_required_else_help = true)]
+	Upgrade,
 }
 
 #[derive(clap::Args)]

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -60,8 +60,24 @@ async fn run() -> anyhow::Result<()> {
 			}
 		}
 
+		Command::Pkg(cmd) => {
+			package::init()?;
+
+			let mut pkg = package::Package::load().await?;
+			match cmd {
+				CommandPkg::Add { ids } => pkg.add_many(&ids).await?,
+				CommandPkg::Delete { ids } => pkg.delete_many(&ids).await?,
+				CommandPkg::Install => pkg.install(false).await?,
+				CommandPkg::List => pkg.print()?,
+				CommandPkg::Upgrade => pkg.install(true).await?,
+			}
+		}
+
 		Command::Pack(cmd) => {
 			package::init()?;
+			outln!(
+				"WARNING: `ya pack` is deprecated, use the new `ya pkg` instead. See https://github.com/sxyazi/yazi/pull/2770 for more details."
+			)?;
 			if cmd.install {
 				package::Package::load().await?.install(false).await?;
 			} else if cmd.list {


### PR DESCRIPTION
This PR deprecates the `ya pack` subcommand and introduces the new `ya pkg` command as its replacement.

The old `ya pack` uses options to indicate the current action, such as `-a` to add a package:

```sh
ya pack -a owner/my-plugin
```

However, because options are not unique and multiple options can be combined semantically, this leads to ambiguity. For example, specifying both the add (`-a`) and the list (`-l`) options at the same time:

```sh
ya pack -a owner/my-plugin -l
```

This also limits the possibility of adding more options for certain operations. For instance, [adding a new option (`-f`)](https://github.com/sxyazi/yazi/issues/2735) to indicate forced deletion for the delete action (`-d`):

```sh
ya pack -d owner/my-plugin -f
```

But since `-f` is at the same level as `-d`, it's difficult to understand their relationship – whether `-f` represents an action or a parameter of an action.

The new `ya pkg` command accepts the action as a required positional subcommand parameter, which resolves this issue:

```sh
ya pkg delete owner/my-plugin
ya pkg delete owner/my-plugin -f
```

## Deprecation

`ya pack` has been deprecated. Please use the new `ya pkg` command instead, doc: https://yazi-rs.github.io/docs/cli#pm

Considering that `ya pack` has been widely used, it will remain available for a considerable period and will warn users to switch to the new `ya pkg` command upon invocation.