### PR TITLE
feat: make custom tab bar easier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,5 @@ Resolves #
 <!--
 A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.
 
-If it already been detailed in the associated issue, please skip this section.
+If it has already been detailed in the associated issue, please skip this section.
 -->

--- a/yazi-plugin/preset/components/modal.lua
+++ b/yazi-plugin/preset/components/modal.lua
@@ -38,7 +38,7 @@ end
 function Modal:children_redraw()
 	local elements = {}
 	for _, child in ipairs(self._children) do
-		elements = ya.list_merge(elements, ya.redraw_with(child[1]:new(self._area)))
+		elements = ya.list_merge(elements, ui.redraw(child[1]:new(self._area)))
 	end
 	return elements
 end

--- a/yazi-plugin/preset/components/parent.lua
+++ b/yazi-plugin/preset/components/parent.lua
@@ -26,9 +26,7 @@ function Parent:redraw()
 		}
 	end
 
-	return {
-		ui.List(items):area(self._area),
-	}
+	return ui.List(items):area(self._area)
 end
 
 -- Mouse events

--- a/yazi-plugin/preset/components/progress.lua
+++ b/yazi-plugin/preset/components/progress.lua
@@ -40,9 +40,7 @@ function Progress:redraw()
 	end
 
 	local left = progress.total - progress.succ
-	return {
-		gauge
-			:percent(percent)
-			:label(ui.Span(string.format("%3d%%, %d left", percent, left)):style(th.status.progress_label)),
-	}
+	return gauge
+		:percent(percent)
+		:label(ui.Span(string.format("%3d%%, %d left", percent, left)):style(th.status.progress_label))
 end

--- a/yazi-plugin/preset/components/rail.lua
+++ b/yazi-plugin/preset/components/rail.lua
@@ -24,7 +24,7 @@ function Rail:reflow() return {} end
 function Rail:redraw()
 	local elements = self._base or {}
 	for _, child in ipairs(self._children) do
-		elements = ya.list_merge(elements, ya.redraw_with(child))
+		elements = ya.list_merge(elements, ui.redraw(child))
 	end
 	return elements
 end

--- a/yazi-plugin/preset/components/root.lua
+++ b/yazi-plugin/preset/components/root.lua
@@ -15,7 +15,7 @@ function Root:layout()
 		:direction(ui.Layout.VERTICAL)
 		:constraints({
 			ui.Constraint.Length(1),
-			ui.Constraint.Length(#cx.tabs > 1 and 1 or 0),
+			ui.Constraint.Length(Tabs.height()),
 			ui.Constraint.Fill(1),
 			ui.Constraint.Length(1),
 		})
@@ -43,7 +43,7 @@ end
 function Root:redraw()
 	local elements = self._base or {}
 	for _, child in ipairs(self._children) do
-		elements = ya.list_merge(elements, ya.redraw_with(child))
+		elements = ya.list_merge(elements, ui.redraw(child))
 	end
 	return elements
 end

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -142,7 +142,7 @@ function Status:redraw()
 		ui.Text(""):area(self._area):style(th.status.overall),
 		ui.Line(left):area(self._area),
 		ui.Line(right):area(self._area):align(ui.Line.RIGHT),
-		table.unpack(ya.redraw_with(Progress:new(self._area, right_width))),
+		table.unpack(ui.redraw(Progress:new(self._area, right_width))),
 	}
 end
 

--- a/yazi-plugin/preset/components/tab.lua
+++ b/yazi-plugin/preset/components/tab.lua
@@ -41,7 +41,7 @@ end
 function Tab:redraw()
 	local elements = self._base or {}
 	for _, child in ipairs(self._children) do
-		elements = ya.list_merge(elements, ya.redraw_with(child))
+		elements = ya.list_merge(elements, ui.redraw(child))
 	end
 	return elements
 end

--- a/yazi-plugin/preset/components/tabs.lua
+++ b/yazi-plugin/preset/components/tabs.lua
@@ -38,8 +38,10 @@ function Tabs:redraw()
 	end
 
 	lines[#lines + 1] = ui.Line(th.tabs.sep_outer.close):fg(th.tabs.inactive.bg)
-	return { ui.Line(lines):area(self._area) }
+	return ui.Line(lines):area(self._area)
 end
+
+function Tabs.height() return #cx.tabs > 1 and 1 or 0 end
 
 function Tabs:inner_width()
 	local si, so = th.tabs.sep_inner, th.tabs.sep_outer

--- a/yazi-plugin/src/utils/call.rs
+++ b/yazi-plugin/src/utils/call.rs
@@ -1,6 +1,4 @@
-use mlua::{Function, Lua, ObjectLike, Table};
-use tracing::error;
-use yazi_config::LAYOUT;
+use mlua::{Function, Lua, Table};
 use yazi_dds::Sendable;
 use yazi_macro::{emit, render};
 use yazi_shared::{Layer, event::Cmd};
@@ -12,29 +10,6 @@ impl Utils {
 		lua.create_function(|_, ()| {
 			render!();
 			Ok(())
-		})
-	}
-
-	pub(super) fn redraw_with(lua: &Lua) -> mlua::Result<Function> {
-		lua.create_function(|lua, c: Table| {
-			let id: mlua::String = c.get("_id")?;
-
-			let mut layout = LAYOUT.get();
-			match id.as_bytes().as_ref() {
-				b"current" => layout.current = *c.raw_get::<crate::elements::Rect>("_area")?,
-				b"preview" => layout.preview = *c.raw_get::<crate::elements::Rect>("_area")?,
-				b"progress" => layout.progress = *c.raw_get::<crate::elements::Rect>("_area")?,
-				_ => {}
-			}
-
-			LAYOUT.set(layout);
-			match c.call_method::<Table>("redraw", ()) {
-				Err(e) => {
-					error!("Failed to `redraw()` the `{}` component:\n{e}", id.display());
-					lua.create_table()
-				}
-				ok => ok,
-			}
 		})
 	}
 

--- a/yazi-plugin/src/utils/utils.rs
+++ b/yazi-plugin/src/utils/utils.rs
@@ -16,7 +16,6 @@ pub fn compose(lua: &Lua, isolate: bool) -> mlua::Result<Value> {
 
 			// Call
 			b"render" => Utils::render(lua)?,
-			b"redraw_with" => Utils::redraw_with(lua)?,
 			b"emit" => Utils::emit(lua)?,
 			b"app_emit" => Utils::app_emit(lua)?,
 			b"mgr_emit" => Utils::mgr_emit(lua)?,


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves https://github.com/sxyazi/yazi/discussions/2780

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it already been detailed in the associated issue, please skip this section.
-->

With this PR, you can more easily replace the default tab bar with a custom one.

For example, the following code mimics the old version of Yazi's tab bar, where the tab bar is positioned at the right side of the header instead of on its own line:

```lua
function Tabs.height() return 0 end

Header:children_add(function()
  if #cx.tabs == 0 then return "" end
  local spans = {}
  for i = 1, #cx.tabs do
    spans[#spans + 1] = ui.Span(" " .. i .. " ")
  end
  spans[cx.tabs.idx]:reverse()
  return ui.Line(spans)
end, 9000, Header.RIGHT)
```

For the currently active tab, the `reverse()` style is applied, but you can add any style you like, https://yazi-rs.github.io/docs/plugins/layout/#style