### PR TITLE
feat: new `ui.Align`, `ui.Wrap`, and `ui.Edge`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,9 +2390,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/yazi-plugin/preset/components/current.lua
+++ b/yazi-plugin/preset/components/current.lua
@@ -20,7 +20,7 @@ function Current:empty()
 	end
 
 	return {
-		ui.Line(s):area(self._area):align(ui.Line.CENTER),
+		ui.Line(s):area(self._area):align(ui.Align.CENTER),
 	}
 end
 
@@ -43,7 +43,7 @@ function Current:redraw()
 
 	return {
 		ui.List(left):area(self._area),
-		ui.Text(right):area(self._area):align(ui.Text.RIGHT),
+		ui.Text(right):area(self._area):align(ui.Align.RIGHT),
 	}
 end
 

--- a/yazi-plugin/preset/components/header.lua
+++ b/yazi-plugin/preset/components/header.lua
@@ -1,4 +1,5 @@
 Header = {
+	-- TODO: remove these two constants
 	LEFT = 0,
 	RIGHT = 1,
 
@@ -83,7 +84,7 @@ function Header:redraw()
 
 	return {
 		ui.Line(left):area(self._area),
-		ui.Line(right):area(self._area):align(ui.Line.RIGHT),
+		ui.Line(right):area(self._area):align(ui.Align.RIGHT),
 	}
 end
 

--- a/yazi-plugin/preset/components/marker.lua
+++ b/yazi-plugin/preset/components/marker.lua
@@ -29,7 +29,7 @@ function Marker:redraw()
 			w = 1,
 			h = math.min(1 + last[2] - last[1], self._area.y + self._area.h - y),
 		}
-		elements[#elements + 1] = ui.Bar(ui.Bar.LEFT):area(rect):style(last[3])
+		elements[#elements + 1] = ui.Bar(ui.Edge.LEFT):area(rect):style(last[3])
 	end
 
 	local last = { 0, 0, nil } -- start, end, style

--- a/yazi-plugin/preset/components/rail.lua
+++ b/yazi-plugin/preset/components/rail.lua
@@ -10,8 +10,8 @@ end
 
 function Rail:build()
 	self._base = {
-		ui.Bar(ui.Bar.RIGHT):area(self._chunks[1]):symbol(th.mgr.border_symbol):style(th.mgr.border_style),
-		ui.Bar(ui.Bar.LEFT):area(self._chunks[3]):symbol(th.mgr.border_symbol):style(th.mgr.border_style),
+		ui.Bar(ui.Edge.RIGHT):area(self._chunks[1]):symbol(th.mgr.border_symbol):style(th.mgr.border_style),
+		ui.Bar(ui.Edge.LEFT):area(self._chunks[3]):symbol(th.mgr.border_symbol):style(th.mgr.border_style),
 	}
 	self._children = {
 		Marker:new(self._chunks[1], self._tab.parent),

--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -1,4 +1,5 @@
 Status = {
+	-- TODO: remove these two constants
 	LEFT = 0,
 	RIGHT = 1,
 
@@ -141,7 +142,7 @@ function Status:redraw()
 	return {
 		ui.Text(""):area(self._area):style(th.status.overall),
 		ui.Line(left):area(self._area),
-		ui.Line(right):area(self._area):align(ui.Line.RIGHT),
+		ui.Line(right):area(self._area):align(ui.Align.RIGHT),
 		table.unpack(ui.redraw(Progress:new(self._area, right_width))),
 	}
 end

--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -45,7 +45,7 @@ function M:peek(job)
 	else
 		ya.preview_widget(job, {
 			ui.Text(left):area(job.area),
-			ui.Text(right):area(job.area):align(ui.Text.RIGHT),
+			ui.Text(right):area(job.area):align(ui.Align.RIGHT),
 		})
 	end
 end

--- a/yazi-plugin/preset/plugins/empty.lua
+++ b/yazi-plugin/preset/plugins/empty.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.msg(job, s) ya.preview_widget(job, ui.Text(ui.Line(s):reverse()):area(job.area):wrap(ui.Text.WRAP)) end
+function M.msg(job, s) ya.preview_widget(job, ui.Text(ui.Line(s):reverse()):area(job.area):wrap(ui.Wrap.YES)) end
 
 function M:peek(job)
 	local path = tostring(job.file.url)

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -11,7 +11,7 @@ function M:peek(job)
 		text = ui.Text(string.format("Failed to start `%s`, error: %s", cmd, err))
 	end
 
-	ya.preview_widget(job, text:area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, text:area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/folder.lua
+++ b/yazi-plugin/preset/plugins/folder.lua
@@ -16,7 +16,7 @@ function M:peek(job)
 	if #folder.files == 0 then
 		local done, err = folder.stage()
 		local s = not done and "Loading..." or not err and "No items" or string.format("Error: %s", err)
-		return ya.preview_widget(job, ui.Line(s):area(job.area):align(ui.Line.CENTER))
+		return ya.preview_widget(job, ui.Line(s):area(job.area):align(ui.Align.CENTER))
 	end
 
 	local items = {}

--- a/yazi-plugin/preset/plugins/font.lua
+++ b/yazi-plugin/preset/plugins/font.lua
@@ -16,7 +16,7 @@ function M:peek(job)
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
 	local _, err = ya.image_show(cache, job.area)
-	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/image.lua
+++ b/yazi-plugin/preset/plugins/image.lua
@@ -9,7 +9,7 @@ function M:peek(job)
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
 	local _, err = ya.image_show(url, job.area)
-	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/json.lua
+++ b/yazi-plugin/preset/plugins/json.lua
@@ -34,7 +34,7 @@ function M:peek(job)
 		lines = lines:gsub("\t", string.rep(" ", rt.preview.tab_size))
 		ya.preview_widget(
 			job,
-			ui.Text.parse(lines):area(job.area):wrap(rt.preview.wrap == "yes" and ui.Text.WRAP or ui.Text.WRAP_NO)
+			ui.Text.parse(lines):area(job.area):wrap(rt.preview.wrap == "yes" and ui.Wrap.YES or ui.Wrap.NO)
 		)
 	end
 end

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -14,7 +14,7 @@ function M:peek(job)
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
 	local _, err = ya.image_show(cache, job.area)
-	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -14,7 +14,7 @@ function M:peek(job)
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
 	local _, err = ya.image_show(cache, job.area)
-	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek(job)

--- a/yazi-plugin/preset/plugins/svg.lua
+++ b/yazi-plugin/preset/plugins/svg.lua
@@ -14,7 +14,7 @@ function M:peek(job)
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
 	local _, err = ya.image_show(cache, job.area)
-	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek() end

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -14,7 +14,7 @@ function M:peek(job)
 	ya.sleep(math.max(0, rt.preview.image_delay / 1000 + start - os.clock()))
 
 	local _, err = ya.image_show(cache, job.area)
-	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Text.WRAP))
+	ya.preview_widget(job, err and ui.Text(tostring(err)):area(job.area):wrap(ui.Wrap.YES))
 end
 
 function M:seek(job)

--- a/yazi-plugin/src/elements/align.rs
+++ b/yazi-plugin/src/elements/align.rs
@@ -1,0 +1,42 @@
+use std::ops::Deref;
+
+use mlua::{FromLua, IntoLua, Lua, Value};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Align(pub(super) ratatui::layout::Alignment);
+
+impl Deref for Align {
+	type Target = ratatui::layout::Alignment;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl Align {
+	pub fn compose(lua: &Lua) -> mlua::Result<Value> {
+		lua.create_table_from([("LEFT", 0), ("CENTER", 1), ("RIGHT", 2)])?.into_lua(lua)
+	}
+}
+
+impl FromLua for Align {
+	fn from_lua(value: Value, _: &Lua) -> mlua::Result<Self> {
+		let Value::Integer(n) = value else {
+			return Err(mlua::Error::FromLuaConversionError {
+				from:    value.type_name(),
+				to:      "Align".to_string(),
+				message: Some("expected an integer representation of Align".to_string()),
+			});
+		};
+		Ok(Self(match n {
+			0 => ratatui::layout::Alignment::Left,
+			1 => ratatui::layout::Alignment::Center,
+			2 => ratatui::layout::Alignment::Right,
+			_ => {
+				return Err(mlua::Error::FromLuaConversionError {
+					from:    value.type_name(),
+					to:      "Align".to_string(),
+					message: Some("invalid value for Align".to_string()),
+				});
+			}
+		}))
+	}
+}

--- a/yazi-plugin/src/elements/align.rs
+++ b/yazi-plugin/src/elements/align.rs
@@ -30,13 +30,11 @@ impl FromLua for Align {
 			0 => ratatui::layout::Alignment::Left,
 			1 => ratatui::layout::Alignment::Center,
 			2 => ratatui::layout::Alignment::Right,
-			_ => {
-				return Err(mlua::Error::FromLuaConversionError {
-					from:    value.type_name(),
-					to:      "Align".to_string(),
-					message: Some("invalid value for Align".to_string()),
-				});
-			}
+			_ => Err(mlua::Error::FromLuaConversionError {
+				from:    value.type_name(),
+				to:      "Align".to_string(),
+				message: Some("invalid value for Align".to_string()),
+			})?,
 		}))
 	}
 }

--- a/yazi-plugin/src/elements/edge.rs
+++ b/yazi-plugin/src/elements/edge.rs
@@ -1,0 +1,48 @@
+use std::ops::Deref;
+
+use mlua::{FromLua, IntoLua, Lua, Value};
+use ratatui::widgets::Borders;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Edge(pub Borders);
+
+impl Deref for Edge {
+	type Target = Borders;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl Edge {
+	pub fn compose(lua: &Lua) -> mlua::Result<Value> {
+		lua
+			.create_table_from([
+				("NONE", Borders::NONE.bits()),
+				("TOP", Borders::TOP.bits()),
+				("RIGHT", Borders::RIGHT.bits()),
+				("BOTTOM", Borders::BOTTOM.bits()),
+				("LEFT", Borders::LEFT.bits()),
+				("ALL", Borders::ALL.bits()),
+			])?
+			.into_lua(lua)
+	}
+}
+
+impl FromLua for Edge {
+	fn from_lua(value: Value, _: &Lua) -> mlua::Result<Self> {
+		let Value::Integer(n) = value else {
+			return Err(mlua::Error::FromLuaConversionError {
+				from:    value.type_name(),
+				to:      "Edge".to_string(),
+				message: Some("expected an integer representation of an Edge".to_string()),
+			});
+		};
+		let Ok(Some(b)) = u8::try_from(n).map(Borders::from_bits) else {
+			return Err(mlua::Error::FromLuaConversionError {
+				from:    value.type_name(),
+				to:      "Edge".to_string(),
+				message: Some("invalid bits for Edge".to_string()),
+			});
+		};
+		Ok(Self(b))
+	}
+}

--- a/yazi-plugin/src/elements/elements.rs
+++ b/yazi-plugin/src/elements/elements.rs
@@ -7,10 +7,12 @@ use crate::Composer;
 pub fn compose(lua: &Lua) -> mlua::Result<Value> {
 	Composer::make(lua, 20, |lua, key| {
 		match key {
+			b"Align" => super::Align::compose(lua)?,
 			b"Bar" => super::Bar::compose(lua)?,
 			b"Border" => super::Border::compose(lua)?,
 			b"Clear" => super::Clear::compose(lua)?,
 			b"Constraint" => super::Constraint::compose(lua)?,
+			b"Edge" => super::Edge::compose(lua)?,
 			b"Gauge" => super::Gauge::compose(lua)?,
 			b"Layout" => super::Layout::compose(lua)?,
 			b"Line" => super::Line::compose(lua)?,

--- a/yazi-plugin/src/elements/line.rs
+++ b/yazi-plugin/src/elements/line.rs
@@ -6,10 +6,7 @@ use ratatui::widgets::Widget;
 use unicode_width::UnicodeWidthChar;
 
 use super::{Area, Span};
-
-const LEFT: u8 = 0;
-const CENTER: u8 = 1;
-const RIGHT: u8 = 2;
+use crate::elements::Align;
 
 const EXPECTED: &str = "expected a string, Span, Line, or a table of them";
 
@@ -40,10 +37,10 @@ impl Line {
 
 		let line = lua.create_table_from([
 			("parse", parse.into_lua(lua)?),
-			// Alignment
-			("LEFT", LEFT.into_lua(lua)?),
-			("CENTER", CENTER.into_lua(lua)?),
-			("RIGHT", RIGHT.into_lua(lua)?),
+			// TODO: remove these constants
+			("LEFT", 0.into_lua(lua)?),
+			("CENTER", 1.into_lua(lua)?),
+			("RIGHT", 2.into_lua(lua)?),
 		])?;
 
 		line.set_metatable(Some(lua.create_table_from([(MetaMethod::Call.name(), new)])?));
@@ -120,12 +117,8 @@ impl UserData for Line {
 		crate::impl_style_shorthands!(methods, inner.style);
 
 		methods.add_method("width", |_, me, ()| Ok(me.inner.width()));
-		methods.add_function_mut("align", |_, (ud, align): (AnyUserData, u8)| {
-			ud.borrow_mut::<Self>()?.inner.alignment = Some(match align {
-				CENTER => ratatui::layout::Alignment::Center,
-				RIGHT => ratatui::layout::Alignment::Right,
-				_ => ratatui::layout::Alignment::Left,
-			});
+		methods.add_function_mut("align", |_, (ud, align): (AnyUserData, Align)| {
+			ud.borrow_mut::<Self>()?.inner.alignment = Some(align.0);
 			Ok(ud)
 		});
 		methods.add_method("visible", |_, me, ()| {

--- a/yazi-plugin/src/elements/mod.rs
+++ b/yazi-plugin/src/elements/mod.rs
@@ -1,3 +1,3 @@
 #![allow(clippy::module_inception)]
 
-yazi_macro::mod_flat!(area bar border cell clear constraint elements gauge layout line list pad pos rect renderable row span style table text utils);
+yazi_macro::mod_flat!(align area bar border cell clear constraint edge elements gauge layout line list pad pos rect renderable row span style table text utils wrap);

--- a/yazi-plugin/src/elements/wrap.rs
+++ b/yazi-plugin/src/elements/wrap.rs
@@ -40,13 +40,11 @@ impl FromLua for Wrap {
 			0 => None,
 			1 => Some(ratatui::widgets::Wrap { trim: false }),
 			2 => Some(ratatui::widgets::Wrap { trim: true }),
-			_ => {
-				return Err(mlua::Error::FromLuaConversionError {
-					from:    value.type_name(),
-					to:      "Wrap".to_string(),
-					message: Some("invalid value for Wrap".to_string()),
-				});
-			}
+			_ => Err(mlua::Error::FromLuaConversionError {
+				from:    value.type_name(),
+				to:      "Wrap".to_string(),
+				message: Some("invalid value for Wrap".to_string()),
+			})?,
 		}))
 	}
 }

--- a/yazi-plugin/src/elements/wrap.rs
+++ b/yazi-plugin/src/elements/wrap.rs
@@ -1,0 +1,52 @@
+use std::ops::Deref;
+
+use mlua::{FromLua, IntoLua, Lua, Value};
+use yazi_config::preview::PreviewWrap;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Wrap(pub(super) Option<ratatui::widgets::Wrap>);
+
+impl Deref for Wrap {
+	type Target = Option<ratatui::widgets::Wrap>;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl Wrap {
+	pub fn compose(lua: &Lua) -> mlua::Result<Value> {
+		lua.create_table_from([("NO", 0), ("YES", 1), ("TRIM", 2)])?.into_lua(lua)
+	}
+}
+
+impl From<PreviewWrap> for Wrap {
+	fn from(value: PreviewWrap) -> Self {
+		Self(match value {
+			PreviewWrap::No => None,
+			PreviewWrap::Yes => Some(ratatui::widgets::Wrap { trim: false }),
+		})
+	}
+}
+
+impl FromLua for Wrap {
+	fn from_lua(value: Value, _: &Lua) -> mlua::Result<Self> {
+		let Value::Integer(n) = value else {
+			return Err(mlua::Error::FromLuaConversionError {
+				from:    value.type_name(),
+				to:      "Wrap".to_string(),
+				message: Some("expected an integer representation of a Wrap".to_string()),
+			});
+		};
+		Ok(Self(match n {
+			0 => None,
+			1 => Some(ratatui::widgets::Wrap { trim: false }),
+			2 => Some(ratatui::widgets::Wrap { trim: true }),
+			_ => {
+				return Err(mlua::Error::FromLuaConversionError {
+					from:    value.type_name(),
+					to:      "Wrap".to_string(),
+					message: Some("invalid value for Wrap".to_string()),
+				});
+			}
+		}))
+	}
+}

--- a/yazi-plugin/src/utils/preview.rs
+++ b/yazi-plugin/src/utils/preview.rs
@@ -1,10 +1,10 @@
 use mlua::{AnyUserData, ExternalError, Function, IntoLuaMulti, Lua, Table, Value};
-use yazi_config::{YAZI, preview::PreviewWrap};
+use yazi_config::YAZI;
 use yazi_macro::emit;
 use yazi_shared::{errors::PeekError, event::Cmd};
 
 use super::Utils;
-use crate::{elements::{Area, Rect, Renderable, Text, WRAP, WRAP_NO}, external::Highlighter, file::FileRef};
+use crate::{elements::{Area, Rect, Renderable, Text}, external::Highlighter, file::FileRef};
 
 #[derive(Debug, Default)]
 pub struct PreviewLock {
@@ -51,7 +51,7 @@ impl Utils {
 			lock.data = vec![Renderable::Text(Text {
 				area,
 				inner,
-				wrap: if YAZI.preview.wrap == PreviewWrap::Yes { WRAP } else { WRAP_NO },
+				wrap: YAZI.preview.wrap.into(),
 				scroll: Default::default(),
 			})];
 

--- a/yazi-plugin/src/utils/spot.rs
+++ b/yazi-plugin/src/utils/spot.rs
@@ -4,7 +4,7 @@ use yazi_macro::emit;
 use yazi_shared::{Id, event::Cmd};
 
 use super::Utils;
-use crate::{elements::Renderable, file::FileRef};
+use crate::{elements::{Edge, Renderable}, file::FileRef};
 
 pub struct SpotLock {
 	pub url:  yazi_shared::url::Url,
@@ -73,7 +73,7 @@ impl Utils {
 				Renderable::Clear(crate::elements::Clear { area }),
 				Renderable::Border(crate::elements::Border {
 					area,
-					position: ratatui::widgets::Borders::ALL,
+					edge: Edge(ratatui::widgets::Borders::ALL),
 					r#type: ratatui::widgets::BorderType::Rounded,
 					style: THEME.spot.border.into(),
 					titles: vec![(


### PR DESCRIPTION
This PR extracts alignment, border type, and wrapping constants from `ui.Line`, `ui.Text`, `ui.Bar`, and `ui.Border` into the new `ui.Align`, `ui.Wrap`, and `ui.Edge`, respectively. Since these constants are used by multiple UI elements, treating them as separate types makes more sense.

I have recently been working on the [Yazi Lua API type definitions](https://github.com/yazi-rs/plugins/tree/main/types.yazi) project, which has also made it easier to define and restrict their types there.

## Deprecated

### `LEFT`, `CENTER`, `RIGHT` on `ui.Line`, `ui.Text` have been deprecated

These constants have been extracted into the new `ui.Align` while retaining their original names, for example:

```diff
- ui.Line.CENTER
+ ui.Align.CENTER
```

### `NONE`, `TOP`, `RIGHT`, `BOTTOM`, `LEFT`, `ALL` on `ui.Bar`, `ui.Border` have been deprecated

These constants have been extracted into the new `ui.Edge` while maintaining their original names, for example:

```diff
- ui.Bar.ALL
+ ui.Edge.ALL
```

### `WRAP_NO`, `WRAP`, `WRAP_TRIM` on `ui.Text` have been deprecated

- `ui.Text.WRAP_NO` => `ui.Wrap.NO`
- `ui.Text.WRAP` => `ui.Wrap.YES`
- `ui.Text.WRAP_TRIM` => `ui.Wrap.TRIM`