### PR TITLE
feat: support `.deb` packages

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -57,8 +57,10 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yazi-${{ matrix.target }}.zip
-          path: yazi-${{ matrix.target }}.zip
+          name: ${{ matrix.target }}
+          path: |
+            yazi-${{ matrix.target }}.zip
+            yazi-${{ matrix.target }}.deb
 
   build-windows:
     strategy:
@@ -100,7 +102,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yazi-${{ matrix.target }}.zip
+          name: ${{ matrix.target }}
           path: yazi-${{ matrix.target }}.zip
 
   build-musl:
@@ -128,8 +130,10 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yazi-${{ matrix.target }}.zip
-          path: yazi-${{ matrix.target }}.zip
+          name: ${{ matrix.target }}
+          path: |
+            yazi-${{ matrix.target }}.zip
+            yazi-${{ matrix.target }}.deb
 
   build-snap:
     strategy:
@@ -206,6 +210,7 @@ jobs:
           draft: true
           files: |
             yazi-*.zip
+            yazi-*.deb
             yazi-*.snap
           generate_release_notes: true
 
@@ -241,6 +246,7 @@ jobs:
           prerelease: true
           files: |
             yazi-*.zip
+            yazi-*.deb
             yazi-*.snap
           name: Nightly Build
           body: ${{ env.NIGHTLY_BODY }}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: yazi-${{ matrix.arch }}.snap
+          name: ${{ matrix.arch }}
           path: yazi-${{ matrix.arch }}.snap
 
   snap:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,6 +3679,10 @@ name = "yazi-macro"
 version = "25.6.11"
 
 [[package]]
+name = "yazi-packing"
+version = "25.5.28"
+
+[[package]]
 name = "yazi-plugin"
 version = "25.6.11"
 dependencies = [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,3 +21,7 @@ if ! command -v zip &> /dev/null; then
 	apt-get update && apt-get install -yq zip
 fi
 zip -r "$ARTIFACT_NAME.zip" "$ARTIFACT_NAME"
+
+# build deb package (see https://crates.io/crates/cargo-deb)
+## run it after build
+cargo deb -p yazi-fm --no-build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,5 @@ if ! command -v zip &> /dev/null; then
 fi
 zip -r "$ARTIFACT_NAME.zip" "$ARTIFACT_NAME"
 
-# build deb package (see https://crates.io/crates/cargo-deb)
-## run it after build
-cargo deb -p yazi-fm --no-build
+# Package deb
+cargo deb -p yazi-packing --no-build -o "$ARTIFACT_NAME.deb"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,4 +23,5 @@ fi
 zip -r "$ARTIFACT_NAME.zip" "$ARTIFACT_NAME"
 
 # Package deb
+cargo install cargo-deb
 cargo deb -p yazi-packing --no-build -o "$ARTIFACT_NAME.deb"

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -76,3 +76,22 @@ path = "src/main.rs"
 [package.metadata.binstall]
 pkg-url = "{repo}/releases/download/v{version}/yazi-{target}{archive-suffix}"
 bin-dir = "yazi-{target}/{bin}{binary-ext}"
+
+[package.metadata.deb]
+license-file = ["../LICENSE", "0"]
+extended-description = """
+Yazi is a terminal file manager written in Rust, based on non-blocking async 
+I/O. It aims to provide an efficient, user-friendly, and customizable file 
+management experience.
+"""
+depends = "file, ffmpeg, 7zip, jq, poppler-utils, fd-find, ripgrep, fzf, zoxide, imagemagick, xsel|xclip|wl-clipboard"
+recommends = "bash-completion"
+section = "utility"
+priority = "optional"
+assets = [
+    ["target/release/ya", "usr/bin/", "755"],
+    ["target/release/yazi", "usr/bin/", "755"],
+    { source = "../README.md", dest = "usr/share/doc/yazi-fm/README", mode = "644"},
+    { source = "../yazi-cli/completions/ya.bash", dest = "usr/share/bash-completion/completions/ya", mode = "644"},
+    { source = "../yazi-boot/completions/yazi.bash", dest = "usr/share/bash-completion/completions/yazi", mode = "644"},
+]

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -76,22 +76,3 @@ path = "src/main.rs"
 [package.metadata.binstall]
 pkg-url = "{repo}/releases/download/v{version}/yazi-{target}{archive-suffix}"
 bin-dir = "yazi-{target}/{bin}{binary-ext}"
-
-[package.metadata.deb]
-license-file = ["../LICENSE", "0"]
-extended-description = """
-Yazi is a terminal file manager written in Rust, based on non-blocking async 
-I/O. It aims to provide an efficient, user-friendly, and customizable file 
-management experience.
-"""
-depends = "file, ffmpeg, 7zip, jq, poppler-utils, fd-find, ripgrep, fzf, zoxide, imagemagick, xsel|xclip|wl-clipboard"
-recommends = "bash-completion"
-section = "utility"
-priority = "optional"
-assets = [
-    ["target/release/ya", "usr/bin/", "755"],
-    ["target/release/yazi", "usr/bin/", "755"],
-    { source = "../README.md", dest = "usr/share/doc/yazi-fm/README", mode = "644"},
-    { source = "../yazi-cli/completions/ya.bash", dest = "usr/share/bash-completion/completions/ya", mode = "644"},
-    { source = "../yazi-boot/completions/yazi.bash", dest = "usr/share/bash-completion/completions/yazi", mode = "644"},
-]

--- a/yazi-packing/Cargo.toml
+++ b/yazi-packing/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name        = "yazi-packing"
+version     = "25.5.28"
+edition     = "2024"
+license     = "MIT"
+authors     = [ "sxyazi <sxyazi@gmail.com>" ]
+description = "Yazi packing"
+homepage    = "https://yazi-rs.github.io"
+repository  = "https://github.com/sxyazi/yazi"
+
+	[package.metadata.deb]
+	name                      = "yazi"
+	license-file              = [ "../LICENSE", "0" ]
+	depends                   = "file, ffmpeg, 7zip, jq, poppler-utils, fd-find, ripgrep, fzf, zoxide, imagemagick, xsel|xclip|wl-clipboard"
+	recommends                = "bash-completion"
+	extended-description-file = "README.md"
+	section                   = "utility"
+	priority                  = "optional"
+	assets                    = [
+		[ "target/release/ya", "usr/bin/", "755" ],
+		[ "target/release/yazi", "usr/bin/", "755" ],
+		[ "../README.md",  "usr/share/doc/yazi/README", "644" ],
+		[ "../yazi-cli/completions/ya.bash", "usr/share/bash-completion/completions/ya", "644" ],
+		[ "../yazi-boot/completions/yazi.bash", "usr/share/bash-completion/completions/yazi", "644" ],
+	]


### PR DESCRIPTION
Added packaging of already built binary files into a valid deb package.

Tested on Ubuntu 24.04

I haven't had a chance to test on different Ubuntu/Debian versions, but as far as I can tell, resulting deb file doesn't have any distribution and version-specific features. So it should work everywhere.

Besides bin files the package installs completion for bash, README.md, LICENSE all dependencies specified in the documentation

recommended way to install the deb package:
```
sudo apt install ./yazi-fm_<version>.deb
```

list of files:
```
❯ dpkg-query -L yazi-fm
/usr
/usr/share
/usr/share/bash-completion
/usr/share/bash-completion/completions
/usr/share/bash-completion/completions/ya
/usr/share/bash-completion/completions/yazi
/usr/share/doc
/usr/share/doc/yazi-fm
/usr/share/doc/yazi-fm/README
/usr/share/doc/yazi-fm/copyright
/usr/bin
/usr/bin/ya
/usr/bin/yazi
```