### PR TITLE
chore(nix): use ffmpeg instead of ffmpegthumbnailer (#1928)

### DIFF
--- a/nix/yazi.nix
+++ b/nix/yazi.nix
@@ -14,7 +14,7 @@
   jq,
   poppler_utils,
   _7zz,
-  ffmpegthumbnailer,
+  ffmpeg,
   fd,
   ripgrep,
   fzf,
@@ -40,7 +40,7 @@ let
     jq
     poppler_utils
     _7zz
-    ffmpegthumbnailer
+    ffmpeg
     fd
     ripgrep
     fzf


### PR DESCRIPTION

## Which issue does this PR resolve?

Now yazi is using ffmpeg instead of ffmpegthumbnailer, and nix system hasn't updated its deps.

Resolves #

Replace ffmpegthumbnailer with ffmpeg for generating previews, bringing the Nix build in line with changes introduced in commit 0f9a3195 (feat!: video spotter & use ffmpeg as previewer backend).
