### PR TITLE
fix: `cd` on the initial creation of a tab should not be added to the backstack

### DIFF
--- a/yazi-core/src/mgr/commands/tab_create.rs
+++ b/yazi-core/src/mgr/commands/tab_create.rs
@@ -3,7 +3,7 @@ use yazi_macro::render;
 use yazi_proxy::AppProxy;
 use yazi_shared::{event::CmdCow, url::Url};
 
-use crate::{mgr::Tabs, tab::Tab};
+use crate::{mgr::Tabs, tab::{Tab, commands::CdSource}};
 
 const MAX_TABS: usize = 9;
 
@@ -35,15 +35,15 @@ impl Tabs {
 
 		let mut tab = Tab::default();
 		if !opt.current {
-			tab.cd(opt.url);
+			tab.cd((opt.url, CdSource::Tab));
 		} else if let Some(h) = self.active().hovered() {
 			tab.pref = self.active().pref.clone();
 			tab.apply_files_attrs();
-			tab.reveal(h.url.to_regular());
+			tab.reveal((h.url.to_regular(), CdSource::Tab));
 		} else {
 			tab.pref = self.active().pref.clone();
 			tab.apply_files_attrs();
-			tab.cd(self.active().cwd().to_regular());
+			tab.cd((self.active().cwd().to_regular(), CdSource::Tab));
 		}
 
 		self.items.insert(self.cursor + 1, tab);

--- a/yazi-core/src/mgr/tabs.rs
+++ b/yazi-core/src/mgr/tabs.rs
@@ -6,7 +6,7 @@ use yazi_fs::File;
 use yazi_proxy::MgrProxy;
 use yazi_shared::{Id, url::Url};
 
-use crate::tab::{Folder, Tab};
+use crate::tab::{Folder, Tab, commands::CdSource};
 
 pub struct Tabs {
 	pub cursor:       usize,
@@ -21,9 +21,9 @@ impl Tabs {
 		for (i, tab) in tabs.iter_mut().enumerate() {
 			let file = &BOOT.files[i];
 			if file.is_empty() {
-				tab.cd(Url::from(&BOOT.cwds[i]));
+				tab.cd((Url::from(&BOOT.cwds[i]), CdSource::Tab));
 			} else {
-				tab.reveal(Url::from(BOOT.cwds[i].join(file)));
+				tab.reveal((Url::from(BOOT.cwds[i].join(file)), CdSource::Tab));
 			}
 		}
 		tabs

--- a/yazi-core/src/tab/commands/back.rs
+++ b/yazi-core/src/tab/commands/back.rs
@@ -1,14 +1,12 @@
 use yazi_shared::event::CmdCow;
 
+use super::cd::CdSource;
 use crate::tab::Tab;
 
 impl Tab {
 	pub fn back(&mut self, _: CmdCow) {
-		if self.current.url.is_regular() {
-			self.backstack.push(&self.current.url);
-		}
 		if let Some(u) = self.backstack.shift_backward().cloned() {
-			self.cd((u, super::cd::OptSource::Back));
+			self.cd((u, CdSource::Back));
 		}
 	}
 }

--- a/yazi-core/src/tab/commands/enter.rs
+++ b/yazi-core/src/tab/commands/enter.rs
@@ -1,5 +1,6 @@
 use yazi_shared::event::CmdCow;
 
+use super::cd::CdSource;
 use crate::tab::Tab;
 
 impl Tab {
@@ -8,6 +9,6 @@ impl Tab {
 			.hovered()
 			.filter(|h| h.is_dir())
 			.map(|h| h.url.to_regular())
-			.map(|u| self.cd((u, super::cd::OptSource::Enter)));
+			.map(|u| self.cd((u, CdSource::Enter)));
 	}
 }

--- a/yazi-core/src/tab/commands/forward.rs
+++ b/yazi-core/src/tab/commands/forward.rs
@@ -1,14 +1,12 @@
 use yazi_shared::event::CmdCow;
 
+use super::cd::CdSource;
 use crate::tab::Tab;
 
 impl Tab {
 	pub fn forward(&mut self, _: CmdCow) {
-		if self.current.url.is_regular() {
-			self.backstack.push(&self.current.url);
-		}
 		if let Some(u) = self.backstack.shift_forward().cloned() {
-			self.cd((u, super::cd::OptSource::Forward));
+			self.cd((u, CdSource::Forward));
 		}
 	}
 }

--- a/yazi-core/src/tab/commands/leave.rs
+++ b/yazi-core/src/tab/commands/leave.rs
@@ -1,5 +1,6 @@
 use yazi_shared::event::CmdCow;
 
+use super::cd::CdSource;
 use crate::tab::Tab;
 
 struct Opt;
@@ -19,6 +20,6 @@ impl Tab {
 			.and_then(|h| h.url.parent_url())
 			.filter(|u| u != self.cwd())
 			.or_else(|| self.cwd().parent_url())
-			.map(|u| self.cd((u.into_regular(), super::cd::OptSource::Leave)));
+			.map(|u| self.cd((u.into_regular(), CdSource::Leave)));
 	}
 }

--- a/yazi-core/src/tab/commands/reveal.rs
+++ b/yazi-core/src/tab/commands/reveal.rs
@@ -2,10 +2,12 @@ use yazi_fs::{File, FilesOp, expand_path};
 use yazi_proxy::MgrProxy;
 use yazi_shared::{event::CmdCow, url::Url};
 
+use super::cd::CdSource;
 use crate::tab::Tab;
 
 struct Opt {
 	target:   Url,
+	source:   CdSource,
 	no_dummy: bool,
 }
 
@@ -16,11 +18,16 @@ impl From<CmdCow> for Opt {
 			target = Url::from(expand_path(&target));
 		}
 
-		Self { target, no_dummy: c.bool("no-dummy") }
+		Self { target, source: CdSource::Reveal, no_dummy: c.bool("no-dummy") }
 	}
 }
+
 impl From<Url> for Opt {
-	fn from(target: Url) -> Self { Self { target, no_dummy: false } }
+	fn from(target: Url) -> Self { Self { target, source: CdSource::Reveal, no_dummy: false } }
+}
+
+impl From<(Url, CdSource)> for Opt {
+	fn from((target, source): (Url, CdSource)) -> Self { Self { target, source, no_dummy: false } }
 }
 
 impl Tab {
@@ -30,7 +37,7 @@ impl Tab {
 			return;
 		};
 
-		self.cd((parent.clone(), super::cd::OptSource::Reveal));
+		self.cd((parent.clone(), opt.source));
 		self.current.hover(child.as_urn());
 
 		if !opt.no_dummy && self.hovered().is_none_or(|f| &child != f.urn()) {


### PR DESCRIPTION
… backstack

## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
