### PR TITLE
fix: out-of-bounds error with empty Backstack and `L` (`forward`)

### DIFF
--- a/yazi-core/src/tab/backstack.rs
+++ b/yazi-core/src/tab/backstack.rs
@@ -41,7 +41,7 @@ impl<T: Eq + Clone> Backstack<T> {
 	}
 
 	pub fn shift_forward(&mut self) -> Option<&T> {
-		if self.cursor + 1 == self.stack.len() {
+		if self.cursor + 1 >= self.stack.len() {
 			None
 		} else {
 			self.cursor += 1;
@@ -56,7 +56,9 @@ mod tests {
 
 	#[test]
 	fn test_backstack() {
-		let mut bs = Backstack::default();
+		let mut bs: Backstack<u32> = Backstack::default();
+		assert_eq!(bs.shift_forward(), None);
+
 		bs.push(&1);
 		assert_eq!(bs.stack[bs.cursor], 1);
 


### PR DESCRIPTION
**Issue:**

After starting yazi, and pressing `L` to go forward to the next visited directory, yazi crashes with the following message:

```rs
❯ RUST_BACKTRACE=full yazi
Backtrace (most recent call first):
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header
  File "<unknown>", line 0, in __mh_execute_header

The application panicked (crashed).
  index out of bounds: the len is 0 but the index is 1
in yazi-core/src/tab/backstack.rs, line 48
thread: main
```

**Solution:**

Fix the out-of-bounds error by accounting for the case where the `Backstack` is empty.

## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
