### PR TITLE
fix: expose `ya` CLI in the Snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,10 @@ apps:
     command: yazi
     environment:
       PATH: $SNAP/bin:$SNAP/usr/bin:$PATH
+  ya:
+    command: ya
+    environment:
+      PATH: $SNAP/bin:$SNAP/usr/bin:$PATH
 
 parts:
   yazi:


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #2903

## Rationale of this PR
Currently the snap build only exposes yazi but not ya, so when installing yazi from the snap store you can't run the package manager unless you explicitly run it from `/snap/yazi/current/ya`.

This PR solves this by exposing a second app from the snap which points to ya. Note that `ya` will be exposed as `yazi.ya` because snap does not support exposing multiple (non-prefixed) entrypoints for a single snap. However, this is still better than not exposing ya at all.

As far as I know this change should be sufficient, but if someone with stronger snap knowledge knows better please chime in.

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
