### PR TITLE
feat: improve the UX of the `pick` component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+checksum = "fcc37f9a2bfe731e69f1e08d29d91d30604b9ce24bcb2880a961e82d89c6ed89"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1928,18 +1928,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
  "syn",

--- a/yazi-core/src/cmp/cmp.rs
+++ b/yazi-core/src/cmp/cmp.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, path::PathBuf};
 use yazi_proxy::options::CmpItem;
 use yazi_shared::Id;
 
+use crate::Scrollable;
+
 #[derive(Default)]
 pub struct Cmp {
 	pub(super) caches: HashMap<PathBuf, Vec<CmpItem>>,
@@ -21,9 +23,6 @@ impl Cmp {
 		let end = (self.offset + self.limit()).min(self.cands.len());
 		&self.cands[self.offset..end]
 	}
-
-	#[inline]
-	pub fn limit(&self) -> usize { self.cands.len().min(10) }
 
 	#[inline]
 	pub fn selected(&self) -> Option<&CmpItem> { self.cands.get(self.cursor) }

--- a/yazi-core/src/help/help.rs
+++ b/yazi-core/src/help/help.rs
@@ -5,7 +5,7 @@ use yazi_config::{KEYMAP, YAZI, keymap::{Chord, Key}};
 use yazi_macro::{render, render_and};
 use yazi_shared::Layer;
 
-use super::HELP_MARGIN;
+use crate::Scrollable;
 
 #[derive(Default)]
 pub struct Help {
@@ -22,9 +22,6 @@ pub struct Help {
 }
 
 impl Help {
-	#[inline]
-	pub fn limit() -> usize { Dimension::available().rows.saturating_sub(HELP_MARGIN) as usize }
-
 	pub fn toggle(&mut self, layer: Layer) {
 		self.visible = !self.visible;
 		self.layer = layer;
@@ -94,7 +91,7 @@ impl Help {
 	// --- Bindings
 	#[inline]
 	pub fn window(&self) -> &[&Chord] {
-		let end = (self.offset + Self::limit()).min(self.bindings.len());
+		let end = (self.offset + self.limit()).min(self.bindings.len());
 		&self.bindings[self.offset..end]
 	}
 

--- a/yazi-core/src/lib.rs
+++ b/yazi-core/src/lib.rs
@@ -6,6 +6,8 @@
 	clippy::unit_arg
 )]
 
+yazi_macro::mod_flat!(scrollable);
+
 yazi_macro::mod_pub!(cmp confirm help input mgr notify pick spot tab tasks which);
 
 pub fn init() {

--- a/yazi-core/src/pick/pick.rs
+++ b/yazi-core/src/pick/pick.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use tokio::sync::oneshot::Sender;
-use yazi_config::{YAZI, popup::Position};
+use yazi_config::popup::Position;
+
+use crate::Scrollable;
 
 #[derive(Default)]
 pub struct Pick {
@@ -9,7 +11,7 @@ pub struct Pick {
 	pub position:     Position,
 
 	pub(super) offset:   usize,
-	pub(super) cursor:   usize,
+	pub cursor:          usize,
 	pub(super) callback: Option<Sender<Result<usize>>>,
 
 	pub visible: bool,
@@ -17,21 +19,15 @@ pub struct Pick {
 
 impl Pick {
 	#[inline]
-	pub fn window(&self) -> &[String] {
-		let end = (self.offset + self.limit()).min(self.items.len());
-		&self.items[self.offset..end]
-	}
-
-	#[inline]
-	pub(super) fn limit(&self) -> usize {
-		self.position.offset.height.saturating_sub(YAZI.pick.border()) as usize
+	pub fn window(&self) -> impl Iterator<Item = (usize, &str)> {
+		self.items.iter().map(AsRef::as_ref).enumerate().skip(self.offset).take(self.limit())
 	}
 }
 
 impl Pick {
 	#[inline]
-	pub fn title(&self) -> String { self.title.clone() }
+	pub const fn len(&self) -> usize { self.items.len() }
 
 	#[inline]
-	pub fn rel_cursor(&self) -> usize { self.cursor - self.offset }
+	pub fn title(&self) -> &str { &self.title }
 }

--- a/yazi-core/src/scrollable.rs
+++ b/yazi-core/src/scrollable.rs
@@ -1,0 +1,43 @@
+use yazi_fs::Step;
+
+pub trait Scrollable {
+	fn len(&self) -> usize;
+	fn limit(&self) -> usize;
+	fn scrolloff(&self) -> usize { self.limit() / 2 }
+	fn cursor_mut(&mut self) -> &mut usize;
+	fn offset_mut(&mut self) -> &mut usize;
+
+	fn scroll(&mut self, step: Step) -> bool {
+		let new = step.add(*self.cursor_mut(), self.len(), self.limit());
+		if new > *self.cursor_mut() { self.next(new) } else { self.prev(new) }
+	}
+
+	fn next(&mut self, n_cur: usize) -> bool {
+		let (o_cur, o_off) = (*self.cursor_mut(), *self.offset_mut());
+		let (len, limit, scrolloff) = (self.len(), self.limit(), self.scrolloff());
+
+		let n_off = if n_cur < len.min(o_off + limit).saturating_sub(scrolloff) {
+			o_off.min(len.saturating_sub(1))
+		} else {
+			len.saturating_sub(limit).min(o_off + n_cur - o_cur)
+		};
+
+		*self.cursor_mut() = n_cur;
+		*self.offset_mut() = n_off;
+		(n_cur, n_off) != (o_cur, o_off)
+	}
+
+	fn prev(&mut self, n_cur: usize) -> bool {
+		let (o_cur, o_off) = (*self.cursor_mut(), *self.offset_mut());
+
+		let n_off = if n_cur < o_off + self.scrolloff() {
+			o_off.saturating_sub(o_cur - n_cur)
+		} else {
+			self.len().saturating_sub(1).min(o_off)
+		};
+
+		*self.cursor_mut() = n_cur;
+		*self.offset_mut() = n_off;
+		(n_cur, n_off) != (o_cur, o_off)
+	}
+}

--- a/yazi-fm/src/pick/list.rs
+++ b/yazi-fm/src/pick/list.rs
@@ -1,0 +1,39 @@
+use ratatui::{buffer::Buffer, layout::{Margin, Rect}, widgets::{ListItem, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget}};
+use yazi_config::THEME;
+use yazi_core::Scrollable;
+
+use crate::Ctx;
+
+pub(crate) struct List<'a> {
+	cx: &'a Ctx,
+}
+
+impl<'a> List<'a> {
+	pub(crate) fn new(cx: &'a Ctx) -> Self { Self { cx } }
+}
+
+impl Widget for List<'_> {
+	fn render(self, area: Rect, buf: &mut Buffer) {
+		let pick = &self.cx.pick;
+
+		// Vertical scrollbar
+		if pick.len() > pick.limit() {
+			Scrollbar::new(ScrollbarOrientation::VerticalRight).render(
+				area,
+				buf,
+				&mut ScrollbarState::new(pick.len()).position(pick.cursor),
+			);
+		}
+
+		// List content
+		let inner = area.inner(Margin::new(1, 0));
+		let items = pick.window().map(|(i, v)| {
+			if i == pick.cursor {
+				ListItem::new(format!(" {v}")).style(THEME.pick.active)
+			} else {
+				ListItem::new(format!("  {v}")).style(THEME.pick.inactive)
+			}
+		});
+		Widget::render(ratatui::widgets::List::new(items), inner, buf);
+	}
+}

--- a/yazi-fm/src/pick/mod.rs
+++ b/yazi-fm/src/pick/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(pick);
+yazi_macro::mod_flat!(list pick);

--- a/yazi-fm/src/pick/pick.rs
+++ b/yazi-fm/src/pick/pick.rs
@@ -1,7 +1,7 @@
-use ratatui::{buffer::Buffer, layout::Rect, widgets::{Block, BorderType, List, ListItem, Widget}};
+use ratatui::{buffer::Buffer, layout::{Margin, Rect}, widgets::{Block, BorderType, Widget}};
 use yazi_config::THEME;
 
-use crate::Ctx;
+use crate::{Ctx, pick::List};
 
 pub(crate) struct Pick<'a> {
 	cx: &'a Ctx,
@@ -16,27 +16,14 @@ impl Widget for Pick<'_> {
 		let pick = &self.cx.pick;
 		let area = self.cx.mgr.area(pick.position);
 
-		let items: Vec<_> = pick
-			.window()
-			.iter()
-			.enumerate()
-			.map(|(i, v)| {
-				if i != pick.rel_cursor() {
-					return ListItem::new(format!("  {v}")).style(THEME.pick.inactive);
-				}
-
-				ListItem::new(format!(" {v}")).style(THEME.pick.active)
-			})
-			.collect();
-
 		yazi_plugin::elements::Clear::default().render(area, buf);
-		List::new(items)
-			.block(
-				Block::bordered()
-					.title(pick.title())
-					.border_type(BorderType::Rounded)
-					.border_style(THEME.pick.border),
-			)
+
+		Block::bordered()
+			.title(pick.title())
+			.border_type(BorderType::Rounded)
+			.border_style(THEME.pick.border)
 			.render(area, buf);
+
+		List::new(self.cx).render(area.inner(Margin::new(0, 1)), buf);
 	}
 }


### PR DESCRIPTION
This PR improves the `pick` component (used for "Open with"):

- When there are more available items in the list than can be displayed within the component's height, a scrollbar is shown to indicate to users that they can scroll down to see more items.
- Supports `scrolloff`: keep a fixed number of items above or below the cursor when the user is moving through the list, so the user can better know when they reach the end.


https://github.com/user-attachments/assets/e0910816-bb73-4b06-8aff-aed1a4bd4393

