### PR TITLE
feat: `filter` by full path (prefix + filename) in search view instead of just filename

### DIFF
--- a/yazi-fs/src/files.rs
+++ b/yazi-fs/src/files.rs
@@ -186,10 +186,9 @@ impl Files {
 		}
 
 		let (mut hidden, mut items) = if let Some(filter) = &self.filter {
-			urns.into_iter().partition(|u| {
-				(!self.show_hidden && u.as_urn().is_hidden())
-					|| !u.as_urn().name().is_some_and(|s| filter.matches(s))
-			})
+			urns
+				.into_iter()
+				.partition(|u| (!self.show_hidden && u.as_urn().is_hidden()) || !filter.matches(u.as_urn()))
 		} else if self.show_hidden {
 			(HashSet::new(), urns)
 		} else {
@@ -267,7 +266,7 @@ impl Files {
 		let (mut hidden, mut items) = if let Some(filter) = &self.filter {
 			files
 				.into_iter()
-				.partition(|(_, f)| (f.is_hidden() && !self.show_hidden) || !filter.matches(f.name()))
+				.partition(|(_, f)| (f.is_hidden() && !self.show_hidden) || !filter.matches(f.urn()))
 		} else if self.show_hidden {
 			(HashMap::new(), files)
 		} else {
@@ -320,7 +319,7 @@ impl Files {
 		if let Some(filter) = &self.filter {
 			files
 				.into_iter()
-				.partition(|f| (f.is_hidden() && !self.show_hidden) || !filter.matches(f.name()))
+				.partition(|f| (f.is_hidden() && !self.show_hidden) || !filter.matches(f.urn()))
 		} else if self.show_hidden {
 			(vec![], files.into_iter().collect())
 		} else {

--- a/yazi-shared/src/url/urn.rs
+++ b/yazi-shared/src/url/urn.rs
@@ -36,6 +36,10 @@ impl AsRef<Path> for Urn {
 	fn as_ref(&self) -> &Path { &self.0 }
 }
 
+impl AsRef<OsStr> for Urn {
+	fn as_ref(&self) -> &OsStr { self.0.as_os_str() }
+}
+
 impl ToOwned for Urn {
 	type Owned = UrnBuf;
 


### PR DESCRIPTION

An implementation of the feature request: https://github.com/sxyazi/yazi/discussions/2565, https://github.com/sxyazi/yazi/issues/2894

---

The search view flatly shows search results, for example, `a/b/c.txt`, where `a/b` is the prefix and `c.txt` is the file name.

Previously, users could only use the `filter` command to filter for the file name portion (`c.txt`) within the search results. 

With this PR, the full path `a/b/c.txt` can now be filtered, which makes it more intuitive, as users should be able to filter for the path as they see it in the list, rather than only the final part of it.


https://github.com/user-attachments/assets/ed9798af-345b-43bc-9a21-a8762178d053

