### PR TITLE
feat!: make `ya.confirm()` and `ui.Pos()` public API

### DIFF
--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -124,7 +124,7 @@ separator_style = { fg = "darkgray" }
 [confirm]
 border     = { fg = "blue" }
 title      = { fg = "blue" }
-content    = {}
+body       = {}
 list       = {}
 btn_yes    = { reversed = true }
 btn_no     = {}

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -124,7 +124,7 @@ separator_style = { fg = "darkgray" }
 [confirm]
 border     = { fg = "blue" }
 title      = { fg = "blue" }
-content    = {}
+body       = {}
 list       = {}
 btn_yes    = { reversed = true }
 btn_no     = {}

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -200,16 +200,16 @@ delete_origin	= "center"
 delete_offset	= [ 0, 0, 70, 20 ]
 
 # overwrite
-overwrite_title   = "Overwrite file?"
-overwrite_content = "Will overwrite the following file:"
-overwrite_origin  = "center"
-overwrite_offset  = [ 0, 0, 50, 15 ]
+overwrite_title  = "Overwrite file?"
+overwrite_body   = "Will overwrite the following file:"
+overwrite_origin = "center"
+overwrite_offset = [ 0, 0, 50, 15 ]
 
 # quit
-quit_title   = "Quit?"
-quit_content = "The following tasks are still running, are you sure you want to quit?"
-quit_origin  = "center"
-quit_offset  = [ 0, 0, 50, 15 ]
+quit_title  = "Quit?"
+quit_body   = "The following tasks are still running, are you sure you want to quit?"
+quit_origin = "center"
+quit_offset = [ 0, 0, 50, 15 ]
 
 [pick]
 open_title  = "Open with:"

--- a/yazi-config/src/popup/confirm.rs
+++ b/yazi-config/src/popup/confirm.rs
@@ -16,16 +16,16 @@ pub struct Confirm {
 	pub delete_offset: Offset,
 
 	// overwrite
-	pub overwrite_title:   String,
-	pub overwrite_content: String,
-	pub overwrite_origin:  Origin,
-	pub overwrite_offset:  Offset,
+	pub overwrite_title:  String,
+	pub overwrite_body:   String,
+	pub overwrite_origin: Origin,
+	pub overwrite_offset: Offset,
 
 	// quit
-	pub quit_title:   String,
-	pub quit_content: String,
-	pub quit_origin:  Origin,
-	pub quit_offset:  Offset,
+	pub quit_title:  String,
+	pub quit_body:   String,
+	pub quit_origin: Origin,
+	pub quit_offset: Offset,
 }
 
 impl Confirm {

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -26,7 +26,7 @@ pub struct PickCfg {
 pub struct ConfirmCfg {
 	pub position: Position,
 	pub title:    Line<'static>,
-	pub content:  Paragraph<'static>,
+	pub body:     Paragraph<'static>,
 	pub list:     Paragraph<'static>,
 }
 
@@ -107,13 +107,13 @@ impl ConfirmCfg {
 	fn new(
 		title: String,
 		(origin, offset): (Origin, Offset),
-		content: Option<Text<'static>>,
+		body: Option<Text<'static>>,
 		list: Option<Text<'static>>,
 	) -> Self {
 		Self {
 			position: Position::new(origin, offset),
 			title:    Line::raw(title),
-			content:  content.map(|c| Paragraph::new(c).wrap(Wrap { trim: false })).unwrap_or_default(),
+			body:     body.map(|c| Paragraph::new(c).wrap(Wrap { trim: false })).unwrap_or_default(),
 			list:     list.map(|l| Paragraph::new(l).wrap(Wrap { trim: false })).unwrap_or_default(),
 		}
 	}
@@ -140,7 +140,7 @@ impl ConfirmCfg {
 		Self::new(
 			YAZI.confirm.overwrite_title.to_owned(),
 			(YAZI.confirm.overwrite_origin, YAZI.confirm.overwrite_offset),
-			Some(Text::raw(&YAZI.confirm.overwrite_content)),
+			Some(Text::raw(&YAZI.confirm.overwrite_body)),
 			Some(url.to_string().into()),
 		)
 	}
@@ -149,7 +149,7 @@ impl ConfirmCfg {
 		Self::new(
 			Self::replace_number(&YAZI.confirm.quit_title, len),
 			(YAZI.confirm.quit_origin, YAZI.confirm.quit_offset),
-			Some(Text::raw(&YAZI.confirm.quit_content)),
+			Some(Text::raw(&YAZI.confirm.quit_body)),
 			Self::truncate_list(names.into_iter(), len, 10),
 		)
 	}

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -132,10 +132,10 @@ pub struct Which {
 
 #[derive(Deserialize, DeserializeOver2)]
 pub struct Confirm {
-	pub border:  Style,
-	pub title:   Style,
-	pub content: Style,
-	pub list:    Style,
+	pub border: Style,
+	pub title:  Style,
+	pub body:   Style,
+	pub list:   Style,
 
 	pub btn_yes:    Style,
 	pub btn_no:     Style,

--- a/yazi-core/src/confirm/commands/show.rs
+++ b/yazi-core/src/confirm/commands/show.rs
@@ -26,7 +26,7 @@ impl Confirm {
 
 		self.close(false);
 		self.title = opt.cfg.title;
-		self.content = opt.cfg.content;
+		self.body = opt.cfg.body;
 		self.list = opt.cfg.list;
 
 		self.position = opt.cfg.position;

--- a/yazi-core/src/confirm/confirm.rs
+++ b/yazi-core/src/confirm/confirm.rs
@@ -4,9 +4,9 @@ use yazi_config::popup::Position;
 
 #[derive(Default)]
 pub struct Confirm {
-	pub title:   Line<'static>,
-	pub content: Paragraph<'static>,
-	pub list:    Paragraph<'static>,
+	pub title: Line<'static>,
+	pub body:  Paragraph<'static>,
+	pub list:  Paragraph<'static>,
 
 	pub position: Position,
 	pub offset:   usize,

--- a/yazi-fm/src/confirm/body.rs
+++ b/yazi-fm/src/confirm/body.rs
@@ -3,20 +3,20 @@ use yazi_config::THEME;
 
 use crate::Ctx;
 
-pub(crate) struct Content<'a> {
+pub(crate) struct Body<'a> {
 	cx:     &'a Ctx,
 	border: bool,
 }
 
-impl<'a> Content<'a> {
+impl<'a> Body<'a> {
 	pub(crate) fn new(cx: &'a Ctx, border: bool) -> Self { Self { cx, border } }
 }
 
-impl Widget for Content<'_> {
+impl Widget for Body<'_> {
 	fn render(self, area: Rect, buf: &mut Buffer) {
 		let confirm = &self.cx.confirm;
 
-		// Content area
+		// Inner area
 		let inner = area.inner(Margin::new(1, 0));
 
 		// Border
@@ -27,11 +27,11 @@ impl Widget for Content<'_> {
 		};
 
 		confirm
-			.content
+			.body
 			.clone()
 			.alignment(ratatui::layout::Alignment::Center)
 			.block(block)
-			.style(THEME.confirm.content.derive(Styled::style(&confirm.content)))
+			.style(THEME.confirm.body.derive(Styled::style(&confirm.body)))
 			.render(inner, buf);
 	}
 }

--- a/yazi-fm/src/confirm/confirm.rs
+++ b/yazi-fm/src/confirm/confirm.rs
@@ -25,21 +25,21 @@ impl Widget for Confirm<'_> {
 			.title_alignment(Alignment::Center)
 			.render(area, buf);
 
-		let content_border = confirm.list.line_count(area.width) != 0;
-		let content_height = confirm.content.line_count(area.width) as u16;
+		let body_border = confirm.list.line_count(area.width) != 0;
+		let body_height = confirm.body.line_count(area.width) as u16;
 
 		let chunks = Layout::vertical([
-			Constraint::Length(if content_height == 0 {
+			Constraint::Length(if body_height == 0 {
 				0
 			} else {
-				content_height.saturating_add(content_border as u16)
+				body_height.saturating_add(body_border as u16)
 			}),
 			Constraint::Fill(1),
 			Constraint::Length(1),
 		])
 		.split(area.inner(Margin::new(0, 1)));
 
-		super::Content::new(self.cx, content_border).render(chunks[0], buf);
+		super::Body::new(self.cx, body_border).render(chunks[0], buf);
 		super::List::new(self.cx).render(chunks[1], buf);
 		super::Buttons.render(chunks[2], buf);
 	}

--- a/yazi-fm/src/confirm/mod.rs
+++ b/yazi-fm/src/confirm/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(buttons confirm content list);
+yazi_macro::mod_flat!(buttons confirm body list);

--- a/yazi-plugin/src/config/theme.rs
+++ b/yazi-plugin/src/config/theme.rs
@@ -158,7 +158,7 @@ impl Theme {
 			match key {
 				b"border" => Style::from(t.border).into_lua(lua),
 				b"title" => Style::from(t.title).into_lua(lua),
-				b"content" => Style::from(t.content).into_lua(lua),
+				b"body" => Style::from(t.body).into_lua(lua),
 				b"list" => Style::from(t.list).into_lua(lua),
 
 				b"btn_yes" => Style::from(t.btn_yes).into_lua(lua),

--- a/yazi-plugin/src/macros.rs
+++ b/yazi-plugin/src/macros.rs
@@ -76,7 +76,7 @@ macro_rules! runtime_mut {
 #[macro_export]
 macro_rules! deprecate {
 	($lua:ident, $tt:tt) => {{
-		let id = match $lua.named_registry_value::<$crate::RtRef>("ir")?.current() {
+		let id = match $crate::runtime!($lua)?.current() {
 			Some(id) => &format!("`{id}.yazi` plugin"),
 			None => "`init.lua` config",
 		};


### PR DESCRIPTION
Follow up to https://github.com/yazi-rs/yazi-rs.github.io/commit/5db68d0a8ed9026aba3c51a13e7479ceb2f24e01

---

This PR makes the final changes to `ya.confirm()` and `ui.Pos()` before going public, and these changes are now reflected in the documentation:

- `ya.confirm()`: https://yazi-rs.github.io/docs/plugins/utils#ya.confirm
- `ui.Pos()`: https://yazi-rs.github.io/docs/plugins/layout#pos

## ⚠️ Breaking changes

### Use `body` instead of the term `content` in confirmations

A confirmation consists of three parts:

- Top: the title
- Middle: the confirmation prompt text
- Bottom: an additional list shown upon confirmation, such as a file list when deleting files

Previously, the middle part was referred to as `content`, but this was inaccurate because all parts except the title are "content" (i.e. the middle and bottom parts). So, the middle part is now changed to `body` from `content`.

```diff
# theme.toml / flavor.toml
[confirm]
- content = {}
+ body    = {}
```

```diff
# yazi.toml
[confirm]
- overwrite_content = "Will overwrite the following file:"
+ overwrite_body    = "Will overwrite the following file:"

- quit_content = "The following tasks are still running, are you sure you want to quit?"
+ quit_body    = "The following tasks are still running, are you sure you want to quit?"
```

## Deprecation

The `position` property of `ya.input()` has been deprecated and replaced by the new `pos` to align with `ya.confirm()` and its type name `ui.Pos`.

The original `position` property is still available, but it will trigger a deprecation warning.

Resolves: https://github.com/sxyazi/yazi/pull/2095#issuecomment-2561700908