### PR TITLE
feat: allow custom mouse click behavior for individual files

### DIFF
--- a/yazi-plugin/preset/components/current.lua
+++ b/yazi-plugin/preset/components/current.lua
@@ -49,19 +49,9 @@ end
 
 -- Mouse events
 function Current:click(event, up)
-	if up or event.is_middle then
-		return
-	end
-
-	local f = self._folder
 	local y = event.y - self._area.y + 1
-	if y > #f.window or not f.hovered then
-		return
-	end
-
-	ya.emit("arrow", { y + f.offset - f.hovered.idx })
-	if event.is_right then
-		ya.emit("open", {})
+	if self._folder.window[y] then
+		Entity:new(self._folder.window[y]):click(event, up)
 	end
 end
 

--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -108,6 +108,18 @@ function Entity:ellipsis(max)
 	end
 end
 
+-- Mouse events
+function Entity:click(event, up)
+	if up or event.is_middle then
+		return
+	end
+
+	ya.emit("reveal", { self._file.url })
+	if event.is_right then
+		ya.emit("open", {})
+	end
+end
+
 -- Children
 function Entity:children_add(fn, order)
 	self._inc = self._inc + 1

--- a/yazi-plugin/preset/components/parent.lua
+++ b/yazi-plugin/preset/components/parent.lua
@@ -31,15 +31,11 @@ end
 
 -- Mouse events
 function Parent:click(event, up)
-	if up or not event.is_left then
-		return
-	end
-
 	local y = event.y - self._area.y + 1
 	local window = self._folder and self._folder.window or {}
 	if window[y] then
-		ya.emit("reveal", { window[y].url })
-	else
+		Entity:new(window[y]):click(event, up)
+	elseif not up and event.is_left then
 		ya.emit("leave", {})
 	end
 end

--- a/yazi-plugin/preset/components/preview.lua
+++ b/yazi-plugin/preset/components/preview.lua
@@ -16,15 +16,11 @@ function Preview:redraw() return {} end
 
 -- Mouse events
 function Preview:click(event, up)
-	if up or not event.is_left then
-		return
-	end
-
 	local y = event.y - self._area.y + 1
 	local window = self._folder and self._folder.window or {}
 	if window[y] then
-		ya.emit("reveal", { window[y].url })
-	else
+		Entity:new(window[y]):click(event, up)
+	elseif not up and event.is_left then
 		ya.emit("enter", {})
 	end
 end


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2790

Closes https://github.com/sxyazi/yazi/issues/2790

---

This PR adds a new `Entity:click()` method, with which, you can implement any mouse behavior you desire in your `init.lua` by simply overwriting it, for example:

```lua
-- ~/.config/yazi/init.lua
function Entity:click(event, up)
  if up then
    return  -- We don't care about mouse release events
  end

  -- Hover on the file we just clicked
  ya.emit("reveal", { self._file.url })
  if event.is_middle then     -- Middle click
    ya.emit("open", { interactive = true })
  elseif event.is_right then  -- Right click
    ya.emit("plugin", { "smart-enter" })
  end
end
```