### PR TITLE
refactor: deprecate `ui.Rect.default`

### DIFF
--- a/yazi-plugin/src/elements/rect.rs
+++ b/yazi-plugin/src/elements/rect.rs
@@ -38,7 +38,7 @@ impl Rect {
 		let index = lua.create_function(move |lua, (_, key): (Table, mlua::String)| {
 			Ok(match key.as_bytes().as_ref() {
 				b"default" => {
-					deprecate!(lua, "`ui.Rect.default` is deprecated, use `ui.Rect{{}}` instead, in your {}");
+					deprecate!(lua, "`ui.Rect.default` is deprecated, use `ui.Rect{{}}` instead, in your {}\nSee #2927 for more details: https://github.com/sxyazi/yazi/pull/2927");
 					Some(Self(Default::default()))
 				}
 				_ => None,


### PR DESCRIPTION
`ui.Rect.default` was introduced as a shorthand for `ui.Rect { x = 0, y = 0, w = 0, h = 0 }`. 

However, since `x`, `y`, `w`, and `h` can now all be omitted (defaulting to `0`), this shorthand is no longer necessary:

```diff
- ui.Rect.default
+ ui.Rect {}
```

The old `ui.Rect.default` is still available, but will trigger a deprecation warning.