### PR TITLE
feat: display newlines in input as spaces to improve readability

### DIFF
--- a/yazi-dds/src/sendable.rs
+++ b/yazi-dds/src/sendable.rs
@@ -156,7 +156,7 @@ impl Sendable {
 		for (k, v) in args {
 			match k {
 				DataKey::Integer(i) => tbl.raw_set(i + 1, Self::data_to_value(lua, v)?),
-				DataKey::String(s) => tbl.raw_set(replace_cow(&s, "-", "_"), Self::data_to_value(lua, v)?),
+				DataKey::String(s) => tbl.raw_set(replace_cow(s, "-", "_"), Self::data_to_value(lua, v)?),
 				_ => Err("invalid key in Data".into_lua_err()),
 			}?;
 		}
@@ -170,7 +170,7 @@ impl Sendable {
 			match k {
 				DataKey::Integer(i) => tbl.raw_set(i + 1, Self::data_to_value_ref(lua, v)?),
 				DataKey::String(s) => {
-					tbl.raw_set(replace_cow(s, "-", "_"), Self::data_to_value_ref(lua, v)?)
+					tbl.raw_set(replace_cow(s.as_ref(), "-", "_"), Self::data_to_value_ref(lua, v)?)
 				}
 				_ => Err("invalid key in Data".into_lua_err()),
 			}?;

--- a/yazi-fs/src/mounts/linux.rs
+++ b/yazi-fs/src/mounts/linux.rs
@@ -169,10 +169,7 @@ impl Partitions {
 		for (a, b) in
 			[(r"\011", "\t"), (r"\012", "\n"), (r"\040", " "), (r"\043", "#"), (r"\134", r"\")]
 		{
-			s = match replace_cow(&s, a, b) {
-				Cow::Borrowed(_) => s,
-				Cow::Owned(new) => Cow::Owned(new),
-			};
+			s = replace_cow(s, a, b);
 		}
 		s
 	}

--- a/yazi-widgets/src/input/commands/replace.rs
+++ b/yazi-widgets/src/input/commands/replace.rs
@@ -1,5 +1,5 @@
 use yazi_macro::render;
-use yazi_shared::event::CmdCow;
+use yazi_shared::{event::CmdCow, replace_cow};
 
 use crate::input::{Input, InputMode, op::InputOp};
 
@@ -15,6 +15,8 @@ impl Input {
 	}
 
 	pub fn replace_str(&mut self, s: &str) {
+		let s = replace_cow(replace_cow(s, "\r", " "), "\n", " ");
+
 		let snap = self.snap_mut();
 		snap.mode = InputMode::Normal;
 
@@ -22,8 +24,8 @@ impl Input {
 		let mut it = snap.value[start..].char_indices();
 		match (it.next(), it.next()) {
 			(None, _) => {}
-			(Some(_), None) => snap.value.replace_range(start..snap.len(), s),
-			(Some(_), Some((len, _))) => snap.value.replace_range(start..start + len, s),
+			(Some(_), None) => snap.value.replace_range(start..snap.len(), &s),
+			(Some(_), Some((len, _))) => snap.value.replace_range(start..start + len, &s),
 		}
 
 		render!();

--- a/yazi-widgets/src/input/commands/type.rs
+++ b/yazi-widgets/src/input/commands/type.rs
@@ -1,5 +1,6 @@
 use yazi_config::keymap::Key;
 use yazi_macro::render;
+use yazi_shared::replace_cow;
 
 use crate::input::{Input, InputMode};
 
@@ -19,11 +20,13 @@ impl Input {
 	}
 
 	pub fn type_str(&mut self, s: &str) {
+		let s = replace_cow(replace_cow(s, "\r", " "), "\n", " ");
+
 		let snap = self.snap_mut();
 		if snap.cursor < 1 {
-			snap.value.insert_str(0, s);
+			snap.value.insert_str(0, &s);
 		} else {
-			snap.value.insert_str(snap.idx(snap.cursor).unwrap(), s);
+			snap.value.insert_str(snap.idx(snap.cursor).unwrap(), &s);
 		}
 
 		self.r#move(s.chars().count() as isize);


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2929

Closes https://github.com/sxyazi/yazi/issues/2929

---

Previously, when users copied content from external sources that contained newlines, these newlines would not be displayed because the input is single-line and inherently cannot display multi-line content. This would surprise users and cause unexpected behavior.

With this PR, newlines will be replaced with spaces, so users can at least know that whitespace characters appeared in the content somewhere.