### PR TITLE
fix: respect user's system media opener instead of hardcoding `mpv`

### DIFF
--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -52,10 +52,10 @@ extract = [
 	{ run = 'ya pub extract --list %*',   desc = "Extract here", for = "windows" },
 ]
 play = [
-	{ run = 'xdg-open "$1"',                desc = "Play with OS default", for = "linux" },
-	{ run = 'open "$@"',                    desc = "Play with OS default", for = "macos" },
-	{ run = 'start "" "%1"', orphan = true, desc = "Play with OS default", for = "windows" },
-	{ run = 'termux-open "$1"',             desc = "Play with OS default", for = "android" },
+	{ run = 'xdg-open "$1"',                desc = "Play", for = "linux" },
+	{ run = 'open "$@"',                    desc = "Play", for = "macos" },
+	{ run = 'start "" "%1"', orphan = true, desc = "Play", for = "windows" },
+	{ run = 'termux-open "$1"',             desc = "Play", for = "android" },
 	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
 

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -53,7 +53,7 @@ extract = [
 ]
 play = [
 	{ run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
-	{ run = 'mpv --force-window %*', orphan = true, for = "windows" },
+	{ run = 'start "" "%1"', orphan = true, for = "windows" },
 	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
 

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -53,7 +53,7 @@ extract = [
 ]
 play = [
 	{ run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
-	{ run = 'start "" "%1"', orphan = true, for = "windows" },
+	{ run = 'start "" "%1"', orphan = true, desc = "Play with OS default", for = "windows" },
 	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
 

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -52,8 +52,10 @@ extract = [
 	{ run = 'ya pub extract --list %*',   desc = "Extract here", for = "windows" },
 ]
 play = [
-	{ run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
+	{ run = 'xdg-open "$1"',                desc = "Play with OS default", for = "linux" },
+	{ run = 'open "$@"',                    desc = "Play with OS default", for = "macos" },
 	{ run = 'start "" "%1"', orphan = true, desc = "Play with OS default", for = "windows" },
+	{ run = 'termux-open "$1"',             desc = "Play with OS default", for = "android" },
 	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
 


### PR DESCRIPTION
## Which issue does this PR resolve?
All platforms fails to play media file if "mpv" is not installed. There is also no response shown.

## Rationale of this PR

The default `open --interactive` menu for Media type is: 
https://github.com/sxyazi/yazi/blob/917e1f54a10445f2e25147c4b81a3c77d8233632/yazi-config/preset/yazi-default.toml#L68-L69

For most platforms, `mpv` is not built in. This PR forces `"play"` to use the default associated application defined in the OS, so that it is always responsive when pressing "Enter" (which triggers [mgr open](https://yazi-rs.github.io/docs/configuration/keymap#mgr.open) and first item in `use` list: "play"`).