### PR TITLE
feat: new "Show media info" for `play` opener on Windows

### DIFF
--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -57,6 +57,7 @@ play = [
 	{ run = 'start "" "%1"', orphan = true, desc = "Play", for = "windows" },
 	{ run = 'termux-open "$1"',             desc = "Play", for = "android" },
 	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
+	{ run = 'mediainfo.exe "%1" & pause', block = true, desc = "Show media info", for = "windows" },
 ]
 
 [open]

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -57,7 +57,7 @@ play = [
 	{ run = 'start "" "%1"', orphan = true, desc = "Play", for = "windows" },
 	{ run = 'termux-open "$1"',             desc = "Play", for = "android" },
 	{ run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
-	{ run = 'mediainfo.exe "%1" & pause', block = true, desc = "Show media info", for = "windows" },
+	{ run = 'mediainfo "%1" & pause', block = true, desc = "Show media info", for = "windows" },
 ]
 
 [open]


### PR DESCRIPTION
## Which issue does this PR resolve?

For media types, Unix has "Show media info" option from interactive open. Windows doesn't.

## Rationale of this PR

Make the feature available for Windows as well.