### PR TITLE
fix: `stringify!(r#move)` is `"r#move"` instead of `"move"`

### DIFF
--- a/yazi-widgets/src/input/commands/commands.rs
+++ b/yazi-widgets/src/input/commands/commands.rs
@@ -10,9 +10,14 @@ impl Input {
 					return self.$name(cmd);
 				}
 			};
+			($name:ident, $alias:literal) => {
+				if cmd.name == $alias {
+					return self.$name(cmd);
+				}
+			};
 		}
 
-		on!(r#move);
+		on!(r#move, "move");
 		on!(backward);
 		on!(forward);
 


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2972