### PR TITLE
feat!: virtual file system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_fig",
  "clap_complete_nushell",
+ "futures",
  "regex",
  "serde",
  "vergen-gitcl",

--- a/yazi-actor/src/lives/file.rs
+++ b/yazi-actor/src/lives/file.rs
@@ -145,7 +145,7 @@ impl UserData for File {
 					return None;
 				}
 
-				let h = finder.filter.highlighted(me.name())?;
+				let h = finder.filter.highlighted(me.url.file_name()?)?;
 				Some(h.into_iter().map(Range::from).collect::<Vec<_>>())
 			})
 		});

--- a/yazi-actor/src/mgr/cd.rs
+++ b/yazi-actor/src/mgr/cd.rs
@@ -5,7 +5,7 @@ use tokio::pin;
 use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
 use yazi_config::popup::InputCfg;
 use yazi_dds::Pubsub;
-use yazi_fs::{File, FilesOp, expand_path};
+use yazi_fs::{File, FilesOp, expand_url};
 use yazi_macro::{act, err, render, succ};
 use yazi_parser::mgr::CdOpt;
 use yazi_proxy::{CmpProxy, InputProxy, MgrProxy};
@@ -76,9 +76,9 @@ impl Cd {
 			while let Some(result) = rx.next().await {
 				match result {
 					Ok(s) => {
-						let url = Url::from(expand_path(s));
+						let Ok(url) = Url::try_from(s).map(expand_url) else { return };
 
-						let Ok(file) = File::new(url.clone()).await else { return };
+						let Ok(file) = File::new(url.as_ref().clone()).await else { return };
 						if file.is_dir() {
 							return MgrProxy::cd(&url);
 						}

--- a/yazi-actor/src/mgr/create.rs
+++ b/yazi-actor/src/mgr/create.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use yazi_config::popup::{ConfirmCfg, InputCfg};
-use yazi_fs::{File, FilesOp, maybe_exists, ok_or_not_found, realname, services};
+use yazi_fs::{File, FilesOp, maybe_exists, ok_or_not_found, provider, realname};
 use yazi_macro::succ;
 use yazi_parser::mgr::CreateOpt;
 use yazi_proxy::{ConfirmProxy, InputProxy, MgrProxy, WATCHER};
@@ -45,15 +45,15 @@ impl Create {
 		let _permit = WATCHER.acquire().await.unwrap();
 
 		if dir {
-			services::create_dir_all(&new).await?;
+			provider::create_dir_all(&new).await?;
 		} else if let Some(real) = realname(&new).await {
-			ok_or_not_found(services::remove_file(&new).await)?;
+			ok_or_not_found(provider::remove_file(&new).await)?;
 			FilesOp::Deleting(parent.clone(), [UrnBuf::from(real)].into()).emit();
-			services::create(&new).await?;
+			provider::create(&new).await?;
 		} else {
-			services::create_dir_all(&parent).await.ok();
-			ok_or_not_found(services::remove_file(&new).await)?;
-			services::create(&new).await?;
+			provider::create_dir_all(&parent).await.ok();
+			ok_or_not_found(provider::remove_file(&new).await)?;
+			provider::create(&new).await?;
 		}
 
 		if let Ok(f) = File::new(new.clone()).await {

--- a/yazi-actor/src/mgr/quit.rs
+++ b/yazi-actor/src/mgr/quit.rs
@@ -75,7 +75,7 @@ impl Quit {
 		}
 
 		let paths = selected.fold(OsString::new(), |mut s, u| {
-			s.push(u.as_os_str());
+			s.push(u.os_str());
 			s.push("\n");
 			s
 		});

--- a/yazi-actor/src/mgr/rename.rs
+++ b/yazi-actor/src/mgr/rename.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use yazi_config::popup::{ConfirmCfg, InputCfg};
 use yazi_dds::Pubsub;
-use yazi_fs::{File, FilesOp, maybe_exists, ok_or_not_found, paths_to_same_file, realname, services};
+use yazi_fs::{File, FilesOp, maybe_exists, ok_or_not_found, paths_to_same_file, provider, realname};
 use yazi_macro::{act, err, succ};
 use yazi_parser::mgr::RenameOpt;
 use yazi_proxy::{ConfirmProxy, InputProxy, MgrProxy, WATCHER};
@@ -65,10 +65,10 @@ impl Rename {
 		let _permit = WATCHER.acquire().await.unwrap();
 
 		let overwritten = realname(&new).await;
-		services::rename(&old, &new).await?;
+		provider::rename(&old, &new).await?;
 
 		if let Some(o) = overwritten {
-			ok_or_not_found(services::rename(p_new.join(&o), &new).await)?;
+			ok_or_not_found(provider::rename(p_new.join(&o), &new).await)?;
 			FilesOp::Deleting(p_new.clone(), [UrnBuf::from(o)].into()).emit();
 		}
 

--- a/yazi-adapter/src/image.rs
+++ b/yazi-adapter/src/image.rs
@@ -1,10 +1,8 @@
-use std::io::BufReader;
-
 use anyhow::Result;
 use image::{DynamicImage, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageReader, ImageResult, Limits, codecs::{jpeg::JpegEncoder, png::PngEncoder}, imageops::FilterType, metadata::Orientation};
 use ratatui::layout::Rect;
 use yazi_config::YAZI;
-use yazi_fs::services;
+use yazi_fs::provider;
 use yazi_shared::url::Url;
 
 use crate::Dimension;
@@ -40,7 +38,7 @@ impl Image {
 		})
 		.await??;
 
-		Ok(services::write(cache, buf).await?)
+		Ok(provider::write(cache, buf).await?)
 	}
 
 	pub(super) async fn downscale(url: &Url, rect: Rect) -> Result<DynamicImage> {
@@ -110,7 +108,7 @@ impl Image {
 			limits.max_image_height = Some(YAZI.tasks.image_bound[1] as u32);
 		}
 
-		let mut reader = ImageReader::new(BufReader::new(services::open(&url).await?.into_std().await));
+		let mut reader = ImageReader::new(provider::open(&url).await?.reader_sync().await);
 		if let Ok(format) = ImageFormat::from_path(url) {
 			reader.set_format(format);
 		}

--- a/yazi-boot/Cargo.toml
+++ b/yazi-boot/Cargo.toml
@@ -16,9 +16,10 @@ yazi-macro   = { path = "../yazi-macro", version = "25.6.11" }
 yazi-shared  = { path = "../yazi-shared", version = "25.6.11" }
 
 # External dependencies
-clap  = { workspace = true }
-regex = { workspace = true }
-serde = { workspace = true }
+clap    = { workspace = true }
+futures = { workspace = true }
+regex   = { workspace = true }
+serde   = { workspace = true }
 
 [build-dependencies]
 yazi-shared = { path = "../yazi-shared", version = "25.6.11" }

--- a/yazi-boot/src/actions/debug.rs
+++ b/yazi-boot/src/actions/debug.rs
@@ -1,8 +1,9 @@
-use std::{env, ffi::OsStr, fmt::Write};
+use std::{env, ffi::OsStr, fmt::Write, path::Path};
 
 use regex::Regex;
 use yazi_adapter::Mux;
-use yazi_shared::timestamp_us;
+use yazi_config::YAZI;
+use yazi_shared::{timestamp_us, url::Url};
 
 use super::Actions;
 
@@ -57,17 +58,17 @@ impl Actions {
 		writeln!(
 			s,
 			"    default     : {:?}",
-			yazi_config::YAZI.opener.first(yazi_config::YAZI.open.all("f75a.txt", "text/plain"))
+			YAZI.opener.first(YAZI.open.all(Url::from(Path::new("f75a.txt")), "text/plain"))
 		)?;
 		writeln!(
 			s,
 			"    block-create: {:?}",
-			yazi_config::YAZI.opener.block(yazi_config::YAZI.open.all("bulk-create.txt", "text/plain"))
+			YAZI.opener.block(YAZI.open.all(Url::from(Path::new("bulk-create.txt")), "text/plain"))
 		)?;
 		writeln!(
 			s,
 			"    block-rename: {:?}",
-			yazi_config::YAZI.opener.block(yazi_config::YAZI.open.all("bulk-rename.txt", "text/plain"))
+			YAZI.opener.block(YAZI.open.all(Url::from(Path::new("bulk-rename.txt")), "text/plain"))
 		)?;
 
 		writeln!(s, "\nMultiplexers")?;

--- a/yazi-boot/src/args.rs
+++ b/yazi-boot/src/args.rs
@@ -1,14 +1,14 @@
 use std::path::PathBuf;
 
 use clap::{Parser, command};
-use yazi_shared::Id;
+use yazi_shared::{Id, url::Url};
 
 #[derive(Debug, Default, Parser)]
 #[command(name = "yazi")]
 pub struct Args {
 	/// Set the current working entry
 	#[arg(index = 1, num_args = 1..=9)]
-	pub entries: Vec<PathBuf>,
+	pub entries: Vec<Url>,
 
 	/// Write the cwd on exit to this file
 	#[arg(long)]

--- a/yazi-cli/src/package/delete.rs
+++ b/yazi-cli/src/package/delete.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use yazi_fs::{ok_or_not_found, remove_dir_clean, services::Local};
+use yazi_fs::{ok_or_not_found, provider::local::Local, remove_dir_clean};
 use yazi_macro::outln;
 
 use super::Dependency;

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use yazi_fs::{remove_dir_clean, services::Local};
+use yazi_fs::{provider::local::Local, remove_dir_clean};
 use yazi_macro::outln;
 
 use super::Dependency;

--- a/yazi-cli/src/package/hash.rs
+++ b/yazi-cli/src/package/hash.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use twox_hash::XxHash3_128;
-use yazi_fs::{ok_or_not_found, services::Local};
+use yazi_fs::{ok_or_not_found, provider::local::Local};
 
 use super::Dependency;
 

--- a/yazi-cli/src/package/package.rs
+++ b/yazi-cli/src/package/package.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use yazi_fs::{Xdg, services::Local};
+use yazi_fs::{Xdg, provider::local::Local};
 use yazi_macro::outln;
 
 use super::Dependency;

--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -239,16 +239,16 @@ rules = [
 	# { mime = "inode/empty", fg = "red" },
 
 	# Special files
-	{ name = "*", is = "orphan", bg = "red" },
-	{ name = "*", is = "exec"  , fg = "green" },
+	{ url = "*", is = "orphan", bg = "red" },
+	{ url = "*", is = "exec"  , fg = "green" },
 
 	# Dummy files
-	{ name = "*", is = "dummy", bg = "red" },
-	{ name = "*/", is = "dummy", bg = "red" },
+	{ url = "*", is = "dummy", bg = "red" },
+	{ url = "*/", is = "dummy", bg = "red" },
 
 	# Fallback
-	# { name = "*", fg = "white" },
-	{ name = "*/", fg = "blue" }
+	# { url = "*", fg = "white" },
+	{ url = "*/", fg = "blue" }
 ]
 
 # : }}}

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -239,16 +239,16 @@ rules = [
 	# { mime = "inode/empty", fg = "red" },
 
 	# Special files
-	{ name = "*", is = "orphan", bg = "red" },
-	{ name = "*", is = "exec"  , fg = "green" },
+	{ url = "*", is = "orphan", bg = "red" },
+	{ url = "*", is = "exec"  , fg = "green" },
 
 	# Dummy files
-	{ name = "*", is = "dummy", bg = "red" },
-	{ name = "*/", is = "dummy", bg = "red" },
+	{ url = "*", is = "dummy", bg = "red" },
+	{ url = "*/", is = "dummy", bg = "red" },
 
 	# Fallback
-	# { name = "*", fg = "white" },
-	{ name = "*/", fg = "blue" }
+	# { url = "*", fg = "white" },
+	{ url = "*/", fg = "blue" }
 ]
 
 # : }}}

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -63,7 +63,7 @@ play = [
 [open]
 rules = [
 	# Folder
-	{ name = "*/", use = [ "edit", "open", "reveal" ] },
+	{ url = "*/", use = [ "edit", "open", "reveal" ] },
 	# Text
 	{ mime = "text/*", use = [ "edit", "reveal" ] },
 	# Image
@@ -78,7 +78,7 @@ rules = [
 	# Empty file
 	{ mime = "inode/empty", use = [ "edit", "reveal" ] },
 	# Fallback
-	{ name = "*", use = [ "open", "reveal" ] },
+	{ url = "*", use = [ "open", "reveal" ] },
 ]
 
 [tasks]
@@ -92,10 +92,10 @@ suppress_preload = false
 [plugin]
 fetchers = [
 	# Mimetype
-	{ id = "mime", name = "*", run = "mime", prio = "high" },
+	{ id = "mime", url = "*", run = "mime", prio = "high" },
 ]
 spotters = [
-	{ name = "*/", run = "folder" },
+	{ url = "*/", run = "folder" },
 	# Code
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
@@ -106,7 +106,7 @@ spotters = [
 	# Video
 	{ mime = "video/*", run = "video" },
 	# Fallback
-	{ name = "*", run = "file" },
+	{ url = "*", run = "file" },
 ]
 preloaders = [
 	# Image
@@ -122,7 +122,7 @@ preloaders = [
 	{ mime = "application/ms-opentype", run = "font" },
 ]
 previewers = [
-	{ name = "*/", run = "folder" },
+	{ url = "*/", run = "folder" },
 	# Code
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
@@ -139,18 +139,18 @@ previewers = [
 	# Archive
 	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", run = "archive" },
 	{ mime = "application/{debian*-package,redhat-package-manager,rpm,android.package-archive}", run = "archive" },
-	{ name = "*.{AppImage,appimage}", run = "archive" },
+	{ url = "*.{AppImage,appimage}", run = "archive" },
 	# Virtual Disk / Disk Image
 	{ mime = "application/{iso9660-image,qemu-disk,ms-wim,apple-diskimage}", run = "archive" },
 	{ mime = "application/virtualbox-{vhd,vhdx}", run = "archive" },
-	{ name = "*.{img,fat,ext,ext2,ext3,ext4,squashfs,ntfs,hfs,hfsx}", run = "archive" },
+	{ url = "*.{img,fat,ext,ext2,ext3,ext4,squashfs,ntfs,hfs,hfsx}", run = "archive" },
 	# Font
 	{ mime = "font/*", run = "font" },
 	{ mime = "application/ms-opentype", run = "font" },
 	# Empty file
 	{ mime = "inode/empty", run = "empty" },
 	# Fallback
-	{ name = "*", run = "file" },
+	{ url = "*", run = "file" },
 ]
 
 [input]

--- a/yazi-config/src/open/rule.rs
+++ b/yazi-config/src/open/rule.rs
@@ -6,7 +6,7 @@ use crate::pattern::Pattern;
 
 #[derive(Debug, Deserialize)]
 pub struct OpenRule {
-	pub name:  Option<Pattern>,
+	pub url:   Option<Pattern>,
 	pub mime:  Option<Pattern>,
 	#[serde(deserialize_with = "OpenRule::deserialize")]
 	pub r#use: Vec<String>,
@@ -14,10 +14,10 @@ pub struct OpenRule {
 
 impl OpenRule {
 	#[inline]
-	pub fn any_file(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_file()) }
+	pub fn any_file(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_file()) }
 
 	#[inline]
-	pub fn any_dir(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_dir()) }
+	pub fn any_dir(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_dir()) }
 }
 
 impl OpenRule {

--- a/yazi-config/src/plugin/fetcher.rs
+++ b/yazi-config/src/plugin/fetcher.rs
@@ -1,7 +1,5 @@
-use std::path::Path;
-
 use serde::Deserialize;
-use yazi_shared::{MIME_DIR, event::Cmd};
+use yazi_shared::{MIME_DIR, event::Cmd, url::Url};
 
 use crate::{Pattern, Priority};
 
@@ -11,7 +9,7 @@ pub struct Fetcher {
 	pub idx: u8,
 
 	pub id:   String,
-	pub name: Option<Pattern>,
+	pub url:  Option<Pattern>,
 	pub mime: Option<Pattern>,
 	pub run:  Cmd,
 	#[serde(default)]
@@ -20,8 +18,8 @@ pub struct Fetcher {
 
 impl Fetcher {
 	#[inline]
-	pub fn matches(&self, path: &Path, mime: &str) -> bool {
+	pub fn matches(&self, url: &Url, mime: &str) -> bool {
 		self.mime.as_ref().is_some_and(|p| p.match_mime(mime))
-			|| self.name.as_ref().is_some_and(|p| p.match_path(path, mime == MIME_DIR))
+			|| self.url.as_ref().is_some_and(|p| p.match_url(url, mime == MIME_DIR))
 	}
 }

--- a/yazi-config/src/plugin/plugin.rs
+++ b/yazi-config/src/plugin/plugin.rs
@@ -1,10 +1,11 @@
-use std::{collections::HashSet, path::Path};
+use std::collections::HashSet;
 
 use anyhow::Result;
 use serde::Deserialize;
 use tracing::warn;
 use yazi_codegen::DeserializeOver2;
 use yazi_fs::File;
+use yazi_shared::url::Url;
 
 use super::{Fetcher, Preloader, Previewer, Spotter};
 use crate::{Preset, plugin::MAX_PREWORKERS};
@@ -39,12 +40,12 @@ pub struct Plugin {
 impl Plugin {
 	pub fn fetchers<'a, 'b: 'a>(
 		&'b self,
-		path: &'a Path,
+		url: &'a Url,
 		mime: &'a str,
 	) -> impl Iterator<Item = &'b Fetcher> + 'a {
 		let mut seen = HashSet::new();
 		self.fetchers.iter().filter(move |&f| {
-			if seen.contains(&f.id) || !f.matches(path, mime) {
+			if seen.contains(&f.id) || !f.matches(url, mime) {
 				return false;
 			}
 			seen.insert(&f.id);
@@ -68,18 +69,18 @@ impl Plugin {
 		})
 	}
 
-	pub fn spotter(&self, path: &Path, mime: &str) -> Option<&Spotter> {
-		self.spotters.iter().find(|&p| p.matches(path, mime))
+	pub fn spotter(&self, url: &Url, mime: &str) -> Option<&Spotter> {
+		self.spotters.iter().find(|&p| p.matches(url, mime))
 	}
 
 	pub fn preloaders<'a, 'b: 'a>(
 		&'b self,
-		path: &'a Path,
+		url: &'a Url,
 		mime: &'a str,
 	) -> impl Iterator<Item = &'b Preloader> + 'a {
 		let mut next = true;
 		self.preloaders.iter().filter(move |&p| {
-			if !next || !p.matches(path, mime) {
+			if !next || !p.matches(url, mime) {
 				return false;
 			}
 			next = p.next;
@@ -87,8 +88,8 @@ impl Plugin {
 		})
 	}
 
-	pub fn previewer(&self, path: &Path, mime: &str) -> Option<&Previewer> {
-		self.previewers.iter().find(|&p| p.matches(path, mime))
+	pub fn previewer(&self, url: &Url, mime: &str) -> Option<&Previewer> {
+		self.previewers.iter().find(|&p| p.matches(url, mime))
 	}
 }
 

--- a/yazi-config/src/plugin/preloader.rs
+++ b/yazi-config/src/plugin/preloader.rs
@@ -1,7 +1,5 @@
-use std::path::Path;
-
 use serde::Deserialize;
-use yazi_shared::{MIME_DIR, event::Cmd};
+use yazi_shared::{MIME_DIR, event::Cmd, url::Url};
 
 use crate::{Pattern, Priority};
 
@@ -10,7 +8,7 @@ pub struct Preloader {
 	#[serde(skip)]
 	pub idx: u8,
 
-	pub name: Option<Pattern>,
+	pub url:  Option<Pattern>,
 	pub mime: Option<Pattern>,
 	pub run:  Cmd,
 	#[serde(default)]
@@ -21,8 +19,8 @@ pub struct Preloader {
 
 impl Preloader {
 	#[inline]
-	pub fn matches(&self, path: &Path, mime: &str) -> bool {
+	pub fn matches(&self, url: &Url, mime: &str) -> bool {
 		self.mime.as_ref().is_some_and(|p| p.match_mime(mime))
-			|| self.name.as_ref().is_some_and(|p| p.match_path(path, mime == MIME_DIR))
+			|| self.url.as_ref().is_some_and(|p| p.match_url(url, mime == MIME_DIR))
 	}
 }

--- a/yazi-config/src/plugin/previewer.rs
+++ b/yazi-config/src/plugin/previewer.rs
@@ -1,27 +1,25 @@
-use std::path::Path;
-
 use serde::Deserialize;
-use yazi_shared::{MIME_DIR, event::Cmd};
+use yazi_shared::{MIME_DIR, event::Cmd, url::Url};
 
 use crate::Pattern;
 
 #[derive(Debug, Deserialize)]
 pub struct Previewer {
-	pub name: Option<Pattern>,
+	pub url:  Option<Pattern>,
 	pub mime: Option<Pattern>,
 	pub run:  Cmd,
 }
 
 impl Previewer {
 	#[inline]
-	pub fn matches(&self, path: &Path, mime: &str) -> bool {
+	pub fn matches(&self, url: &Url, mime: &str) -> bool {
 		self.mime.as_ref().is_some_and(|p| p.match_mime(mime))
-			|| self.name.as_ref().is_some_and(|p| p.match_path(path, mime == MIME_DIR))
+			|| self.url.as_ref().is_some_and(|p| p.match_url(url, mime == MIME_DIR))
 	}
 
 	#[inline]
-	pub fn any_file(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_file()) }
+	pub fn any_file(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_file()) }
 
 	#[inline]
-	pub fn any_dir(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_dir()) }
+	pub fn any_dir(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_dir()) }
 }

--- a/yazi-config/src/plugin/spotter.rs
+++ b/yazi-config/src/plugin/spotter.rs
@@ -1,27 +1,25 @@
-use std::path::Path;
-
 use serde::Deserialize;
-use yazi_shared::{MIME_DIR, event::Cmd};
+use yazi_shared::{MIME_DIR, event::Cmd, url::Url};
 
 use crate::Pattern;
 
 #[derive(Debug, Deserialize)]
 pub struct Spotter {
-	pub name: Option<Pattern>,
+	pub url:  Option<Pattern>,
 	pub mime: Option<Pattern>,
 	pub run:  Cmd,
 }
 
 impl Spotter {
 	#[inline]
-	pub fn matches(&self, path: &Path, mime: &str) -> bool {
+	pub fn matches(&self, url: &Url, mime: &str) -> bool {
 		self.mime.as_ref().is_some_and(|p| p.match_mime(mime))
-			|| self.name.as_ref().is_some_and(|p| p.match_path(path, mime == MIME_DIR))
+			|| self.url.as_ref().is_some_and(|p| p.match_url(url, mime == MIME_DIR))
 	}
 
 	#[inline]
-	pub fn any_file(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_file()) }
+	pub fn any_file(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_file()) }
 
 	#[inline]
-	pub fn any_dir(&self) -> bool { self.name.as_ref().is_some_and(|p| p.any_dir()) }
+	pub fn any_dir(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_dir()) }
 }

--- a/yazi-config/src/theme/filetype.rs
+++ b/yazi-config/src/theme/filetype.rs
@@ -22,7 +22,7 @@ impl Deref for Filetype {
 pub struct FiletypeRule {
 	#[serde(default)]
 	is:        Is,
-	name:      Option<Pattern>,
+	url:       Option<Pattern>,
 	mime:      Option<Pattern>,
 	#[serde(flatten)]
 	pub style: Style,
@@ -35,6 +35,6 @@ impl FiletypeRule {
 		}
 
 		self.mime.as_ref().is_some_and(|p| p.match_mime(mime))
-			|| self.name.as_ref().is_some_and(|n| n.match_path(&file.url, file.is_dir()))
+			|| self.url.as_ref().is_some_and(|n| n.match_url(&file.url, file.is_dir()))
 	}
 }

--- a/yazi-config/src/theme/icon.rs
+++ b/yazi-config/src/theme/icon.rs
@@ -70,7 +70,7 @@ impl Icon {
 
 	#[inline]
 	fn match_by_glob(&self, file: &File) -> Option<&I> {
-		self.globs.iter().find(|(p, _)| p.match_path(&file.url, file.is_dir())).map(|(_, i)| i)
+		self.globs.iter().find(|(p, _)| p.match_url(&file.url, file.is_dir())).map(|(_, i)| i)
 	}
 
 	#[inline]

--- a/yazi-core/src/mgr/watcher.rs
+++ b/yazi-core/src/mgr/watcher.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use tokio::{pin, sync::{mpsc::{self, UnboundedReceiver}, watch}};
 use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
 use tracing::error;
-use yazi_fs::{File, Files, FilesOp, cha::Cha, realname_unchecked, services};
+use yazi_fs::{File, Files, FilesOp, cha::Cha, provider, realname_unchecked};
 use yazi_proxy::WATCHER;
 use yazi_shared::{RoCell, url::Url};
 
@@ -139,7 +139,7 @@ impl Watcher {
 				};
 
 				let u = &file.url;
-				let eq = (!file.is_link() && services::canonicalize(u).await.is_ok_and(|c| c == *u))
+				let eq = (!file.is_link() && provider::canonicalize(u).await.is_ok_and(|c| c == *u))
 					|| realname_unchecked(u, &mut cached).await.is_ok_and(|s| urn.as_urn() == s);
 
 				if !eq {
@@ -194,7 +194,7 @@ impl Watcher {
 
 		async fn go(todo: HashSet<Url>) {
 			for from in todo {
-				let Ok(to) = services::canonicalize(&from).await else { continue };
+				let Ok(to) = provider::canonicalize(&from).await else { continue };
 
 				if to != from && WATCHED.read().contains(&from) {
 					LINKED.write().insert(from, to);

--- a/yazi-core/src/tab/selected.rs
+++ b/yazi-core/src/tab/selected.rs
@@ -126,7 +126,7 @@ impl Selected {
 mod tests {
 	use super::*;
 
-	fn url(s: &str) -> Url { Url::try_from(s).unwrap() }
+	fn url(s: &str) -> Url { s.parse().unwrap() }
 
 	#[test]
 	fn test_insert_non_conflicting() {

--- a/yazi-dds/src/stream.rs
+++ b/yazi-dds/src/stream.rs
@@ -38,7 +38,7 @@ impl Stream {
 	pub(super) async fn bind() -> std::io::Result<ServerListener> {
 		let p = Self::socket_file();
 
-		yazi_fs::services::Local::remove_file(&p).await.ok();
+		yazi_fs::provider::local::Local::remove_file(&p).await.ok();
 		tokio::net::UnixListener::bind(p)
 	}
 

--- a/yazi-fm/build.rs
+++ b/yazi-fm/build.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 	//   C:\Users\Ika\AppData\Local\Temp\cargo-installTFU8cj\release\build\
 	// yazi-fm-45dffef2500eecd0\out
 
-	if dir.contains("\\release\\build\\yazi-fm-") {
+	if dir.contains(r"\release\build\yazi-fm-") {
 		panic!(
 			"Unwinding must be enabled for Windows. Please use `cargo build --profile release-windows --locked` instead to build Yazi."
 		);

--- a/yazi-fm/src/app/commands/bootstrap.rs
+++ b/yazi-fm/src/app/commands/bootstrap.rs
@@ -3,7 +3,7 @@ use yazi_actor::Ctx;
 use yazi_boot::BOOT;
 use yazi_macro::act;
 use yazi_parser::{VoidOpt, mgr::CdSource};
-use yazi_shared::{event::Data, url::Url};
+use yazi_shared::event::Data;
 
 use crate::app::App;
 
@@ -18,10 +18,10 @@ impl App {
 			let cx = &mut Ctx::active(&mut self.core);
 			cx.tab = i;
 
-			if file.is_empty() {
-				act!(mgr:cd, cx, (Url::from(&BOOT.cwds[i]), CdSource::Tab))?;
+			if file.as_os_str().is_empty() {
+				act!(mgr:cd, cx, (BOOT.cwds[i].clone(), CdSource::Tab))?;
 			} else {
-				act!(mgr:reveal, cx, (Url::from(BOOT.cwds[i].join(file)), CdSource::Tab))?;
+				act!(mgr:reveal, cx, (BOOT.cwds[i].join(file), CdSource::Tab))?;
 			}
 		}
 

--- a/yazi-fm/src/app/commands/quit.rs
+++ b/yazi-fm/src/app/commands/quit.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 
 use yazi_boot::ARGS;
-use yazi_fs::services::Local;
+use yazi_fs::provider::local::Local;
 use yazi_shared::event::EventQuit;
 
 use crate::{Term, app::App};
@@ -25,7 +25,7 @@ impl App {
 
 	async fn cwd_to_file(&self, no: bool) {
 		if let Some(p) = ARGS.cwd_file.as_ref().filter(|_| !no) {
-			let cwd = self.core.mgr.cwd().as_os_str();
+			let cwd = self.core.mgr.cwd().os_str();
 			Local::write(p, cwd.as_encoded_bytes()).await.ok();
 		}
 	}

--- a/yazi-fs/src/cha/cha.rs
+++ b/yazi-fs/src/cha/cha.rs
@@ -4,7 +4,7 @@ use yazi_macro::{unix_either, win_either};
 use yazi_shared::url::Url;
 
 use super::ChaKind;
-use crate::services;
+use crate::provider;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Cha {
@@ -59,14 +59,14 @@ impl Cha {
 
 	#[inline]
 	pub async fn from_url(url: &Url) -> std::io::Result<Self> {
-		Ok(Self::from_follow(url, services::symlink_metadata(url).await?).await)
+		Ok(Self::from_follow(url, provider::symlink_metadata(url).await?).await)
 	}
 
 	pub async fn from_follow(url: &Url, mut meta: Metadata) -> Self {
 		let mut attached = ChaKind::hidden(url, &meta);
 		if meta.is_symlink() {
 			attached |= ChaKind::LINK;
-			meta = services::metadata(url).await.unwrap_or(meta);
+			meta = provider::metadata(url).await.unwrap_or(meta);
 		}
 		if meta.is_symlink() {
 			attached |= ChaKind::ORPHAN;

--- a/yazi-fs/src/file.rs
+++ b/yazi-fs/src/file.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsStr, fs::{FileType, Metadata}, hash::{BuildHasher, Hash, Hasher
 use anyhow::Result;
 use yazi_shared::url::{Url, Urn, UrnBuf};
 
-use crate::{cha::Cha, services};
+use crate::{cha::Cha, provider};
 
 #[derive(Clone, Debug, Default)]
 pub struct File {
@@ -22,13 +22,13 @@ impl Deref for File {
 impl File {
 	#[inline]
 	pub async fn new(url: Url) -> Result<Self> {
-		let meta = services::symlink_metadata(&url).await?;
+		let meta = provider::symlink_metadata(&url).await?;
 		Ok(Self::from_follow(url, meta).await)
 	}
 
 	#[inline]
 	pub async fn from_follow(url: Url, meta: Metadata) -> Self {
-		let link_to = if meta.is_symlink() { services::read_link(&url).await.ok() } else { None };
+		let link_to = if meta.is_symlink() { provider::read_link(&url).await.ok() } else { None };
 
 		let cha = Cha::from_follow(&url, meta).await;
 

--- a/yazi-fs/src/files.rs
+++ b/yazi-fs/src/files.rs
@@ -4,7 +4,7 @@ use tokio::{select, sync::mpsc::{self, UnboundedReceiver}};
 use yazi_shared::{Id, url::{Url, Urn, UrnBuf}};
 
 use super::{FilesSorter, Filter};
-use crate::{FILES_TICKET, File, FilesOp, SortBy, cha::Cha, mounts::PARTITIONS, services};
+use crate::{FILES_TICKET, File, FilesOp, SortBy, cha::Cha, mounts::PARTITIONS, provider::{self, DirEntry}};
 
 #[derive(Default)]
 pub struct Files {
@@ -31,7 +31,7 @@ impl Files {
 	pub fn new(show_hidden: bool) -> Self { Self { show_hidden, ..Default::default() } }
 
 	pub async fn from_dir(dir: &Url) -> std::io::Result<UnboundedReceiver<File>> {
-		let mut it = services::read_dir(dir).await?;
+		let mut it = provider::read_dir(dir).await?;
 		let (tx, rx) = mpsc::unbounded_channel();
 
 		tokio::spawn(async move {
@@ -39,7 +39,7 @@ impl Files {
 				select! {
 					_ = tx.closed() => break,
 					result = item.metadata() => {
-						let url = Url::from(item.path());
+						let url = item.url();
 						_ = tx.send(match result {
 							Ok(meta) => File::from_follow(url, meta).await,
 							Err(_) => File::from_dummy(url, item.file_type().await.ok())
@@ -52,7 +52,7 @@ impl Files {
 	}
 
 	pub async fn from_dir_bulk(dir: &Url) -> std::io::Result<Vec<File>> {
-		let mut it = services::read_dir(dir).await?;
+		let mut it = provider::read_dir(dir).await?;
 		let mut entries = Vec::with_capacity(5000);
 		while let Ok(Some(entry)) = it.next_entry().await {
 			entries.push(entry);
@@ -60,10 +60,10 @@ impl Files {
 
 		let (first, rest) = entries.split_at(entries.len() / 3);
 		let (second, third) = rest.split_at(entries.len() / 3);
-		async fn go(entries: &[tokio::fs::DirEntry]) -> Vec<File> {
+		async fn go(entries: &[DirEntry]) -> Vec<File> {
 			let mut files = Vec::with_capacity(entries.len());
 			for entry in entries {
-				let url = Url::from(entry.path());
+				let url = entry.url();
 				files.push(match entry.metadata().await {
 					Ok(meta) => File::from_follow(url, meta).await,
 					Err(_) => File::from_dummy(url, entry.file_type().await.ok()),

--- a/yazi-fs/src/lib.rs
+++ b/yazi-fs/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::if_same_then_else, clippy::option_map_unit_fn)]
 
-yazi_macro::mod_pub!(cha mounts services);
+yazi_macro::mod_pub!(cha mounts provider);
 
 yazi_macro::mod_flat!(calculator cwd file files filter fns op path sorter sorting stage xdg);
 

--- a/yazi-fs/src/provider/buffer.rs
+++ b/yazi-fs/src/provider/buffer.rs
@@ -1,0 +1,9 @@
+// --- BufRead
+pub trait BufRead: tokio::io::AsyncRead + Send {}
+
+impl<T: tokio::io::AsyncRead + Send> BufRead for T {}
+
+// --- BufReadSync
+pub trait BufReadSync: std::io::BufRead + std::io::Seek + Send {}
+
+impl<T: std::io::BufRead + std::io::Seek + Send> BufReadSync for T {}

--- a/yazi-fs/src/provider/dir_entry.rs
+++ b/yazi-fs/src/provider/dir_entry.rs
@@ -1,0 +1,68 @@
+use std::{ffi::OsString, io};
+
+use yazi_shared::url::Url;
+
+pub enum DirEntry {
+	Local(super::local::DirEntry),
+}
+
+impl DirEntry {
+	#[must_use]
+	pub fn url(&self) -> Url {
+		match self {
+			DirEntry::Local(local) => local.url(),
+		}
+	}
+
+	#[must_use]
+	pub fn file_name(&self) -> OsString {
+		match self {
+			DirEntry::Local(local) => local.file_name(),
+		}
+	}
+
+	pub async fn metadata(&self) -> io::Result<std::fs::Metadata> {
+		match self {
+			DirEntry::Local(local) => local.metadata().await,
+		}
+	}
+
+	pub async fn file_type(&self) -> io::Result<std::fs::FileType> {
+		match self {
+			DirEntry::Local(local) => local.file_type().await,
+		}
+	}
+}
+
+// --- DirEntrySync
+pub enum DirEntrySync {
+	Local(super::local::DirEntrySync),
+}
+
+impl DirEntrySync {
+	#[must_use]
+	pub fn url(&self) -> Url {
+		match self {
+			DirEntrySync::Local(local) => local.url(),
+		}
+	}
+
+	#[must_use]
+	pub fn file_name(&self) -> OsString {
+		match self {
+			DirEntrySync::Local(local) => local.file_name(),
+		}
+	}
+
+	pub fn metadata(&self) -> io::Result<std::fs::Metadata> {
+		match self {
+			DirEntrySync::Local(local) => local.metadata(),
+		}
+	}
+
+	pub fn file_type(&self) -> io::Result<std::fs::FileType> {
+		match self {
+			DirEntrySync::Local(local) => local.file_type(),
+		}
+	}
+}

--- a/yazi-fs/src/provider/local/dir_entry.rs
+++ b/yazi-fs/src/provider/local/dir_entry.rs
@@ -1,0 +1,46 @@
+use std::ops::Deref;
+
+use yazi_shared::url::Url;
+
+pub struct DirEntry(tokio::fs::DirEntry);
+
+impl Deref for DirEntry {
+	type Target = tokio::fs::DirEntry;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl From<tokio::fs::DirEntry> for DirEntry {
+	fn from(value: tokio::fs::DirEntry) -> Self { Self(value) }
+}
+
+impl From<DirEntry> for crate::provider::DirEntry {
+	fn from(value: DirEntry) -> Self { crate::provider::DirEntry::Local(value) }
+}
+
+impl DirEntry {
+	#[must_use]
+	pub fn url(&self) -> Url { self.0.path().into() }
+}
+
+// --- DirEntrySync
+pub struct DirEntrySync(std::fs::DirEntry);
+
+impl Deref for DirEntrySync {
+	type Target = std::fs::DirEntry;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl From<std::fs::DirEntry> for DirEntrySync {
+	fn from(value: std::fs::DirEntry) -> Self { Self(value) }
+}
+
+impl From<DirEntrySync> for crate::provider::DirEntrySync {
+	fn from(value: DirEntrySync) -> Self { crate::provider::DirEntrySync::Local(value) }
+}
+
+impl DirEntrySync {
+	#[must_use]
+	pub fn url(&self) -> Url { self.0.path().into() }
+}

--- a/yazi-fs/src/provider/local/gate.rs
+++ b/yazi-fs/src/provider/local/gate.rs
@@ -1,0 +1,14 @@
+use std::ops::{Deref, DerefMut};
+
+#[derive(Default)]
+pub struct Gate(tokio::fs::OpenOptions);
+
+impl Deref for Gate {
+	type Target = tokio::fs::OpenOptions;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl DerefMut for Gate {
+	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+}

--- a/yazi-fs/src/provider/local/local.rs
+++ b/yazi-fs/src/provider/local/local.rs
@@ -1,5 +1,7 @@
 use std::{io, path::{Path, PathBuf}};
 
+use crate::provider::local::{Gate, ReadDir, ReadDirSync, RwFile};
+
 pub struct Local;
 
 impl Local {
@@ -9,8 +11,8 @@ impl Local {
 	}
 
 	#[inline]
-	pub async fn create(path: impl AsRef<Path>) -> io::Result<tokio::fs::File> {
-		tokio::fs::File::create(path).await
+	pub async fn create(path: impl AsRef<Path>) -> io::Result<RwFile> {
+		Gate::default().write(true).create(true).truncate(true).open(path).await.map(Into::into)
 	}
 
 	#[inline]
@@ -34,21 +36,21 @@ impl Local {
 	}
 
 	#[inline]
-	pub async fn open(path: impl AsRef<Path>) -> io::Result<tokio::fs::File> {
-		tokio::fs::File::open(path).await
+	pub async fn open(path: impl AsRef<Path>) -> io::Result<RwFile> {
+		Gate::default().read(true).open(path).await.map(Into::into)
 	}
 
 	#[inline]
 	pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> { tokio::fs::read(path).await }
 
 	#[inline]
-	pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<tokio::fs::ReadDir> {
-		tokio::fs::read_dir(path).await
+	pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
+		tokio::fs::read_dir(path).await.map(Into::into)
 	}
 
 	#[inline]
-	pub fn read_dir_sync(path: impl AsRef<Path>) -> io::Result<std::fs::ReadDir> {
-		std::fs::read_dir(path)
+	pub fn read_dir_sync(path: impl AsRef<Path>) -> io::Result<ReadDirSync> {
+		std::fs::read_dir(path).map(Into::into)
 	}
 
 	#[inline]

--- a/yazi-fs/src/provider/local/mod.rs
+++ b/yazi-fs/src/provider/local/mod.rs
@@ -1,0 +1,1 @@
+yazi_macro::mod_flat!(dir_entry gate local read_dir rw_file);

--- a/yazi-fs/src/provider/local/read_dir.rs
+++ b/yazi-fs/src/provider/local/read_dir.rs
@@ -1,0 +1,38 @@
+use std::io;
+
+use super::{DirEntry, DirEntrySync};
+
+pub struct ReadDir(tokio::fs::ReadDir);
+
+impl From<tokio::fs::ReadDir> for ReadDir {
+	fn from(value: tokio::fs::ReadDir) -> Self { Self(value) }
+}
+
+impl From<ReadDir> for crate::provider::ReadDir {
+	fn from(value: ReadDir) -> Self { crate::provider::ReadDir::Local(value) }
+}
+
+impl ReadDir {
+	pub async fn next_entry(&mut self) -> io::Result<Option<DirEntry>> {
+		self.0.next_entry().await.map(|entry| entry.map(Into::into))
+	}
+}
+
+// --- ReadDirSync
+pub struct ReadDirSync(std::fs::ReadDir);
+
+impl From<std::fs::ReadDir> for ReadDirSync {
+	fn from(value: std::fs::ReadDir) -> Self { Self(value) }
+}
+
+impl From<ReadDirSync> for crate::provider::ReadDirSync {
+	fn from(value: ReadDirSync) -> Self { crate::provider::ReadDirSync::Local(value) }
+}
+
+impl Iterator for ReadDirSync {
+	type Item = io::Result<DirEntrySync>;
+
+	fn next(&mut self) -> Option<io::Result<DirEntrySync>> {
+		self.0.next().map(|result| result.map(Into::into))
+	}
+}

--- a/yazi-fs/src/provider/local/rw_file.rs
+++ b/yazi-fs/src/provider/local/rw_file.rs
@@ -1,0 +1,23 @@
+pub struct RwFile(tokio::fs::File);
+
+impl From<tokio::fs::File> for RwFile {
+	fn from(value: tokio::fs::File) -> Self { Self(value) }
+}
+
+impl From<RwFile> for crate::provider::RwFile {
+	fn from(value: RwFile) -> Self { crate::provider::RwFile::Local(value) }
+}
+
+impl From<tokio::fs::File> for crate::provider::RwFile {
+	fn from(value: tokio::fs::File) -> Self { RwFile(value).into() }
+}
+
+impl RwFile {
+	#[inline]
+	pub fn reader(self) -> tokio::io::BufReader<tokio::fs::File> { tokio::io::BufReader::new(self.0) }
+
+	#[inline]
+	pub async fn reader_sync(self) -> std::io::BufReader<std::fs::File> {
+		std::io::BufReader::new(self.0.into_std().await)
+	}
+}

--- a/yazi-fs/src/provider/mod.rs
+++ b/yazi-fs/src/provider/mod.rs
@@ -1,0 +1,3 @@
+yazi_macro::mod_pub!(local);
+
+yazi_macro::mod_flat!(buffer dir_entry provider read_dir rw_file);

--- a/yazi-fs/src/provider/provider.rs
+++ b/yazi-fs/src/provider/provider.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use yazi_shared::url::Url;
 
-use crate::services::Local;
+use crate::provider::{ReadDir, ReadDirSync, RwFile, local::Local};
 
 #[inline]
 pub async fn canonicalize(url: impl AsRef<Url>) -> io::Result<Url> {
@@ -14,9 +14,9 @@ pub async fn canonicalize(url: impl AsRef<Url>) -> io::Result<Url> {
 }
 
 #[inline]
-pub async fn create(url: impl AsRef<Url>) -> io::Result<tokio::fs::File> {
+pub async fn create(url: impl AsRef<Url>) -> io::Result<RwFile> {
 	if let Some(path) = url.as_ref().as_path() {
-		Local::create(path).await
+		Local::create(path).await.map(Into::into)
 	} else {
 		Err(io::Error::new(io::ErrorKind::Unsupported, "Unsupported filesystem"))
 	}
@@ -59,27 +59,27 @@ pub async fn metadata(url: impl AsRef<Url>) -> io::Result<std::fs::Metadata> {
 }
 
 #[inline]
-pub async fn open(url: impl AsRef<Url>) -> io::Result<tokio::fs::File> {
+pub async fn open(url: impl AsRef<Url>) -> io::Result<RwFile> {
 	if let Some(path) = url.as_ref().as_path() {
-		Local::open(path).await
+		Local::open(path).await.map(Into::into)
 	} else {
 		Err(io::Error::new(io::ErrorKind::Unsupported, "Unsupported filesystem"))
 	}
 }
 
 #[inline]
-pub async fn read_dir(url: impl AsRef<Url>) -> io::Result<tokio::fs::ReadDir> {
+pub async fn read_dir(url: impl AsRef<Url>) -> io::Result<ReadDir> {
 	if let Some(path) = url.as_ref().as_path() {
-		Local::read_dir(path).await
+		Local::read_dir(path).await.map(Into::into)
 	} else {
 		Err(io::Error::new(io::ErrorKind::Unsupported, "Unsupported filesystem"))
 	}
 }
 
 #[inline]
-pub fn read_dir_sync(url: impl AsRef<Url>) -> io::Result<std::fs::ReadDir> {
+pub fn read_dir_sync(url: impl AsRef<Url>) -> io::Result<ReadDirSync> {
 	if let Some(path) = url.as_ref().as_path() {
-		Local::read_dir_sync(path)
+		Local::read_dir_sync(path).map(Into::into)
 	} else {
 		Err(io::Error::new(io::ErrorKind::Unsupported, "Unsupported filesystem"))
 	}

--- a/yazi-fs/src/provider/read_dir.rs
+++ b/yazi-fs/src/provider/read_dir.rs
@@ -1,0 +1,30 @@
+use std::io;
+
+use super::{DirEntry, DirEntrySync};
+
+pub enum ReadDir {
+	Local(super::local::ReadDir),
+}
+
+impl ReadDir {
+	pub async fn next_entry(&mut self) -> io::Result<Option<DirEntry>> {
+		match self {
+			ReadDir::Local(local) => local.next_entry().await.map(|entry| entry.map(Into::into)),
+		}
+	}
+}
+
+// --- ReadDirSync
+pub enum ReadDirSync {
+	Local(super::local::ReadDirSync),
+}
+
+impl Iterator for ReadDirSync {
+	type Item = io::Result<DirEntrySync>;
+
+	fn next(&mut self) -> Option<io::Result<DirEntrySync>> {
+		match self {
+			ReadDirSync::Local(local) => local.next().map(|result| result.map(Into::into)),
+		}
+	}
+}

--- a/yazi-fs/src/provider/rw_file.rs
+++ b/yazi-fs/src/provider/rw_file.rs
@@ -1,0 +1,21 @@
+use crate::provider::{BufRead, BufReadSync};
+
+pub enum RwFile {
+	Local(super::local::RwFile),
+}
+
+impl RwFile {
+	#[inline]
+	pub fn reader(self) -> Box<dyn BufRead> {
+		match self {
+			RwFile::Local(local) => Box::new(local.reader()),
+		}
+	}
+
+	#[inline]
+	pub async fn reader_sync(self) -> Box<dyn BufReadSync> {
+		match self {
+			RwFile::Local(local) => Box::new(local.reader_sync().await),
+		}
+	}
+}

--- a/yazi-fs/src/services/mod.rs
+++ b/yazi-fs/src/services/mod.rs
@@ -1,1 +1,0 @@
-yazi_macro::mod_flat!(local services);

--- a/yazi-parser/src/mgr/tab_create.rs
+++ b/yazi-parser/src/mgr/tab_create.rs
@@ -16,7 +16,7 @@ impl From<CmdCow> for TabCreateOpt {
 			return Self { wd: None };
 		}
 		let Some(mut wd) = c.take_first_url() else {
-			return Self { wd: Some(Url::from(&BOOT.cwds[0])) };
+			return Self { wd: Some(BOOT.cwds[0].clone()) };
 		};
 		if !c.bool("raw")
 			&& let Cow::Owned(u) = expand_url(&wd)

--- a/yazi-plugin/preset/components/header.lua
+++ b/yazi-plugin/preset/components/header.lua
@@ -38,7 +38,7 @@ function Header:flags()
 
 	local t = {}
 	if cwd.is_search then
-		t[#t + 1] = string.format("search: %s", cwd.frag)
+		t[#t + 1] = string.format("search: %s", cwd.domain)
 	end
 	if filter then
 		t[#t + 1] = string.format("filter: %s", filter)

--- a/yazi-plugin/src/external/highlighter.rs
+++ b/yazi-plugin/src/external/highlighter.rs
@@ -3,9 +3,9 @@ use std::{borrow::Cow, io::Cursor, mem, path::{Path, PathBuf}, sync::OnceLock};
 use anyhow::{Result, anyhow};
 use ratatui::{layout::Size, text::{Line, Span, Text}};
 use syntect::{LoadingError, dumps, easy::HighlightLines, highlighting::{self, Theme, ThemeSet}, parsing::{SyntaxReference, SyntaxSet}};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::AsyncBufReadExt;
 use yazi_config::{THEME, YAZI, preview::PreviewWrap};
-use yazi_fs::services::Local;
+use yazi_fs::provider::local::Local;
 use yazi_shared::{Ids, errors::PeekError, replace_to_printable};
 
 static INCR: Ids = Ids::new();
@@ -39,7 +39,7 @@ impl Highlighter {
 	pub fn abort() { INCR.next(); }
 
 	pub async fn highlight(&self, skip: usize, size: Size) -> Result<Text<'static>, PeekError> {
-		let mut reader = BufReader::new(Local::open(&self.path).await?);
+		let mut reader = Local::open(&self.path).await?.reader();
 
 		let syntax = Self::find_syntax(&self.path).await;
 		let mut plain = syntax.is_err();
@@ -143,7 +143,7 @@ impl Highlighter {
 		}
 
 		let mut line = String::new();
-		let mut reader = BufReader::new(Local::open(&path).await?);
+		let mut reader = Local::open(&path).await?.reader();
 		reader.read_line(&mut line).await?;
 		syntaxes.find_syntax_by_first_line(&line).ok_or_else(|| anyhow!("No syntax found"))
 	}

--- a/yazi-plugin/src/loader/loader.rs
+++ b/yazi-plugin/src/loader/loader.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use mlua::{ChunkMode, ExternalError, Lua, Table};
 use parking_lot::RwLock;
 use yazi_boot::BOOT;
-use yazi_fs::services::Local;
+use yazi_fs::provider::local::Local;
 use yazi_macro::plugin_preset as preset;
 use yazi_shared::{LOG_LEVEL, RoCell};
 

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use tokio::{select, sync::mpsc::{self, UnboundedReceiver}, task::JoinHandle};
 use yazi_config::{YAZI, plugin::{Fetcher, Preloader}};
 use yazi_dds::Pump;
-use yazi_fs::{must_be_dir, remove_dir_clean, services, unique_name};
+use yazi_fs::{must_be_dir, provider, remove_dir_clean, unique_name};
 use yazi_parser::{app::PluginOpt, tasks::ProcessExecOpt};
 use yazi_proxy::MgrProxy;
 use yazi_shared::{Id, Throttle, url::Url};
@@ -175,7 +175,7 @@ impl Scheduler {
 			move |canceled: bool| {
 				async move {
 					if !canceled {
-						services::remove_dir_all(&target).await.ok();
+						provider::remove_dir_all(&target).await.ok();
 						MgrProxy::update_tasks(&target);
 						Pump::push_delete(target);
 					}

--- a/yazi-shared/src/event/data.rs
+++ b/yazi-shared/src/event/data.rs
@@ -66,9 +66,9 @@ impl Data {
 	#[inline]
 	pub fn into_url(self) -> Option<Url> {
 		match self {
-			Self::String(s) => Url::try_from(s.as_ref()).ok(),
+			Self::String(s) => s.parse().ok(),
 			Self::Url(u) => Some(u),
-			Self::Bytes(b) => Url::try_from(b.as_slice()).ok(),
+			Self::Bytes(b) => b.as_slice().try_into().ok(),
 			_ => None,
 		}
 	}
@@ -96,9 +96,9 @@ impl Data {
 	#[inline]
 	pub fn to_url(&self) -> Option<Url> {
 		match self {
-			Self::String(s) => Url::try_from(s.as_ref()).ok(),
+			Self::String(s) => s.parse().ok(),
 			Self::Url(u) => Some(u.clone()),
-			Self::Bytes(b) => Url::try_from(b.as_slice()).ok(),
+			Self::Bytes(b) => b.as_slice().try_into().ok(),
 			_ => None,
 		}
 	}
@@ -186,9 +186,9 @@ impl DataKey {
 	#[inline]
 	pub fn into_url(self) -> Option<Url> {
 		match self {
-			Self::String(s) => Url::try_from(s.as_ref()).ok(),
+			Self::String(s) => s.parse().ok(),
 			Self::Url(u) => Some(u),
-			Self::Bytes(b) => Url::try_from(b.as_slice()).ok(),
+			Self::Bytes(b) => b.as_slice().try_into().ok(),
 			_ => None,
 		}
 	}

--- a/yazi-shared/src/url/display.rs
+++ b/yazi-shared/src/url/display.rs
@@ -1,4 +1,4 @@
-use crate::url::Url;
+use crate::url::{Encode, Url};
 
 pub struct Display<'a> {
 	inner: &'a Url,
@@ -13,7 +13,7 @@ impl<'a> std::fmt::Display for Display<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let Url { loc, scheme } = self.inner;
 		if scheme.is_virtual() {
-			scheme.fmt(f)?;
+			Encode::from(self.inner).fmt(f)?;
 		}
 		loc.display().fmt(f)
 	}

--- a/yazi-shared/src/url/encode.rs
+++ b/yazi-shared/src/url/encode.rs
@@ -1,0 +1,76 @@
+use std::fmt::{self, Display};
+
+use percent_encoding::{AsciiSet, CONTROLS, PercentEncode, percent_encode};
+
+use crate::url::{Loc, Scheme, Url};
+
+pub struct Encode<'a> {
+	loc:    &'a Loc,
+	scheme: &'a Scheme,
+}
+
+impl<'a> From<&'a Url> for Encode<'a> {
+	fn from(url: &'a Url) -> Self { Self::new(&url.loc, &url.scheme) }
+}
+
+impl<'a> Encode<'a> {
+	#[inline]
+	pub(super) fn new(loc: &'a Loc, scheme: &'a Scheme) -> Self { Self { loc, scheme } }
+
+	#[inline]
+	fn domain<'s>(s: &'s str) -> PercentEncode<'s> {
+		const SET: &AsciiSet = &CONTROLS.add(b'/').add(b':');
+		percent_encode(s.as_bytes(), SET)
+	}
+
+	#[inline]
+	fn urn(loc: &'a Loc) -> impl Display {
+		struct D(usize);
+
+		impl Display for D {
+			fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+				if self.0 != 0 {
+					write!(f, ":{}", self.0)?;
+				}
+				Ok(())
+			}
+		}
+
+		D(loc.urn().components().count())
+	}
+}
+
+impl Display for Encode<'_> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self.scheme {
+			Scheme::Regular => write!(f, "regular://"),
+			Scheme::Search(d) => write!(f, "search://{}{}/", Self::domain(d), Self::urn(self.loc)),
+			Scheme::Archive(d) => write!(f, "archive://{}{}/", Self::domain(d), Self::urn(self.loc)),
+			Scheme::Sftp(d) => write!(f, "sftp://{}{}/", Self::domain(d), Self::urn(self.loc)),
+		}
+	}
+}
+
+// --- Tilded
+pub struct EncodeTilded<'a> {
+	loc:    &'a Loc,
+	scheme: &'a Scheme,
+}
+
+impl<'a> From<&'a Url> for EncodeTilded<'a> {
+	fn from(url: &'a Url) -> Self { Self { loc: &url.loc, scheme: &url.scheme } }
+}
+
+impl Display for EncodeTilded<'_> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		use Encode as E;
+
+		let loc = percent_encode(self.loc.as_os_str().as_encoded_bytes(), CONTROLS);
+		match self.scheme {
+			Scheme::Regular => write!(f, "regular~://{loc}"),
+			Scheme::Search(d) => write!(f, "search~://{}{}/{loc}", E::domain(d), E::urn(self.loc)),
+			Scheme::Archive(d) => write!(f, "archive~://{}{}/{loc}", E::domain(d), E::urn(self.loc)),
+			Scheme::Sftp(d) => write!(f, "sftp~://{}{}/{loc}", E::domain(d), E::urn(self.loc)),
+		}
+	}
+}

--- a/yazi-shared/src/url/loc.rs
+++ b/yazi-shared/src/url/loc.rs
@@ -1,12 +1,13 @@
 use std::{borrow::Cow, cmp, ffi::{OsStr, OsString}, fmt::{self, Debug, Formatter}, hash::{Hash, Hasher}, ops::Deref, path::{Path, PathBuf}};
 
+use anyhow::{Result, bail};
+
 use crate::url::{Urn, UrnBuf};
 
 #[derive(Clone, Default)]
 pub struct Loc {
 	inner: PathBuf,
 	urn:   usize,
-	name:  usize,
 }
 
 impl Deref for Loc {
@@ -39,11 +40,7 @@ impl Hash for Loc {
 
 impl Debug for Loc {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		f.debug_struct("Loc")
-			.field("path", &self.inner)
-			.field("urn", &self.urn())
-			.field("name", &self.name())
-			.finish()
+		f.debug_struct("Loc").field("path", &self.inner).field("urn", &self.urn()).finish()
 	}
 }
 
@@ -59,20 +56,22 @@ impl From<PathBuf> for Loc {
 	fn from(path: PathBuf) -> Self {
 		let Some(name) = path.file_name() else {
 			let urn = path.as_os_str().len();
-			return Self { inner: path, urn, name: 0 };
+			return Self { inner: path, urn };
 		};
 
 		let name_len = name.len();
 		let prefix_len = unsafe {
-			name.as_encoded_bytes().as_ptr().offset_from(path.as_os_str().as_encoded_bytes().as_ptr())
+			name
+				.as_encoded_bytes()
+				.as_ptr()
+				.offset_from_unsigned(path.as_os_str().as_encoded_bytes().as_ptr())
 		};
 
 		let mut bytes = path.into_os_string().into_encoded_bytes();
-		bytes.truncate(name_len + prefix_len as usize);
+		bytes.truncate(prefix_len + name_len);
 		Self {
 			inner: PathBuf::from(unsafe { OsString::from_encoded_bytes_unchecked(bytes) }),
 			urn:   name_len,
-			name:  name_len,
 		}
 	}
 }
@@ -86,7 +85,26 @@ impl<T: ?Sized + AsRef<OsStr>> From<&T> for Loc {
 }
 
 impl Loc {
-	pub fn with(base: &Path, path: PathBuf) -> Self {
+	pub fn zeroed(path: PathBuf) -> Self {
+		let mut loc = Self::from(path);
+		loc.urn = 0;
+		loc
+	}
+
+	pub fn with(urn: usize, path: PathBuf) -> Result<Self> {
+		let mut loc = Self::from(path);
+		let mut it = loc.inner.components();
+		for _ in 0..urn {
+			if it.next_back().is_none() {
+				bail!("URN exceeds its entire URL");
+			}
+		}
+
+		loc.urn = loc.strip_prefix(it).unwrap().as_os_str().len();
+		Ok(loc)
+	}
+
+	pub fn with_lossy(base: &Path, path: PathBuf) -> Self {
 		let mut loc = Self::from(path);
 		loc.urn = loc.inner.strip_prefix(base).unwrap_or(&loc.inner).as_os_str().len();
 		loc
@@ -105,28 +123,20 @@ impl Loc {
 	pub fn urn_owned(&self) -> UrnBuf { self.urn().to_owned() }
 
 	#[inline]
-	pub fn name(&self) -> &OsStr {
-		unsafe {
-			OsStr::from_encoded_bytes_unchecked(
-				self.bytes().get_unchecked(self.bytes().len() - self.name..),
-			)
-		}
-	}
+	pub fn name(&self) -> &OsStr { self.inner.file_name().unwrap_or(OsStr::new("")) }
 
 	pub fn set_name(&mut self, name: impl AsRef<OsStr>) {
-		let name = name.as_ref();
-		if name == self.name() {
+		let (old, new) = (self.name(), name.as_ref());
+		if old == new {
 			return;
 		}
 
-		if self.name > name.len() {
-			self.urn -= self.name - name.len();
+		if old.len() > new.len() {
+			self.urn -= old.len() - new.len();
 		} else {
-			self.urn += name.len() - self.name;
+			self.urn += new.len() - old.len();
 		}
-
-		self.name = name.len();
-		self.inner.set_file_name(name);
+		self.inner.set_file_name(new);
 	}
 
 	#[inline]
@@ -143,12 +153,15 @@ impl Loc {
 
 	#[inline]
 	pub fn rebase(&self, parent: &Path) -> Self {
-		debug_assert!(self.urn == self.name);
+		debug_assert!(self.urn == self.name().len());
 		let path = parent.join(self.name());
 
-		debug_assert!(path.file_name().is_some_and(|s| s.len() == self.name));
-		Self { inner: path, urn: self.name, name: self.name }
+		debug_assert!(path.file_name().is_some_and(|s| s.len() == self.name().len()));
+		Self { inner: path, urn: self.urn }
 	}
+
+	#[inline]
+	pub fn to_path(&self) -> PathBuf { self.inner.clone() }
 
 	#[inline]
 	pub fn into_path(self) -> PathBuf { self.inner }
@@ -159,8 +172,6 @@ impl Loc {
 
 #[cfg(test)]
 mod tests {
-	use std::path::MAIN_SEPARATOR;
-
 	use super::*;
 
 	#[test]
@@ -182,18 +193,37 @@ mod tests {
 	}
 
 	#[test]
-	fn test_from() {
-		let loc = Loc::with(Path::new("/"), "/".into());
+	fn test_with() -> Result<()> {
+		let loc = Loc::with(0, "/".into())?;
 		assert_eq!(loc.urn().as_os_str(), OsStr::new(""));
 		assert_eq!(loc.name(), OsStr::new(""));
 		assert_eq!(loc.base().as_os_str(), OsStr::new("/"));
 
-		let loc = Loc::with(Path::new("/root/"), "/root/code/".into());
+		let loc = Loc::with(1, "/root/code/".into())?;
 		assert_eq!(loc.urn().as_os_str(), OsStr::new("code"));
 		assert_eq!(loc.name(), OsStr::new("code"));
 		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
 
-		let loc = Loc::with(Path::new("/root//"), "/root/code/foo//".into());
+		let loc = Loc::with(2, "/root/code/foo//".into())?;
+		assert_eq!(loc.urn().as_os_str(), OsStr::new("code/foo"));
+		assert_eq!(loc.name(), OsStr::new("foo"));
+		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
+		Ok(())
+	}
+
+	#[test]
+	fn test_with_lossy() {
+		let loc = Loc::with_lossy(Path::new("/"), "/".into());
+		assert_eq!(loc.urn().as_os_str(), OsStr::new(""));
+		assert_eq!(loc.name(), OsStr::new(""));
+		assert_eq!(loc.base().as_os_str(), OsStr::new("/"));
+
+		let loc = Loc::with_lossy(Path::new("/root/"), "/root/code/".into());
+		assert_eq!(loc.urn().as_os_str(), OsStr::new("code"));
+		assert_eq!(loc.name(), OsStr::new("code"));
+		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
+
+		let loc = Loc::with_lossy(Path::new("/root//"), "/root/code/foo//".into());
 		assert_eq!(loc.urn().as_os_str(), OsStr::new("code/foo"));
 		assert_eq!(loc.name(), OsStr::new("foo"));
 		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
@@ -201,18 +231,20 @@ mod tests {
 
 	#[test]
 	fn test_set_name() {
-		let mut loc = Loc::with(Path::new("/root"), "/root/code/foo/".into());
+		const S: char = std::path::MAIN_SEPARATOR;
+
+		let mut loc = Loc::with_lossy(Path::new("/root"), "/root/code/foo/".into());
 		assert_eq!(loc.urn().as_os_str(), OsStr::new("code/foo"));
 		assert_eq!(loc.name(), OsStr::new("foo"));
 		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
 
 		loc.set_name("bar.txt");
-		assert_eq!(loc.urn().as_os_str(), OsString::from(format!("code{MAIN_SEPARATOR}bar.txt")));
+		assert_eq!(loc.urn().as_os_str(), OsString::from(format!("code{S}bar.txt")));
 		assert_eq!(loc.name(), OsStr::new("bar.txt"));
 		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
 
 		loc.set_name("baz");
-		assert_eq!(loc.urn().as_os_str(), OsString::from(format!("code{MAIN_SEPARATOR}baz")));
+		assert_eq!(loc.urn().as_os_str(), OsString::from(format!("code{S}baz")));
 		assert_eq!(loc.name(), OsStr::new("baz"));
 		assert_eq!(loc.base().as_os_str(), OsStr::new("/root/"));
 	}

--- a/yazi-shared/src/url/mod.rs
+++ b/yazi-shared/src/url/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(component cov display loc scheme url urn);
+yazi_macro::mod_flat!(component cov display encode loc scheme url urn);


### PR DESCRIPTION
Prepare for https://github.com/sxyazi/yazi/issues/611

---

## ⚠️ Breaking changes

The `name` rule for [open](https://yazi-rs.github.io/docs/configuration/yazi#open), [fetchers](https://yazi-rs.github.io/docs/configuration/yazi#plugin.fetchers), spotters, [preloaders](https://yazi-rs.github.io/docs/configuration/yazi#plugin.preloaders), [previewers](https://yazi-rs.github.io/docs/configuration/yazi#plugin.previewers), [filetype](https://yazi-rs.github.io/docs/configuration/theme#filetype), and [`globs` icon rules](https://yazi-rs.github.io/docs/configuration/theme#icon) has been renamed to `url`, e.g.:

```diff
# yazi.toml
[plugin]
prepend_previewers = [
-   { name = "*/", run = "folder" },
+   { url = "*/", run = "folder" },
]
```

```diff
# theme.toml / flavor.toml
[filetype]
rules = [
-   { name = "*/", fg = "blue" },
+   { url = "*/", fg = "blue" },
]
```

This change addresses:

- The original term `name` was inaccurate since the `name` rule doesn't apply to the filename actually, but to the full file path, e.g., `{ name = "/Downloads/**/*.zip", ... }`.
- With this PR, virtual file system has been supported, and there needs to be a way for matching URL schemes, for instance, to disable previews for SFTP servers: `{ url = "sftp://**", run = "noop" }`.

URL is a superset of path, which means that the new `url` rule will inherit the functionality of the original `name` rule while also providing support for URL scheme matching.

## Deprecated

The `frag` property of `Url` has been deprecated and replaced by the new `domain`:

```diff
- print(url.frag)
+ print(url.domain)
```

This change is part of the redesign of the URL system. Previously, the fragment was included after the URL's path:

```sh
search:///path/to/file#keyword
```

But this means that the character `#` could no longer appear in the path, otherwise it would be unclear where the fragment starts, hence it required the path to be URL encoded:

```sh
search://%2Fpath%2Fto%2Ffile#keyword
```

This reduced readability and made typing URLs more cumbersome since the path is the most critical part of a URL. The new implementation stores the original fragment as the URL's domain:

```sh
search://keyword//path/to/file
```

Fragments occur far less frequently than paths, and they are typically only used for internal data exchange in Yazi, and users usually do not have to input them, so encoding fragments instead is acceptable.