### PR TITLE
fix: prevent PDF out-of-range error message from overlapping preview image

### DIFF
--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -51,6 +51,7 @@ function M:preload(job)
 		local pages = tonumber(output.stderr:match("the last page %((%d+)%)")) or 0
 		if job.skip > 0 and pages > 0 then
 			ya.emit("peek", { math.max(0, pages - 1), only_if = job.file.url, upper_bound = true })
+			return false
 		end
 		return true, Err("Failed to convert PDF to image, stderr: %s", output.stderr)
 	end


### PR DESCRIPTION
Fixes: https://github.com/sxyazi/yazi/issues/3066