### PR TITLE
feat: support mouse drop event

### DIFF
--- a/yazi-plugin/preset/components/root.lua
+++ b/yazi-plugin/preset/components/root.lua
@@ -76,3 +76,5 @@ end
 function Root:move(event) end
 
 function Root:drag(event) end
+
+function Root:drop(data) end


### PR DESCRIPTION
## Rationale of this PR

Current Yazi doesn’t handle mouse drop events.
Many terminals map drag-and-drop into a `Paste` event in Crossterm. When no input element is visible, if the user drops something into the Yazi area, the `Root:drop` method will be called with the dropped string. From there, the user can decide how to handle it.