### PR TITLE
fix: add `fd` as a dependency to the `.deb` packaging workflow

### DIFF
--- a/yazi-packing/Cargo.toml
+++ b/yazi-packing/Cargo.toml
@@ -11,7 +11,7 @@ repository  = "https://github.com/sxyazi/yazi"
 	[package.metadata.deb]
 	name                      = "yazi"
 	license-file              = [ "../LICENSE", "0" ]
-	depends                   = "file, ffmpeg, 7zip, jq, poppler-utils, fd-find, ripgrep, fzf, zoxide, imagemagick, xsel|xclip|wl-clipboard"
+	depends                   = "file, ffmpeg, 7zip, jq, poppler-utils, fd-find|fd, ripgrep, fzf, zoxide, imagemagick, xsel|xclip|wl-clipboard"
 	recommends                = "bash-completion"
 	extended-description-file = "README.md"
 	section                   = "utility"


### PR DESCRIPTION

## Rationale of this PR

The dependency on `fd-find` causes a removal of `fd` due to a noted conflict and if the user has installed `fd` (i.e. from github or via `deb-get` ) because the renamed `fd-find` in their LTS installation is too old they'll suffer a surprise downgrade or get into a blocked situation.

```
$ apt-cache policy fd-find fd
fd-find:
  Installed: (none)
  Candidate: 8.3.1-1ubuntu0.1
  Version table:
     8.3.1-1ubuntu0.1 500
        500 http://gb.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages
        500 http://gb.archive.ubuntu.com/ubuntu jammy-security/universe amd64 Packages
     8.3.1-1 500
        500 http://gb.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages
fd:
  Installed: 10.3.0
  Candidate: 10.3.0
  Version table:
 *** 10.3.0 100
        100 /var/lib/dpkg/status
```

It might be preferable even to limit the `fd` dependency to >='10.3.0' , but I think the simple alternative would do.

```
deb-get show fd yazi
fd
  Package:	fd
  Repository:	01-main
  Updater:	deb-get
  Installed:	10.3.0
  Published:	10.3.0
  Architecture:	amd64 arm64 armhf
  Download:	https://github.com/sharkdp/fd/releases/download/v10.3.0/fd_10.3.0_amd64.deb
  Website:	https://github.com/sharkdp/fd
  Summary:	A simple, fast and user-friendly alternative to 'find'.
Yazi
  Package:	yazi
  Repository:	99-local
  Updater:	deb-get
  Installed:	No
  Published:	25.5.28-1
  Architecture:	amd64 arm64
  Download:	https://github.com/sxyazi/yazi/releases/download/nightly/yazi-x86_64-unknown-linux-gnu.deb
  Website:	https://yazi-rs.github.io/
  Summary:	💥 Blazing fast terminal file manager written in Rust, based on async I/O.
```

I've re-opened https://github.com/wimpysworld/deb-get/issues/1158 and created a [draft PR](https://github.com/wimpysworld/deb-get/pull/1508) there ready for your next release.


