### PR TITLE
feat: offload mimetype fetching on opening files to the task scheduler

### DIFF
--- a/yazi-actor/src/lives/task.rs
+++ b/yazi-actor/src/lives/task.rs
@@ -32,6 +32,7 @@ impl UserData for TaskSnap {
 
 		fields.add_field_method_get("running", |_, me| Ok(me.prog.running()));
 		fields.add_field_method_get("success", |_, me| Ok(me.prog.success()));
+		fields.add_field_method_get("cleaning", |_, me| Ok(me.prog.cleaning()));
 		fields.add_field_method_get("percent", |_, me| Ok(me.prog.percent()));
 	}
 }

--- a/yazi-actor/src/lives/yanked.rs
+++ b/yazi-actor/src/lives/yanked.rs
@@ -38,9 +38,9 @@ impl UserData for Yanked {
 	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
 		methods.add_meta_method(MetaMethod::Len, |_, me, ()| Ok(me.len()));
 
-		methods.add_meta_function(MetaMethod::Pairs, |lua, ud: AnyUserData| {
-			let me = ud.borrow::<Self>()?;
-			get_metatable(lua, &me.iter)?.call_function::<MultiValue>(MetaMethod::Pairs.name(), ud)
+		methods.add_meta_method(MetaMethod::Pairs, |lua, me, ()| {
+			get_metatable(lua, &me.iter)?
+				.call_function::<MultiValue>(MetaMethod::Pairs.name(), me.iter.clone())
 		});
 	}
 }

--- a/yazi-actor/src/tasks/inspect.rs
+++ b/yazi-actor/src/tasks/inspect.rs
@@ -55,7 +55,7 @@ impl Actor for Inspect {
 						execute!(TTY.writer(), crossterm::style::Print(line), crossterm::style::Print("\r\n")).ok();
 					}
 					_ = time::sleep(time::Duration::from_millis(500)) => {
-						if ongoing.lock().get(id).is_none() {
+						if !ongoing.lock().exists(id) {
 							execute!(TTY.writer(), crossterm::style::Print("Task finished, press `q` to quit\r\n")).ok();
 							break;
 						}

--- a/yazi-core/src/tasks/preload.rs
+++ b/yazi-core/src/tasks/preload.rs
@@ -23,7 +23,7 @@ impl Tasks {
 		drop(loaded);
 		for (i, tasks) in tasks.into_iter().enumerate() {
 			if !tasks.is_empty() {
-				self.scheduler.fetch_paged(&YAZI.plugin.fetchers[i], tasks);
+				self.scheduler.fetch_paged(&YAZI.plugin.fetchers[i], tasks, None);
 			}
 		}
 	}

--- a/yazi-parser/src/mgr/update_yanked.rs
+++ b/yazi-parser/src/mgr/update_yanked.rs
@@ -73,9 +73,9 @@ impl UserData for UpdateYankedIter {
 	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
 		methods.add_meta_method(MetaMethod::Len, |_, me, ()| Ok(me.len));
 
-		methods.add_meta_function(MetaMethod::Pairs, |lua, ud: AnyUserData| {
-			let me = ud.borrow::<Self>()?;
-			get_metatable(lua, &me.inner)?.call_function::<MultiValue>(MetaMethod::Pairs.name(), ud)
+		methods.add_meta_method(MetaMethod::Pairs, |lua, me, ()| {
+			get_metatable(lua, &me.inner)?
+				.call_function::<MultiValue>(MetaMethod::Pairs.name(), me.inner.clone())
 		});
 	}
 }

--- a/yazi-plugin/preset/components/tasks.lua
+++ b/yazi-plugin/preset/components/tasks.lua
@@ -74,9 +74,16 @@ end
 function Tasks:progress_redraw(snap, y)
 	local kind = snap.prog.kind
 	if kind == "FilePaste" or kind == "FileDelete" then
+		local percent
+		if snap.cleaning then
+			percent = "Cleaning…"
+		else
+			percent = string.format("%3d%%", math.floor(snap.percent))
+		end
+
 		local label = string.format(
-			"%3d%% - %s / %s",
-			math.floor(snap.percent),
+			"%s - %s / %s",
+			percent,
 			ya.readable_size(snap.prog.processed_bytes),
 			ya.readable_size(snap.prog.total_bytes)
 		)
@@ -103,7 +110,7 @@ function Tasks:progress_redraw(snap, y)
 		if snap.running then
 			text = "Running…"
 		elseif snap.success then
-			text = "Completing…"
+			text = "Cleaning…"
 		else
 			text = "Failed, press Enter to view log…"
 		end

--- a/yazi-scheduler/src/file/out.rs
+++ b/yazi-scheduler/src/file/out.rs
@@ -4,8 +4,9 @@ use crate::{Task, TaskProg};
 #[derive(Debug)]
 pub(crate) enum FileOutPaste {
 	New(u64),
-	Init,
 	Deform(String),
+	Init,
+	Clean,
 }
 
 impl From<std::io::Error> for FileOutPaste {
@@ -20,13 +21,16 @@ impl FileOutPaste {
 				prog.total_files += 1;
 				prog.total_bytes += bytes;
 			}
-			Self::Init => {
-				prog.collected = true;
-			}
 			Self::Deform(reason) => {
 				prog.total_files += 1;
 				prog.failed_files += 1;
 				task.log(reason);
+			}
+			Self::Init => {
+				prog.collected = true;
+			}
+			Self::Clean => {
+				prog.cleaned = true;
 			}
 		}
 	}
@@ -111,8 +115,8 @@ impl FileOutLink {
 #[derive(Debug)]
 pub(crate) enum FileOutHardlink {
 	New,
-	Init,
 	Deform(String),
+	Init,
 }
 
 impl From<std::io::Error> for FileOutHardlink {
@@ -126,13 +130,13 @@ impl FileOutHardlink {
 			Self::New => {
 				prog.total += 1;
 			}
-			Self::Init => {
-				prog.collected = true;
-			}
 			Self::Deform(reason) => {
 				prog.total += 1;
 				prog.failed += 1;
 				task.log(reason);
+			}
+			Self::Init => {
+				prog.collected = true;
 			}
 		}
 	}
@@ -168,8 +172,9 @@ impl FileOutHardlinkDo {
 #[derive(Debug)]
 pub(crate) enum FileOutDelete {
 	New(u64),
-	Init,
 	Deform(String),
+	Init,
+	Clean,
 }
 
 impl From<std::io::Error> for FileOutDelete {
@@ -184,13 +189,16 @@ impl FileOutDelete {
 				prog.total_files += 1;
 				prog.total_bytes += size;
 			}
-			Self::Init => {
-				prog.collected = true;
-			}
 			Self::Deform(reason) => {
 				prog.total_files += 1;
 				prog.failed_files += 1;
 				task.log(reason);
+			}
+			Self::Init => {
+				prog.collected = true;
+			}
+			Self::Clean => {
+				prog.cleaned = true;
 			}
 		}
 	}

--- a/yazi-scheduler/src/file/progress.rs
+++ b/yazi-scheduler/src/file/progress.rs
@@ -10,6 +10,7 @@ pub struct FileProgPaste {
 	pub total_bytes:     u64,
 	pub processed_bytes: u64,
 	pub collected:       bool,
+	pub cleaned:         bool,
 }
 
 impl From<FileProgPaste> for TaskSummary {
@@ -29,6 +30,8 @@ impl FileProgPaste {
 	}
 
 	pub fn success(self) -> bool { self.collected && self.success_files == self.total_files }
+
+	pub fn cleaning(self) -> bool { !self.cleaned && self.success() }
 
 	pub fn percent(self) -> Option<f32> {
 		Some(if self.success() {
@@ -63,6 +66,8 @@ impl FileProgLink {
 
 	pub fn success(self) -> bool { self.state == Some(true) }
 
+	pub fn cleaning(self) -> bool { self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }
 
@@ -91,6 +96,8 @@ impl FileProgHardlink {
 
 	pub fn success(self) -> bool { self.collected && self.success == self.total }
 
+	pub fn cleaning(self) -> bool { self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }
 
@@ -103,6 +110,7 @@ pub struct FileProgDelete {
 	pub total_bytes:     u64,
 	pub processed_bytes: u64,
 	pub collected:       bool,
+	pub cleaned:         bool,
 }
 
 impl From<FileProgDelete> for TaskSummary {
@@ -122,6 +130,8 @@ impl FileProgDelete {
 	}
 
 	pub fn success(self) -> bool { self.collected && self.success_files == self.total_files }
+
+	pub fn cleaning(self) -> bool { !self.cleaned && self.success() }
 
 	pub fn percent(self) -> Option<f32> {
 		Some(if self.success() {
@@ -155,6 +165,8 @@ impl FileProgTrash {
 	pub fn running(self) -> bool { self.state.is_none() }
 
 	pub fn success(self) -> bool { self.state == Some(true) }
+
+	pub fn cleaning(self) -> bool { self.success() }
 
 	pub fn percent(self) -> Option<f32> { None }
 }

--- a/yazi-scheduler/src/ongoing.rs
+++ b/yazi-scheduler/src/ongoing.rs
@@ -26,15 +26,10 @@ impl Ongoing {
 	}
 
 	#[inline]
-	pub fn get(&self, id: Id) -> Option<&Task> { self.all.get(&id) }
-
-	#[inline]
 	pub fn get_mut(&mut self, id: Id) -> Option<&mut Task> { self.all.get_mut(&id) }
 
-	#[inline]
 	pub fn get_id(&self, idx: usize) -> Option<Id> { self.values().nth(idx).map(|t| t.id) }
 
-	#[inline]
 	pub fn len(&self) -> usize {
 		if YAZI.tasks.suppress_preload {
 			self.all.values().filter(|&t| t.prog.is_user()).count()
@@ -46,7 +41,6 @@ impl Ongoing {
 	#[inline]
 	pub fn exists(&self, id: Id) -> bool { self.all.contains_key(&id) }
 
-	#[inline]
 	pub fn values(&self) -> Box<dyn Iterator<Item = &Task> + '_> {
 		if YAZI.tasks.suppress_preload {
 			Box::new(self.all.values().filter(|&t| t.prog.is_user()))
@@ -57,11 +51,6 @@ impl Ongoing {
 
 	#[inline]
 	pub fn is_empty(&self) -> bool { self.len() == 0 }
-
-	pub fn remove(&mut self, id: Id) {
-		self.hooks.pop(id);
-		self.all.remove(&id);
-	}
 
 	pub fn summary(&self) -> TaskSummary {
 		let mut summary = TaskSummary::default();

--- a/yazi-scheduler/src/plugin/progress.rs
+++ b/yazi-scheduler/src/plugin/progress.rs
@@ -23,5 +23,7 @@ impl PluginProgEntry {
 
 	pub fn success(self) -> bool { self.state == Some(true) }
 
+	pub fn cleaning(self) -> bool { self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }

--- a/yazi-scheduler/src/prework/progress.rs
+++ b/yazi-scheduler/src/prework/progress.rs
@@ -23,6 +23,8 @@ impl PreworkProgFetch {
 
 	pub fn success(self) -> bool { self.state == Some(true) }
 
+	pub fn cleaning(self) -> bool { self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }
 
@@ -48,6 +50,8 @@ impl PreworkProgLoad {
 
 	pub fn success(self) -> bool { self.state == Some(true) }
 
+	pub fn cleaning(self) -> bool { self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }
 
@@ -72,6 +76,8 @@ impl PreworkProgSize {
 	pub fn running(self) -> bool { !self.done }
 
 	pub fn success(self) -> bool { self.done }
+
+	pub fn cleaning(self) -> bool { self.success() }
 
 	pub fn percent(self) -> Option<f32> { None }
 }

--- a/yazi-scheduler/src/process/out.rs
+++ b/yazi-scheduler/src/process/out.rs
@@ -4,6 +4,7 @@ use crate::{Task, TaskProg};
 pub(crate) enum ProcessOutBlock {
 	Succ,
 	Fail(String),
+	Clean,
 }
 
 impl From<std::io::Error> for ProcessOutBlock {
@@ -21,6 +22,9 @@ impl ProcessOutBlock {
 				prog.state = Some(false);
 				task.log(reason);
 			}
+			Self::Clean => {
+				prog.cleaned = true;
+			}
 		}
 	}
 }
@@ -30,6 +34,7 @@ impl ProcessOutBlock {
 pub(crate) enum ProcessOutOrphan {
 	Succ,
 	Fail(String),
+	Clean,
 }
 
 impl From<anyhow::Error> for ProcessOutOrphan {
@@ -47,6 +52,9 @@ impl ProcessOutOrphan {
 				prog.state = Some(false);
 				task.log(reason);
 			}
+			Self::Clean => {
+				prog.cleaned = true;
+			}
 		}
 	}
 }
@@ -57,6 +65,7 @@ pub(crate) enum ProcessOutBg {
 	Log(String),
 	Succ,
 	Fail(String),
+	Clean,
 }
 
 impl From<anyhow::Error> for ProcessOutBg {
@@ -76,6 +85,9 @@ impl ProcessOutBg {
 			Self::Fail(reason) => {
 				prog.state = Some(false);
 				task.log(reason);
+			}
+			Self::Clean => {
+				prog.cleaned = true;
 			}
 		}
 	}

--- a/yazi-scheduler/src/process/progress.rs
+++ b/yazi-scheduler/src/process/progress.rs
@@ -4,7 +4,8 @@ use yazi_parser::app::TaskSummary;
 // --- Block
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProcessProgBlock {
-	pub state: Option<bool>,
+	pub state:   Option<bool>,
+	pub cleaned: bool,
 }
 
 impl From<ProcessProgBlock> for TaskSummary {
@@ -23,13 +24,16 @@ impl ProcessProgBlock {
 
 	pub fn success(self) -> bool { self.state == Some(true) }
 
+	pub fn cleaning(self) -> bool { !self.cleaned && self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }
 
 // --- Orphan
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProcessProgOrphan {
-	pub state: Option<bool>,
+	pub state:   Option<bool>,
+	pub cleaned: bool,
 }
 
 impl From<ProcessProgOrphan> for TaskSummary {
@@ -48,13 +52,16 @@ impl ProcessProgOrphan {
 
 	pub fn success(self) -> bool { self.state == Some(true) }
 
+	pub fn cleaning(self) -> bool { !self.cleaned && self.success() }
+
 	pub fn percent(self) -> Option<f32> { None }
 }
 
 // --- Bg
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProcessProgBg {
-	pub state: Option<bool>,
+	pub state:   Option<bool>,
+	pub cleaned: bool,
 }
 
 impl From<ProcessProgBg> for TaskSummary {
@@ -72,6 +79,8 @@ impl ProcessProgBg {
 	pub fn running(self) -> bool { self.state.is_none() }
 
 	pub fn success(self) -> bool { self.state == Some(true) }
+
+	pub fn cleaning(self) -> bool { !self.cleaned && self.success() }
 
 	pub fn percent(self) -> Option<f32> { None }
 }

--- a/yazi-scheduler/src/progress.rs
+++ b/yazi-scheduler/src/progress.rs
@@ -101,6 +101,27 @@ impl TaskProg {
 		}
 	}
 
+	pub fn cleaning(self) -> bool {
+		match self {
+			// File
+			Self::FilePaste(p) => p.cleaning(),
+			Self::FileLink(p) => p.cleaning(),
+			Self::FileHardlink(p) => p.cleaning(),
+			Self::FileDelete(p) => p.cleaning(),
+			Self::FileTrash(p) => p.cleaning(),
+			// Plugin
+			Self::PluginEntry(p) => p.cleaning(),
+			// Prework
+			Self::PreworkFetch(p) => p.cleaning(),
+			Self::PreworkLoad(p) => p.cleaning(),
+			Self::PreworkSize(p) => p.cleaning(),
+			// Process
+			Self::ProcessBlock(p) => p.cleaning(),
+			Self::ProcessOrphan(p) => p.cleaning(),
+			Self::ProcessBg(p) => p.cleaning(),
+		}
+	}
+
 	pub fn percent(self) -> Option<f32> {
 		match self {
 			// File


### PR DESCRIPTION
For network devices, retrieving the mimetype may take some time, offloading it to the task scheduler will allow users to see it in the task manager and know what's happening