### PR TITLE
feat: multi-entry support for plugin system

### DIFF
--- a/yazi-cli/src/args.rs
+++ b/yazi-cli/src/args.rs
@@ -24,9 +24,6 @@ pub(super) enum Command {
 	/// Manage packages.
 	#[command(subcommand)]
 	Pkg(CommandPkg),
-	#[command(hide = true)]
-	/// Manage packages.
-	Pack(CommandPack), // TODO: remove
 	/// Publish a message to the current instance.
 	Pub(CommandPub),
 	/// Publish a message to the specified instance.
@@ -81,26 +78,6 @@ pub(super) enum CommandPkg {
 		#[arg(index = 1, num_args = 0..)]
 		ids: Vec<String>,
 	},
-}
-
-#[derive(clap::Args)]
-#[command(arg_required_else_help = true)]
-pub(super) struct CommandPack {
-	/// Add packages.
-	#[arg(short = 'a', long, num_args = 1..)]
-	pub(super) add:     Option<Vec<String>>,
-	/// Delete packages.
-	#[arg(short = 'd', long, num_args = 1..)]
-	pub(super) delete:  Option<Vec<String>>,
-	/// Install all packages.
-	#[arg(short = 'i', long)]
-	pub(super) install: bool,
-	/// List all packages.
-	#[arg(short = 'l', long)]
-	pub(super) list:    bool,
-	/// Upgrade all packages.
-	#[arg(short = 'u', long)]
-	pub(super) upgrade: bool,
 }
 
 #[derive(clap::Args)]

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -73,24 +73,6 @@ async fn run() -> anyhow::Result<()> {
 			}
 		}
 
-		Command::Pack(cmd) => {
-			package::init()?;
-			outln!(
-				"WARNING: `ya pack` is deprecated, use the new `ya pkg` instead. See https://github.com/sxyazi/yazi/pull/2770 for more details."
-			)?;
-			if cmd.install {
-				package::Package::load().await?.install().await?;
-			} else if cmd.list {
-				package::Package::load().await?.print()?;
-			} else if cmd.upgrade {
-				package::Package::load().await?.upgrade_many(&[]).await?;
-			} else if let Some(uses) = cmd.add {
-				package::Package::load().await?.add_many(&uses).await?;
-			} else if let Some(uses) = cmd.delete {
-				package::Package::load().await?.delete_many(&uses).await?;
-			}
-		}
-
 		Command::Pub(cmd) => {
 			yazi_boot::init_default();
 			yazi_dds::init();

--- a/yazi-cli/src/package/delete.rs
+++ b/yazi-cli/src/package/delete.rs
@@ -41,15 +41,12 @@ impl Dependency {
 
 	pub(super) async fn delete_sources(&self) -> Result<()> {
 		let dir = self.target();
-		let files = if self.is_flavor {
-			&["flavor.toml", "tmtheme.xml", "README.md", "preview.png", "LICENSE", "LICENSE-tmtheme"][..]
-		} else {
-			&["main.lua", "README.md", "LICENSE"][..]
-		};
+		let files =
+			if self.is_flavor { Self::flavor_files() } else { Self::plugin_files(&dir).await? };
 
-		for p in files.iter().map(|&f| dir.join(f)) {
-			ok_or_not_found(remove_sealed(&p).await)
-				.with_context(|| format!("failed to delete `{}`", p.display()))?;
+		for path in files.iter().map(|s| dir.join(s)) {
+			ok_or_not_found(remove_sealed(&path).await)
+				.with_context(|| format!("failed to delete `{}`", path.display()))?;
 		}
 
 		if ok_or_not_found(Local::remove_dir(&dir).await).is_ok() {

--- a/yazi-cli/src/package/deploy.rs
+++ b/yazi-cli/src/package/deploy.rs
@@ -57,14 +57,9 @@ impl Dependency {
 	}
 
 	async fn deploy_sources(from: &Path, to: &Path, is_flavor: bool) -> Result<()> {
-		let files = if is_flavor {
-			&["flavor.toml", "tmtheme.xml", "README.md", "preview.png", "LICENSE", "LICENSE-tmtheme"][..]
-		} else {
-			&["main.lua", "README.md", "LICENSE"][..]
-		};
-
+		let files = if is_flavor { Self::flavor_files() } else { Self::plugin_files(from).await? };
 		for file in files {
-			let (from, to) = (from.join(file), to.join(file));
+			let (from, to) = (from.join(&file), to.join(&file));
 			copy_and_seal(&from, &to)
 				.await
 				.with_context(|| format!("failed to copy `{}` to `{}`", from.display(), to.display()))?;

--- a/yazi-cli/src/package/hash.rs
+++ b/yazi-cli/src/package/hash.rs
@@ -7,22 +7,11 @@ use super::Dependency;
 impl Dependency {
 	pub(crate) async fn hash(&self) -> Result<String> {
 		let dir = self.target();
-		let files = if self.is_flavor {
-			&[
-				"LICENSE",
-				"LICENSE-tmtheme",
-				"README.md",
-				"filestyle.toml",
-				"flavor.toml",
-				"preview.png",
-				"tmtheme.xml",
-			][..]
-		} else {
-			&["LICENSE", "README.md", "main.lua"][..]
-		};
+		let files =
+			if self.is_flavor { Self::flavor_files() } else { Self::plugin_files(&dir).await? };
 
 		let mut h = XxHash3_128::new();
-		for &file in files {
+		for file in files {
 			h.write(file.as_bytes());
 			h.write(b"VpvFw9Atb7cWGOdqhZCra634CcJJRlsRl72RbZeV0vpG1\0");
 			h.write(&ok_or_not_found(Local::read(dir.join(file)).await)?);

--- a/yazi-dds/src/ember/ember.rs
+++ b/yazi-dds/src/ember/ember.rs
@@ -81,8 +81,8 @@ impl Ember<'static> {
 		if it.peek() == Some(&b'@') {
 			it.next(); // Skip `@` as it's a prefix for static messages
 		}
-		if !it.all(|b| b.is_ascii_alphanumeric() || b == b'-') {
-			bail!("Kind must be alphanumeric with dashes");
+		if !it.all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'-')) {
+			bail!("Kind `{kind}` must be in kebab-case");
 		}
 
 		Ok(())

--- a/yazi-plugin/src/loader/require.rs
+++ b/yazi-plugin/src/loader/require.rs
@@ -118,7 +118,7 @@ impl Require {
 	fn absolute_id<'a>(lua: &Lua, id: &'a str) -> mlua::Result<Cow<'a, str>> {
 		let Some(stripped) = id.strip_prefix('.') else { return Ok(id.into()) };
 		Ok(if let Some(cur) = runtime!(lua)?.current() {
-			format!("{cur}.{stripped}").into()
+			format!("{}.{stripped}", cur.split('.').next().unwrap_or(cur)).into()
 		} else {
 			stripped.into()
 		})

--- a/yazi-plugin/src/utils/utils.rs
+++ b/yazi-plugin/src/utils/utils.rs
@@ -19,7 +19,6 @@ pub fn compose(
 			b"render" => Utils::render(lua)?,
 			b"emit" => Utils::emit(lua)?,
 			b"mgr_emit" => Utils::mgr_emit(lua)?,
-			b"manager_emit" => Utils::mgr_emit(lua)?, // TODO: remove this in the future
 
 			// Image
 			b"image_info" => Utils::image_info(lua)?,

--- a/yazi-shared/src/bytes.rs
+++ b/yazi-shared/src/bytes.rs
@@ -1,8 +1,13 @@
 pub trait BytesExt {
+	fn kebab_cased(&self) -> bool;
 	fn split_by_seq(&self, sep: &[u8]) -> Option<(&[u8], &[u8])>;
 }
 
 impl BytesExt for [u8] {
+	fn kebab_cased(&self) -> bool {
+		self.iter().all(|&b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'-'))
+	}
+
 	fn split_by_seq(&self, sep: &[u8]) -> Option<(&[u8], &[u8])> {
 		let idx = memchr::memmem::find(self, sep)?;
 		let (left, right) = self.split_at(idx);


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/2781

Closes https://github.com/sxyazi/yazi/issues/2781

---

With this PR, Yazi will support Lua files other than `main.lua` as plugin entry points. To achieve this, a new dot (`.`) syntax has been introduced. For example:

```sh
~/.config/yazi/plugins/demo.yazi/
├── main.lua
├── foo.lua
├── bar.lua
├── README.md
└── LICENSE
```

Now, in the [`plugin` command](https://yazi-rs.github.io/docs/plugins/overview#functional-plugin), and fetchers, spotters, preloaders, and previewers rules, in addition to specifying `demo` (which corresponds to `main.lua`) as the entry point as before:

```toml
[[plugin.prepend_previewers]]
mime = "text/*"
run  = "demo"
```

You can also explicitly specify other Lua scripts as entry points, such as `foo.lua`:

```toml
[[plugin.prepend_previewers]]
mime = "text/*"
run  = "demo.foo"
```

You can explicitly call `main.lua` with `demo.main` for sure, but internally this will be normalized to just `demo`:

```toml
[[plugin.prepend_previewers]]
mime = "text/*"
run  = "demo.main"
```

For the `require()` function, the new dot (`.`) syntax is also supported, which means you can have:

```lua
-- ~/.config/yazi/plugins/demo.yazi/foo.lua

local bar = require("demo.bar")  -- Loads the `bar.lua` entry of the `demo` plugin
```

`require()` also supports relative paths, which means the above code can also be written as:

```lua
-- ~/.config/yazi/plugins/demo.yazi/foo.lua

local bar = require(".bar")  -- Loads the `bar.lua` entry of the current plugin (`demo`)
```
