### PR TITLE
feature: Multiple previewers to cycle through

### DIFF
--- a/yazi-actor/src/mgr/peek.rs
+++ b/yazi-actor/src/mgr/peek.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use yazi_config::YAZI;
 use yazi_macro::succ;
 use yazi_parser::mgr::PeekOpt;
 use yazi_proxy::HIDER;
@@ -24,30 +25,55 @@ impl Actor for Peek {
 		let mime = cx.mgr.mimetype.by_file_owned(&hovered).unwrap_or_default();
 		let folder = cx.tab().hovered_folder().map(|f| (f.offset, f.cha));
 
-		if !cx.tab().preview.same_url(&hovered.url) {
-			cx.tab_mut().preview.skip = folder.map(|f| f.0).unwrap_or_default();
-		}
-		if !cx.tab().preview.same_file(&hovered, &mime) {
-			cx.tab_mut().preview.reset();
+		let same_url = cx.tab().preview.same_url(&hovered.url);
+		let same_file = cx.tab().preview.same_file(&hovered, &mime);
+
+		{
+			let preview = &mut cx.tab_mut().preview;
+			if !same_url {
+				preview.skip = folder.map(|f| f.0).unwrap_or_default();
+				preview.run = 0;
+			}
+			if !same_file {
+				preview.reset();
+			}
+
+			if let Some(step) = opt.cycle {
+				if step == 0 {
+					preview.run = 0;
+				} else if let Some(previewer) = YAZI.plugin.previewer(&hovered.url, &mime) {
+					let len = previewer.len();
+					if len == 0 {
+						preview.run = 0;
+					} else {
+						let len_isize = len as isize;
+						let current = (preview.run % len) as isize;
+						let next = (current + step as isize).rem_euclid(len_isize);
+						preview.run = next as usize;
+					}
+				} else {
+					preview.run = 0;
+				}
+			}
+
+			if let Some(skip) = opt.skip {
+				if opt.upper_bound {
+					preview.skip = preview.skip.min(skip);
+				} else {
+					preview.skip = skip;
+				}
+			}
 		}
 
 		if matches!(opt.only_if, Some(u) if u != hovered.url) {
 			succ!();
 		}
 
-		if let Some(skip) = opt.skip {
-			let preview = &mut cx.tab_mut().preview;
-			if opt.upper_bound {
-				preview.skip = preview.skip.min(skip);
-			} else {
-				preview.skip = skip;
-			}
-		}
-
+		let force = opt.force || opt.cycle.is_some();
 		if hovered.is_dir() {
-			cx.tab_mut().preview.go_folder(hovered, folder.map(|(_, cha)| cha), opt.force);
+			cx.tab_mut().preview.go_folder(hovered, folder.map(|(_, cha)| cha), force);
 		} else {
-			cx.tab_mut().preview.go(hovered, mime, opt.force);
+			cx.tab_mut().preview.go(hovered, mime, force);
 		}
 		succ!();
 	}

--- a/yazi-actor/src/mgr/seek.rs
+++ b/yazi-actor/src/mgr/seek.rs
@@ -26,8 +26,12 @@ impl Actor for Seek {
 		let Some(previewer) = YAZI.plugin.previewer(&hovered.url, mime) else {
 			succ!(cx.tab_mut().preview.reset());
 		};
+		let run_idx = cx.tab().preview.run;
+		let Some(cmd) = previewer.cmd(run_idx) else {
+			succ!(cx.tab_mut().preview.reset());
+		};
 
-		isolate::seek_sync(&previewer.run, hovered.clone(), opt.units);
+		isolate::seek_sync(cmd, hovered.clone(), opt.units);
 		succ!();
 	}
 }

--- a/yazi-actor/src/mgr/update_peeked.rs
+++ b/yazi-actor/src/mgr/update_peeked.rs
@@ -18,7 +18,9 @@ impl Actor for UpdatePeeked {
 		};
 
 		if opt.lock.url == *hovered {
-			cx.tab_mut().preview.lock = Some(opt.lock);
+			let preview = &mut cx.tab_mut().preview;
+			preview.lock_run = preview.run;
+			preview.lock = Some(opt.lock);
 			render!();
 		}
 

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -54,6 +54,8 @@ keymap = [
 	# Seeking
 	{ on = "K", run = "seek -5", desc = "Seek up 5 units in the preview" },
 	{ on = "J", run = "seek 5",  desc = "Seek down 5 units in the preview" },
+	{ on = [ "g", "p" ], run = "peek --cycle=next", desc = "Cycle to next previewer" },
+	{ on = [ "g", "P" ], run = "peek --cycle=prev", desc = "Cycle to previous previewer" },
 
 	# Spotting
 	{ on = "<Tab>", run = "spot", desc = "Spot hovered file" },

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -124,8 +124,8 @@ preloaders = [
 previewers = [
 	{ url = "*/", run = "folder" },
 	# Code
-	{ mime = "text/*", run = "code" },
-	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
+	{ mime = "text/*", run = [ "code", "file" ] },
+	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = [ "code", "file" ] },
 	# JSON
 	{ mime = "application/{json,ndjson}", run = "json" },
 	# Image

--- a/yazi-config/src/plugin/previewer.rs
+++ b/yazi-config/src/plugin/previewer.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
 use yazi_shared::{MIME_DIR, event::Cmd, url::UrlBuf};
 
 use crate::Pattern;
@@ -7,7 +7,8 @@ use crate::Pattern;
 pub struct Previewer {
 	pub url:  Option<Pattern>,
 	pub mime: Option<Pattern>,
-	pub run:  Cmd,
+	#[serde(deserialize_with = "deserialize_run")]
+	pub run:  Vec<Cmd>,
 }
 
 impl Previewer {
@@ -18,8 +19,46 @@ impl Previewer {
 	}
 
 	#[inline]
+	pub fn len(&self) -> usize { self.run.len() }
+
+	#[inline]
+	pub fn cmd(&self, index: usize) -> Option<&Cmd> {
+		if self.run.is_empty() {
+			return None;
+		}
+		self.run.get(index).or_else(|| self.run.first())
+	}
+
+	#[inline]
 	pub fn any_file(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_file()) }
 
 	#[inline]
 	pub fn any_dir(&self) -> bool { self.url.as_ref().is_some_and(|p| p.any_dir()) }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RunField {
+	One(String),
+	Many(Vec<String>),
+}
+
+fn deserialize_run<'de, D>(deserializer: D) -> Result<Vec<Cmd>, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let field = RunField::deserialize(deserializer)?;
+	let items: Vec<String> = match field {
+		RunField::One(s) => vec![s],
+		RunField::Many(list) => list,
+	};
+
+	if items.is_empty() {
+		return Err(de::Error::custom("previewer.run must not be empty"));
+	}
+
+	items
+		.into_iter()
+		.map(|s| s.parse::<Cmd>().map_err(de::Error::custom))
+		.collect()
 }

--- a/yazi-parser/src/mgr/peek.rs
+++ b/yazi-parser/src/mgr/peek.rs
@@ -7,6 +7,7 @@ pub struct PeekOpt {
 	pub force:       bool,
 	pub only_if:     Option<UrlCow<'static>>,
 	pub upper_bound: bool,
+	pub cycle:       Option<i32>,
 }
 
 impl From<CmdCow> for PeekOpt {
@@ -16,6 +17,7 @@ impl From<CmdCow> for PeekOpt {
 			force:       c.bool("force"),
 			only_if:     c.take_url("only-if"),
 			upper_bound: c.bool("upper-bound"),
+			cycle:       c.take_str("cycle").and_then(|s| parse_cycle(s.as_ref())),
 		}
 	}
 }
@@ -30,4 +32,13 @@ impl FromLua for PeekOpt {
 
 impl IntoLua for PeekOpt {
 	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+}
+
+fn parse_cycle(value: &str) -> Option<i32> {
+	match value.to_ascii_lowercase().as_str() {
+		"next" | "forward" | "+" => Some(1),
+		"prev" | "previous" | "back" | "-" => Some(-1),
+		"reset" | "first" | "start" | "0" => Some(0),
+		_ => value.parse().ok(),
+	}
 }

--- a/yazi-plugin/src/runtime/plugin.rs
+++ b/yazi-plugin/src/runtime/plugin.rs
@@ -98,15 +98,23 @@ impl UserData for Preloader {
 struct Previewer {
 	inner: &'static yazi_config::plugin::Previewer,
 
-	v_cmd: Option<Value>,
+	v_cmd:  Option<Value>,
+	v_cmds: Option<Value>,
 }
 
 impl Previewer {
-	pub fn new(inner: &'static yazi_config::plugin::Previewer) -> Self { Self { inner, v_cmd: None } }
+	pub fn new(inner: &'static yazi_config::plugin::Previewer) -> Self {
+		Self { inner, v_cmd: None, v_cmds: None }
+	}
 }
 
 impl UserData for Previewer {
 	fn add_fields<F: mlua::UserDataFields<Self>>(fields: &mut F) {
-		cached_field!(fields, cmd, |lua, me| lua.create_string(me.inner.run.name.as_ref()));
+		cached_field!(fields, cmd, |lua, me| {
+			lua.create_string(me.inner.cmd(0).map(|cmd| cmd.name.as_ref()).unwrap_or(""))
+		});
+		cached_field!(fields, cmds, |lua, me| {
+			lua.create_sequence_from(me.inner.run.iter().map(|cmd| cmd.name.as_ref()))
+		});
 	}
 }


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->
Resolves #3176

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

From a user perspective it would be nice to set up a previewer entry with a list of strings for multiple previews and then be able to set a keymap to cycle through them.