### PR TITLE
fix: wrong architecture label in aarch64 `.deb` packages

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ mv "target/$1/release" target/release
 # Package deb
 if [[ "$ARTIFACT_NAME" == *-linux-* ]] && { [[ "$ARTIFACT_NAME" == *-aarch64-* ]] || [[ "$ARTIFACT_NAME" == *-x86_64-* ]]; }; then
 	cargo install cargo-deb
-	cargo deb -p yazi-packing --no-build -o "$ARTIFACT_NAME.deb"
+	cargo deb -p yazi-packing --no-build --target "$1" -o "$ARTIFACT_NAME.deb"
 fi
 
 # Create the artifact


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/3205

Fixes https://github.com/sxyazi/yazi/pull/3208