### PR TITLE
fix: incorrect `$0` and `$@` parameters in `shell` command under empty directories

### DIFF
--- a/yazi-core/src/tab/tab.rs
+++ b/yazi-core/src/tab/tab.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use anyhow::Result;
 use ratatui::layout::Rect;
 use tokio::task::JoinHandle;
@@ -96,7 +94,9 @@ impl Tab {
 	}
 
 	pub fn hovered_and_selected(&self) -> Box<dyn Iterator<Item = &UrlBuf> + '_> {
-		let Some(h) = self.hovered() else { return Box::new(iter::empty()) };
+		let Some(h) = self.hovered() else {
+			return Box::new([UrlBuf::new()].into_iter().chain(self.selected.values()));
+		};
 		if self.selected.is_empty() {
 			Box::new([&h.url, &h.url].into_iter())
 		} else {

--- a/yazi-shared/src/loc/buf.rs
+++ b/yazi-shared/src/loc/buf.rs
@@ -84,7 +84,9 @@ impl LocBuf {
 		Ok(Self { inner: loc.inner, uri, urn })
 	}
 
-	pub const fn empty() -> Self { Self { inner: PathBuf::new(), uri: 0, urn: 0 } }
+	// FIXME: use `LocBuf::empty()` when Rust 1.91.0 released
+	// pub const fn empty() -> Self { Self { inner: PathBuf::new(), uri: 0, urn: 0 }
+	// }
 
 	pub fn zeroed(path: impl Into<PathBuf>) -> Self {
 		let loc = Self::from(path.into());

--- a/yazi-shared/src/loc/buf.rs
+++ b/yazi-shared/src/loc/buf.rs
@@ -84,6 +84,8 @@ impl LocBuf {
 		Ok(Self { inner: loc.inner, uri, urn })
 	}
 
+	pub const fn empty() -> Self { Self { inner: PathBuf::new(), uri: 0, urn: 0 } }
+
 	pub fn zeroed(path: impl Into<PathBuf>) -> Self {
 		let loc = Self::from(path.into());
 		let Loc { inner, uri, urn } = Loc::zeroed(&loc.inner);

--- a/yazi-shared/src/url/buf.rs
+++ b/yazi-shared/src/url/buf.rs
@@ -80,6 +80,12 @@ impl PartialEq<Url<'_>> for &UrlBuf {
 
 impl UrlBuf {
 	#[inline]
+	pub const fn new() -> &'static Self {
+		static U: UrlBuf = UrlBuf { loc: LocBuf::empty(), scheme: Scheme::Regular };
+		&U
+	}
+
+	#[inline]
 	pub fn join(&self, path: impl AsRef<Path>) -> Self { self.as_url().join(path) }
 
 	#[inline]

--- a/yazi-shared/src/url/buf.rs
+++ b/yazi-shared/src/url/buf.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ffi::OsStr, fmt::{Debug, Formatter}, hash::BuildHasher, path::{Path, PathBuf}, str::FromStr};
+use std::{borrow::Cow, ffi::OsStr, fmt::{Debug, Formatter}, hash::BuildHasher, path::{Path, PathBuf}, str::FromStr, sync::OnceLock};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -80,9 +80,13 @@ impl PartialEq<Url<'_>> for &UrlBuf {
 
 impl UrlBuf {
 	#[inline]
-	pub const fn new() -> &'static Self {
-		static U: UrlBuf = UrlBuf { loc: LocBuf::empty(), scheme: Scheme::Regular };
-		&U
+	pub fn new() -> &'static Self {
+		static U: OnceLock<UrlBuf> = OnceLock::new();
+		U.get_or_init(Self::default)
+
+		// FIXME: use `LocBuf::empty()` when Rust 1.91.0 released
+		// static U: UrlBuf = UrlBuf { loc: LocBuf::empty(), scheme: Scheme::Regular
+		// }; &U
 	}
 
 	#[inline]


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/2104#issuecomment-3364618422

When running the `shell` command in an empty directory, the value of `$0` becomes a `"sh"` string, and `$@` becomes an empty array, even if files are selected in other directories.

With this PR, when in an empty directory (no hovered file), `$0` will be an empty string (`""`), and `$@` will correctly contain the array of selected file paths - to fix this issue, the behavior of `$0` in empty directories has been changed from `"sh"` to `""`. 

The issue was originally introduced in https://github.com/sxyazi/yazi/commit/2efda755f1179c29556fd5c8809247530ef84c00 (`$0` was first supported), since then `$0` has never worked correctly, so this change should not break anything