### PR TITLE
feat: new mimetype fetcher dedicated to remote files

### DIFF
--- a/yazi-actor/src/cmp/trigger.rs
+++ b/yazi-actor/src/cmp/trigger.rs
@@ -5,7 +5,7 @@ use yazi_fs::{CWD, path::expand_url, provider::{DirReader, FileHolder}};
 use yazi_macro::{act, render, succ};
 use yazi_parser::cmp::{CmpItem, ShowOpt, TriggerOpt};
 use yazi_proxy::CmpProxy;
-use yazi_shared::{OsStrSplit, data::Data, natsort, url::{UrlBuf, UrlCow, UrnBuf}};
+use yazi_shared::{OsStrSplit, data::Data, natsort, scheme::SchemeLike, url::{UrlBuf, UrlCow, UrnBuf}};
 use yazi_vfs::provider;
 
 use crate::{Actor, Ctx};
@@ -70,7 +70,7 @@ impl Trigger {
 	fn split_url(s: &str) -> Option<(UrlBuf, UrnBuf)> {
 		let (scheme, path, ..) = UrlCow::parse(s.as_bytes()).ok()?;
 
-		if !scheme.is_virtual() && path.as_os_str() == "~" {
+		if scheme.is_local() && path.as_os_str() == "~" {
 			return None; // We don't autocomplete a `~`, but `~/`
 		}
 

--- a/yazi-actor/src/mgr/download.rs
+++ b/yazi-actor/src/mgr/download.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use futures::{StreamExt, stream::FuturesUnordered};
 use hashbrown::HashSet;
 use tokio::sync::oneshot;
-use yazi_fs::{File, FsUrl, provider::{Provider, local::Local}};
+use yazi_fs::{File, FsScheme, provider::{Provider, local::Local}};
 use yazi_macro::succ;
 use yazi_parser::mgr::{DownloadOpt, OpenOpt};
 use yazi_proxy::MgrProxy;
@@ -75,7 +75,7 @@ impl Actor for Download {
 
 impl Download {
 	async fn prepare(urls: &[UrlCow<'_>]) {
-		let roots: HashSet<_> = urls.iter().filter_map(|u| u.cache_root()).collect();
+		let roots: HashSet<_> = urls.iter().filter_map(|u| u.scheme().cache()).collect();
 		for mut root in roots {
 			root.push("%lock");
 			Local.create_dir_all(root).await.ok();

--- a/yazi-binding/src/cha.rs
+++ b/yazi-binding/src/cha.rs
@@ -1,7 +1,7 @@
 use std::{ops::Deref, time::{Duration, SystemTime}};
 
 use mlua::{ExternalError, FromLua, IntoLua, Lua, Table, UserData, UserDataFields, UserDataMethods};
-use yazi_fs::cha::{ChaKind, ChaMode};
+use yazi_fs::{FsHash128, cha::{ChaKind, ChaMode}};
 
 #[derive(Clone, Copy, FromLua)]
 pub struct Cha(pub yazi_fs::cha::Cha);
@@ -76,6 +76,13 @@ impl UserData for Cha {
 	}
 
 	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+		methods.add_method("hash", |_, me, long: Option<bool>| {
+			Ok(if long.unwrap_or(false) {
+				format!("{:x}", me.hash_u128())
+			} else {
+				Err("Short hash not supported".into_lua_err())?
+			})
+		});
 		methods.add_method("perm", |lua, _me, ()| {
 			Ok(
 				#[cfg(unix)]

--- a/yazi-binding/src/scheme.rs
+++ b/yazi-binding/src/scheme.rs
@@ -1,13 +1,16 @@
 use std::ops::Deref;
 
 use mlua::{UserData, UserDataFields, Value};
+use yazi_fs::FsScheme;
+use yazi_shared::scheme::SchemeLike;
 
-use crate::cached_field;
+use crate::{Url, cached_field};
 
 pub struct Scheme {
 	inner: yazi_shared::scheme::Scheme,
 
-	v_kind: Option<Value>,
+	v_kind:  Option<Value>,
+	v_cache: Option<Value>,
 }
 
 impl Deref for Scheme {
@@ -18,13 +21,14 @@ impl Deref for Scheme {
 
 impl Scheme {
 	pub fn new(scheme: &yazi_shared::scheme::Scheme) -> Self {
-		Self { inner: scheme.clone(), v_kind: None }
+		Self { inner: scheme.clone(), v_kind: None, v_cache: None }
 	}
 }
 
 impl UserData for Scheme {
 	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
 		cached_field!(fields, kind, |_, me| Ok(me.kind()));
+		cached_field!(fields, cache, |_, me| Ok(me.cache().map(Url::new)));
 
 		fields.add_field_method_get("is_virtual", |_, me| Ok(me.is_virtual()));
 	}

--- a/yazi-binding/src/url.rs
+++ b/yazi-binding/src/url.rs
@@ -1,7 +1,8 @@
 use std::ops::Deref;
 
 use mlua::{AnyUserData, ExternalError, FromLua, Lua, MetaMethod, UserData, UserDataFields, UserDataMethods, UserDataRef, Value};
-use yazi_shared::{IntoOsStr, url::{AsUrl, UrlCow, UrlLike}};
+use yazi_fs::{FsHash64, FsHash128};
+use yazi_shared::{IntoOsStr, scheme::SchemeLike, url::{AsUrl, UrlCow, UrlLike}};
 
 use crate::{Scheme, Urn, cached_field, deprecate};
 
@@ -128,6 +129,13 @@ impl UserData for Url {
 	}
 
 	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+		methods.add_method("hash", |_, me, long: Option<bool>| {
+			Ok(if long.unwrap_or(false) {
+				format!("{:x}", me.hash_u128())
+			} else {
+				format!("{:x}", me.hash_u64())
+			})
+		});
 		methods.add_method("join", |_, me, other: Value| {
 			Ok(Self::new(match other {
 				Value::String(s) => me.join(s.as_bytes().into_os_str()?),

--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -232,7 +232,7 @@ rules = [
 	# Document
 	{ mime = "application/{pdf,doc,rtf}", fg = "cyan" },
 	# Virtual file system
-	{ mime = "vfs/*", fg = "gray" },
+	{ mime = "vfs/{absent,stale}", fg = "gray" },
 	# Special file
 	{ url = "*", is = "orphan", bg = "red" },
 	{ url = "*", is = "exec"  , fg = "green" },

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -232,7 +232,7 @@ rules = [
 	# Document
 	{ mime = "application/{pdf,doc,rtf}", fg = "cyan" },
 	# Virtual file system
-	{ mime = "vfs/*", fg = "darkgray" },
+	{ mime = "vfs/{absent,stale}", fg = "darkgray" },
 	# Special file
 	{ url = "*", is = "orphan", bg = "red" },
 	{ url = "*", is = "exec"  , fg = "green" },

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -81,7 +81,7 @@ rules = [
 	# Empty file
 	{ mime = "inode/empty", use = [ "edit", "reveal" ] },
 	# Virtual file system
-	{ mime = "vfs/*", use = "download" },
+	{ mime = "vfs/{absent,stale}", use = "download" },
 	# Fallback
 	{ url = "*", use = [ "open", "reveal" ] },
 ]
@@ -97,8 +97,9 @@ suppress_preload = false
 [plugin]
 fetchers = [
 	# Mimetype
-	{ id = "mime", url = "*/", run = "mime.dir", prio = "high" },
-	{ id = "mime", url = "*", run = "mime.file", prio = "high" },
+	{ id = "mime", url = "*/",         run = "mime.dir", prio = "high" },
+	{ id = "mime", url = "local://*",  run = "mime.local", prio = "high" },
+	{ id = "mime", url = "remote://*", run = "mime.remote", prio = "high" },
 ]
 spotters = [
 	{ url = "*/", run = "folder" },

--- a/yazi-fs/src/hash.rs
+++ b/yazi-fs/src/hash.rs
@@ -30,9 +30,8 @@ impl FsHash128 for Cha {
 		self.mode.bits().hash(&mut h);
 		self.len.hash(&mut h);
 
-		self.mtime_dur().ok().map(|d| d.as_nanos()).hash(&mut h);
 		self.btime_dur().ok().map(|d| d.as_nanos()).hash(&mut h);
-		self.ctime_dur().ok().map(|d| d.as_nanos()).hash(&mut h);
+		self.mtime_dur().ok().map(|d| d.as_nanos()).hash(&mut h);
 
 		h.finish_128()
 	}

--- a/yazi-fs/src/lib.rs
+++ b/yazi-fs/src/lib.rs
@@ -2,7 +2,7 @@
 
 yazi_macro::mod_pub!(cha error mounts path provider);
 
-yazi_macro::mod_flat!(cwd file files filter fns hash op sorter sorting splatter stage url xdg);
+yazi_macro::mod_flat!(cwd file files filter fns hash op scheme sorter sorting splatter stage url xdg);
 
 pub fn init() {
 	CWD.init(<_>::default());

--- a/yazi-fs/src/provider/local/gate.rs
+++ b/yazi-fs/src/provider/local/gate.rs
@@ -34,10 +34,10 @@ impl FileBuilder for Gate {
 	}
 
 	async fn new(scheme: SchemeRef<'_>) -> io::Result<Self> {
-		if scheme.is_virtual() {
-			Err(io::Error::new(io::ErrorKind::InvalidInput, "Not a local filesystem"))?
-		} else {
+		if scheme.is_local() {
 			Ok(Self::default())
+		} else {
+			Err(io::Error::new(io::ErrorKind::InvalidInput, "Not a local filesystem"))?
 		}
 	}
 

--- a/yazi-fs/src/provider/local/local.rs
+++ b/yazi-fs/src/provider/local/local.rs
@@ -17,10 +17,10 @@ impl Provider for Local {
 		U: AsUrl,
 	{
 		let url = url.as_url();
-		if url.scheme.is_virtual() {
-			Err(io::Error::new(io::ErrorKind::InvalidInput, "Not a local URL"))
-		} else {
+		if url.scheme.is_local() {
 			Ok(absolute_url(url))
+		} else {
+			Err(io::Error::new(io::ErrorKind::InvalidInput, "Not a local URL"))
 		}
 	}
 

--- a/yazi-fs/src/scheme.rs
+++ b/yazi-fs/src/scheme.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+use yazi_shared::scheme::{AsScheme, Scheme, SchemeRef};
+
+use crate::Xdg;
+
+pub trait FsScheme {
+	fn cache(&self) -> Option<PathBuf>;
+}
+
+impl FsScheme for SchemeRef<'_> {
+	fn cache(&self) -> Option<PathBuf> {
+		match self {
+			SchemeRef::Regular | SchemeRef::Search(_) => None,
+			SchemeRef::Archive(name) => {
+				Some(Xdg::cache_dir().join(format!("archive-{}", yazi_shared::url::Encode::domain(name))))
+			}
+			SchemeRef::Sftp(name) => {
+				Some(Xdg::cache_dir().join(format!("sftp-{}", yazi_shared::url::Encode::domain(name))))
+			}
+		}
+	}
+}
+
+impl FsScheme for Scheme {
+	fn cache(&self) -> Option<PathBuf> { self.as_scheme().cache() }
+}

--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -40,9 +40,12 @@ function M:spot_base(job)
 	for i, v in ipairs(fetchers) do
 		fetchers[i] = v.cmd
 	end
+	fetchers = #fetchers ~= 0 and fetchers or { "-" }
+
 	for i, v in ipairs(preloaders) do
 		preloaders[i] = v.cmd
 	end
+	preloaders = #preloaders ~= 0 and preloaders or { "-" }
 
 	return {
 		ui.Row({ "Base" }):style(ui.Style():fg("green")),
@@ -54,8 +57,8 @@ function M:spot_base(job)
 		ui.Row({ "Plugins" }):style(ui.Style():fg("green")),
 		ui.Row { "  Spotter:", spotter and spotter.cmd or "-" },
 		ui.Row { "  Previewer:", previewer and previewer.cmd or "-" },
-		ui.Row { "  Fetchers:", #fetchers ~= 0 and fetchers or "-" },
-		ui.Row { "  Preloaders:", #preloaders ~= 0 and preloaders or "-" },
+		ui.Row({ "  Fetchers:", fetchers }):height(#fetchers),
+		ui.Row({ "  Preloaders:", preloaders }):height(#preloaders),
 	}
 end
 

--- a/yazi-plugin/preset/plugins/mime-remote.lua
+++ b/yazi-plugin/preset/plugins/mime-remote.lua
@@ -1,0 +1,59 @@
+local M = {}
+
+local function stale_cache(file)
+	local url = file.url
+	local lock = url.scheme.cache:join(string.format("%%lock/%s", url:hash(true)))
+
+	local f = io.open(tostring(lock), "r")
+	if not f then
+		return true
+	end
+
+	local hash = f:read(32)
+	f:close()
+	return hash ~= file.cha:hash(true)
+end
+
+function M:fetch(job)
+	local updates, unknown, state = {}, {}, {}
+	for i, file in ipairs(job.files) do
+		if not file.cache then
+			unknown[#unknown + 1] = file
+		elseif not fs.cha(file.cache) then
+			updates[file.url], state[i] = "vfs/absent", true
+		elseif stale_cache(file) then
+			updates[file.url], state[i] = "vfs/stale", true
+		else
+			unknown[#unknown + 1] = file
+		end
+	end
+
+	if next(updates) then
+		ya.emit("update_mimes", { updates = updates })
+	end
+
+	if #unknown == 0 then
+		return state
+	else
+		return self.fallback_local(job, unknown, state)
+	end
+end
+
+function M.fallback_local(job, unknown, state)
+	local indices = {}
+	for i, f in ipairs(job.files) do
+		indices[f:hash()] = i
+	end
+
+	local result = require("mime.local"):fetch(ya.dict_merge(job, { files = unknown }))
+	for i, f in ipairs(unknown) do
+		if type(result) == "table" then
+			state[indices[f:hash()]] = result[i]
+		else
+			state[indices[f:hash()]] = result
+		end
+	end
+	return state
+end
+
+return M

--- a/yazi-plugin/preset/plugins/mime.lua
+++ b/yazi-plugin/preset/plugins/mime.lua
@@ -1,12 +1,12 @@
 local function fetch(_, job)
 	ya.notify {
 		title = "Deprecated plugin",
-		content = "The `mime` fetcher is deprecated, use `mime.file` instead in your `yazi.toml`\n\nSee https://github.com/sxyazi/yazi/pull/3222 for more details.",
+		content = "The `mime` fetcher is deprecated, use `mime.local` instead in your `yazi.toml`\n\nSee https://github.com/sxyazi/yazi/pull/3222 for more details.",
 		timeout = 15,
 		level = "warn",
 	}
 
-	return require("mime.file"):fetch(job)
+	return require("mime.local"):fetch(job)
 end
 
 return { fetch = fetch }

--- a/yazi-plugin/src/loader/loader.rs
+++ b/yazi-plugin/src/loader/loader.rs
@@ -40,7 +40,8 @@ impl Default for Loader {
 			("magick".to_owned(), preset!("plugins/magick").into()),
 			("mime".to_owned(), preset!("plugins/mime").into()), // TODO: remove this
 			("mime.dir".to_owned(), preset!("plugins/mime-dir").into()),
-			("mime.file".to_owned(), preset!("plugins/mime-file").into()),
+			("mime.local".to_owned(), preset!("plugins/mime-local").into()),
+			("mime.remote".to_owned(), preset!("plugins/mime-remote").into()),
 			("noop".to_owned(), preset!("plugins/noop").into()),
 			("pdf".to_owned(), preset!("plugins/pdf").into()),
 			("session".to_owned(), preset!("plugins/session").into()),

--- a/yazi-scheduler/src/file/file.rs
+++ b/yazi-scheduler/src/file/file.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 use yazi_config::YAZI;
 use yazi_fs::{Cwd, FsHash128, FsUrl, cha::Cha, ok_or_not_found, path::{path_relative_to, skip_url}, provider::{DirReader, FileHolder, Provider, local::Local}};
 use yazi_macro::ok_or_not_found;
-use yazi_shared::{timestamp_us, url::{AsUrl, UrlBuf, UrlCow, UrlLike}};
+use yazi_shared::{scheme::SchemeLike, timestamp_us, url::{AsUrl, UrlBuf, UrlCow, UrlLike}};
 use yazi_vfs::{VfsCha, copy_with_progress, maybe_exists, provider::{self, DirEntry}, unique_name};
 
 use super::{FileInDelete, FileInHardlink, FileInLink, FileInPaste, FileInTrash};

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -8,7 +8,7 @@ use yazi_config::{YAZI, plugin::{Fetcher, Preloader}};
 use yazi_dds::Pump;
 use yazi_parser::{app::PluginOpt, tasks::ProcessOpenOpt};
 use yazi_proxy::TasksProxy;
-use yazi_shared::{Id, Throttle, url::{UrlBuf, UrlLike}};
+use yazi_shared::{Id, Throttle, scheme::SchemeLike, url::{UrlBuf, UrlLike}};
 use yazi_vfs::{must_be_dir, provider, unique_name};
 
 use super::{Ongoing, TaskOp};
@@ -215,7 +215,7 @@ impl Scheduler {
 			ongoing.hooks.add_sync(id, move |canceled| _ = tx.send(canceled));
 		}
 
-		if !url.scheme.is_virtual() {
+		if !url.scheme.is_remote() {
 			return self.ops.out(id, FileOutDownload::Fail("Cannot download non-remote file".to_owned()));
 		};
 
@@ -229,7 +229,7 @@ impl Scheduler {
 		let mut ongoing = self.ongoing.lock();
 		let id = ongoing.add::<FileProgUpload>(format!("Upload {}", url.display()));
 
-		if !url.scheme.is_virtual() {
+		if !url.scheme.is_remote() {
 			return self.ops.out(id, FileOutUpload::Fail("Cannot upload non-remote file".to_owned()));
 		};
 

--- a/yazi-shared/src/scheme/mod.rs
+++ b/yazi-shared/src/scheme/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(cow r#ref scheme);
+yazi_macro::mod_flat!(cow r#ref scheme traits);

--- a/yazi-shared/src/scheme/scheme.rs
+++ b/yazi-shared/src/scheme/scheme.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-use crate::{pool::Symbol, scheme::SchemeRef};
+use crate::{pool::Symbol, scheme::{AsScheme, SchemeRef}};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum Scheme {
@@ -15,26 +15,9 @@ pub enum Scheme {
 }
 
 impl Hash for Scheme {
-	fn hash<H: Hasher>(&self, state: &mut H) { self.as_ref().hash(state); }
+	fn hash<H: Hasher>(&self, state: &mut H) { self.as_scheme().hash(state); }
 }
 
 impl PartialEq<SchemeRef<'_>> for Scheme {
-	fn eq(&self, other: &SchemeRef<'_>) -> bool { self.as_ref() == *other }
-}
-
-impl Scheme {
-	#[inline]
-	pub fn as_ref(&self) -> SchemeRef<'_> { self.into() }
-
-	#[inline]
-	pub fn kind(&self) -> &'static str { self.as_ref().kind() }
-
-	#[inline]
-	pub fn domain(&self) -> Option<&str> { self.as_ref().domain() }
-
-	#[inline]
-	pub fn covariant(&self, other: &Self) -> bool { self.as_ref().covariant(other) }
-
-	#[inline]
-	pub fn is_virtual(&self) -> bool { self.as_ref().is_virtual() }
+	fn eq(&self, other: &SchemeRef<'_>) -> bool { self.as_scheme() == *other }
 }

--- a/yazi-shared/src/scheme/traits.rs
+++ b/yazi-shared/src/scheme/traits.rs
@@ -1,0 +1,63 @@
+use crate::scheme::{Scheme, SchemeCow, SchemeRef};
+
+pub trait AsScheme {
+	fn as_scheme(&self) -> SchemeRef<'_>;
+}
+
+impl AsScheme for SchemeRef<'_> {
+	#[inline]
+	fn as_scheme(&self) -> SchemeRef<'_> { *self }
+}
+
+impl AsScheme for Scheme {
+	#[inline]
+	fn as_scheme(&self) -> SchemeRef<'_> {
+		match self {
+			Scheme::Regular => SchemeRef::Regular,
+			Scheme::Search(d) => SchemeRef::Search(d),
+			Scheme::Archive(d) => SchemeRef::Archive(d),
+			Scheme::Sftp(d) => SchemeRef::Sftp(d),
+		}
+	}
+}
+
+impl AsScheme for &Scheme {
+	#[inline]
+	fn as_scheme(&self) -> SchemeRef<'_> { (**self).as_scheme() }
+}
+
+impl AsScheme for SchemeCow<'_> {
+	#[inline]
+	fn as_scheme(&self) -> SchemeRef<'_> {
+		match self {
+			SchemeCow::Borrowed(s) => *s,
+			SchemeCow::Owned(s) => s.as_scheme(),
+		}
+	}
+}
+
+impl AsScheme for &SchemeCow<'_> {
+	#[inline]
+	fn as_scheme(&self) -> SchemeRef<'_> { (**self).as_scheme() }
+}
+
+// --- SchemeLike
+pub trait SchemeLike
+where
+	Self: AsScheme + Sized,
+{
+	fn kind(&self) -> &'static str { self.as_scheme().kind() }
+
+	fn domain(&self) -> Option<&str> { self.as_scheme().domain() }
+
+	fn covariant(&self, other: impl AsScheme) -> bool { self.as_scheme().covariant(other) }
+
+	fn is_local(&self) -> bool { self.as_scheme().is_local() }
+
+	fn is_remote(&self) -> bool { self.as_scheme().is_remote() }
+
+	fn is_virtual(&self) -> bool { self.as_scheme().is_virtual() }
+}
+
+impl SchemeLike for Scheme {}
+impl SchemeLike for SchemeCow<'_> {}

--- a/yazi-shared/src/url/buf.rs
+++ b/yazi-shared/src/url/buf.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, ffi::OsStr, fmt::{Debug, Formatter}, path::{Path, PathBuf
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::{loc::LocBuf, pool::Pool, scheme::Scheme, url::{AsUrl, Encode, EncodeTilded, Url, UrlCow}};
+use crate::{loc::LocBuf, pool::Pool, scheme::{Scheme, SchemeLike}, url::{AsUrl, Encode, EncodeTilded, Url, UrlCow}};
 
 #[derive(Clone, Default, Eq, Hash, PartialEq)]
 pub struct UrlBuf {
@@ -91,7 +91,7 @@ impl UrlBuf {
 
 	#[inline]
 	pub fn into_path(self) -> Option<PathBuf> {
-		Some(self.loc.into_path()).filter(|_| !self.scheme.is_virtual())
+		Some(self.loc.into_path()).filter(|_| self.scheme.is_local())
 	}
 
 	#[inline]

--- a/yazi-shared/src/url/component.rs
+++ b/yazi-shared/src/url/component.rs
@@ -77,7 +77,7 @@ impl<'a> From<Url<'a>> for Components<'a> {
 impl<'a> Components<'a> {
 	pub fn os_str(&self) -> Cow<'a, OsStr> {
 		let path = self.inner.as_path();
-		if !self.url.scheme.is_virtual() || self.scheme_yielded {
+		if self.url.scheme.is_local() || self.scheme_yielded {
 			return path.as_os_str().into();
 		}
 

--- a/yazi-shared/src/url/cow.rs
+++ b/yazi-shared/src/url/cow.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::{Path, PathBuf}};
 use anyhow::Result;
 use percent_encoding::percent_decode;
 
-use crate::{IntoOsStr, loc::{Loc, LocBuf}, scheme::{SchemeCow, SchemeRef}, url::{AsUrl, Url, UrlBuf}};
+use crate::{IntoOsStr, loc::{Loc, LocBuf}, scheme::{AsScheme, SchemeCow, SchemeRef}, url::{AsUrl, Url, UrlBuf}};
 
 #[derive(Clone, Debug)]
 pub enum UrlCow<'a> {
@@ -109,8 +109,8 @@ impl<'a> UrlCow<'a> {
 	#[inline]
 	pub fn scheme(&self) -> SchemeRef<'_> {
 		match self {
-			UrlCow::Borrowed { scheme, .. } => scheme.as_ref(),
-			UrlCow::Owned { scheme, .. } => scheme.as_ref(),
+			UrlCow::Borrowed { scheme, .. } => scheme.as_scheme(),
+			UrlCow::Owned { scheme, .. } => scheme.as_scheme(),
 		}
 	}
 

--- a/yazi-shared/src/url/traits.rs
+++ b/yazi-shared/src/url/traits.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ffi::OsStr, path::{Path, PathBuf}};
 
-use crate::{scheme::SchemeRef, url::{Components, Display, Uri, Url, UrlBuf, UrlCow, Urn}};
+use crate::{scheme::{AsScheme, SchemeRef}, url::{Components, Display, Uri, Url, UrlBuf, UrlCow, Urn}};
 
 // --- AsUrl
 pub trait AsUrl {
@@ -34,7 +34,7 @@ impl AsUrl for Url<'_> {
 
 impl AsUrl for UrlBuf {
 	#[inline]
-	fn as_url(&self) -> Url<'_> { Url { loc: self.loc.as_loc(), scheme: self.scheme.as_ref() } }
+	fn as_url(&self) -> Url<'_> { Url { loc: self.loc.as_loc(), scheme: self.scheme.as_scheme() } }
 }
 
 impl AsUrl for &UrlBuf {
@@ -51,8 +51,8 @@ impl AsUrl for UrlCow<'_> {
 	#[inline]
 	fn as_url(&self) -> Url<'_> {
 		match self {
-			UrlCow::Borrowed { loc, scheme } => Url { loc: *loc, scheme: scheme.as_ref() },
-			UrlCow::Owned { loc, scheme } => Url { loc: loc.as_loc(), scheme: scheme.as_ref() },
+			UrlCow::Borrowed { loc, scheme } => Url { loc: *loc, scheme: scheme.as_scheme() },
+			UrlCow::Owned { loc, scheme } => Url { loc: loc.as_loc(), scheme: scheme.as_scheme() },
 		}
 	}
 }
@@ -122,6 +122,5 @@ where
 	fn urn(&self) -> &Urn { self.as_url().urn() }
 }
 
-impl UrlLike for Url<'_> {}
 impl UrlLike for UrlBuf {}
 impl UrlLike for UrlCow<'_> {}

--- a/yazi-shared/src/url/url.rs
+++ b/yazi-shared/src/url/url.rs
@@ -200,7 +200,7 @@ impl<'a> Url<'a> {
 
 	#[inline]
 	pub fn as_path(self) -> Option<&'a Path> {
-		Some(self.loc.as_path()).filter(|_| !self.scheme.is_virtual())
+		Some(self.loc.as_path()).filter(|_| self.scheme.is_local())
 	}
 
 	#[inline]


### PR DESCRIPTION
Prepare for https://github.com/sxyazi/yazi/issues/611

This PR introduces a new `mime.remote` fetcher plugin dedicated to remote files.

This PR also renames `mime.file` to `mime.local` to correspond with `mime.remote`.

`mime.file` was introduced in https://github.com/sxyazi/yazi/pull/3222 and has not been included in any release, so it should not break anything. The original PR has been edited to reflect this change