### PR TITLE
fix: follow upstream renaming of `poppler_utils` to `poppler-utils` in Nix flake

### DIFF
--- a/nix/yazi.nix
+++ b/nix/yazi.nix
@@ -12,7 +12,7 @@
 
   # default optional deps
   jq,
-  poppler_utils,
+  poppler-utils,
   _7zz,
   ffmpeg,
   fd,
@@ -39,7 +39,7 @@ let
 
   defaultDeps = [
     jq
-    poppler_utils
+    poppler-utils
     _7zz
     ffmpeg
     fd


### PR DESCRIPTION
## Which issue does this PR resolve?
Getting this error on nixos after update flake.lock.
`error: 'poppler_utils' has been renamed to/replaced by 'poppler-utils'`
<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->


## Rationale of this PR
upstream convert the alias of poppler_utils to throw since 27/10/2025 and make build failure on nixos
 `poppler_utils = throw "'poppler_utils' has been renamed to/replaced by 'poppler-utils'"; # Converted to throw 2025-10-27`
<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
