### PR TITLE
fix: `-flatten` flag should come after the input file in preset ImageMagick previewer

### DIFF
--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,11 +25,11 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_limit()
-	cmd:arg { tostring(job.file.url), "-auto-orient", "-strip" }
+	local cmd = M.with_limit():arg(tostring(job.file.url))
 	if job.args.flatten then
 		cmd:arg("-flatten")
 	end
+	cmd:arg { "-auto-orient", "-strip" }
 
 	local size = string.format("%dx%d>", rt.preview.max_width, rt.preview.max_height)
 	if rt.preview.image_filter == "nearest" then


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #3338 

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

Small change, just moves the logic for the `-flatten` flag after the line with the input file arg when setting up the call to `magick`. `magick` expects `flatten` to come after the input file in its argument list, and errors out if it is before.