### PR TITLE
feat!: introduce `Path` as a subset of `Url` to enforce type safety

### DIFF
--- a/yazi-binding/src/path.rs
+++ b/yazi-binding/src/path.rs
@@ -115,6 +115,9 @@ impl UserData for Path {
 		cached_field!(fields, stem, |lua, me| {
 			me.stem().map(|s| lua.create_string(s.encoded_bytes())).transpose()
 		});
+
+		fields.add_field_method_get("is_absolute", |_, me| Ok(me.is_absolute()));
+		fields.add_field_method_get("has_root", |_, me| Ok(me.has_root()));
 	}
 
 	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {


### PR DESCRIPTION
Prepare for https://github.com/sxyazi/yazi/issues/611

With https://github.com/sxyazi/yazi/pull/3034, `Url` gained support for virtual filesystem namespaces, which means a scheme can appear in the URL now, so it can be used like this:

```lua
local url = Url("sftp://my-server//path/to/file"):strip_prefix("sftp://my-server//path")
print(url)  -- Url("/to/file")
```

The value returned here is actually a path that does not include the scheme (`sftp://my-server/`), so returning it as a `Url` no longer makes sense:

- `Url("/to/file")` denotes a local file whose path is `/to/file`.
- But it's a remote file `/to/file` in the `my-server` namespace

That ambiguity can create potential security risks, for example, passing it to an API like [`fs.remove()`](https://yazi-rs.github.io/docs/plugins/utils#fs.remove) could end up deleting a local file when the intention was to delete a remote one.

By introducing `Path` and restricting its usage, for example, `fs.remove()` accepts only `Url` and not `Path`, so that users must explicitly construct a `Url` from a `Path` before operating on it, which reduces misuse-driven security risks and enforces type safety:

```lua
local path = Url("sftp://my-server//path/to/file"):strip_prefix("sftp://my-server//path")
print(path)  -- Path("/to/file")

local url = Url("sftp://my-server/" .. path)
fs.remove("file", path)  -- Errors out to avoid removing the local file `/to/file` by mistake
fs.remove("file", url)  -- Removes remote file `sftp://my-server//to/file`, which is intentional
```

## ⚠️ Breaking change

Url's `strip_prefix()` method now returns a newly introduced `Path` type instead of the original `Url`.

`Path` exposes all of `Url`'s API except for the scheme. Documentation is available at https://yazi-rs.github.io/docs/next/plugins/types#path