### PR TITLE
feat: toggle selection using Shift-cursor

### DIFF
--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -43,7 +43,12 @@ keymap = [
 	{ on = "L", run = "forward", desc = "Forward to next directory" },
 
 	# Toggle
-	{ on = "<Space>", run = [ "toggle", "arrow next" ], desc = "Toggle the current selection state" },
+	{ on = "<Space>",  run = [ "toggle", "arrow next" ], desc = "Toggle the current selection state" },
+	{ on = "<S-Down>", run = [ "toggle", "arrow next" ], desc = "Toggle the current selection state" },
+	{ on = "J",        run = [ "toggle", "arrow next" ], desc = "Toggle the current selection state" },
+	{ on = "<S-Up>",   run = [ "toggle", "arrow prev" ], desc = "Toggle the current selection state" },
+	{ on = "K",        run = [ "toggle", "arrow prev" ], desc = "Toggle the current selection state" },
+
 	{ on = "<C-a>",   run = "toggle_all --state=on",    desc = "Select all files" },
 	{ on = "<C-r>",   run = "toggle_all",               desc = "Invert selection of all files" },
 


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves no issue reported

## Rationale of this PR

Comming from Commander One or, even older, PC-Tools, I'm used to Shift-Up/Down for (de-)selecting items. T.b.h. I had to look up the documentation to find that space is the selection-key.

So I added my common keys to my keymap. 

Perhaps this method of selection is more widespread and beginners are more accustomed to it? I therefore suggest incorporating this as the default setting.

But it's okay to reject the pull request.
