### PR TITLE
feat: check if already in visual mode before entering visual mode

### DIFF
--- a/yazi-widgets/src/input/commands/visual.rs
+++ b/yazi-widgets/src/input/commands/visual.rs
@@ -12,10 +12,15 @@ impl Input {
 		}
 
 		let snap = self.snap_mut();
+		if let InputOp::Select(_) = snap.op {
+			succ!();
+		}
+
 		if !snap.value.is_empty() {
 			snap.op = InputOp::Select(snap.cursor);
 			render!();
 		}
+
 		succ!();
 	}
 }


### PR DESCRIPTION
An implementation of the feature request: 

Closes https://github.com/sxyazi/yazi/issues/3378

---

This PR makes it easier for users to start selecting backwards or forwards with `<S-Left>` or `<S-Right>`:

```sh
{ on = "<S-Left>", run = [ "visual", "move -1" ] },
{ on = "<S-Right>", run = [ "visual", "move 1" ] },
```
