### PR TITLE
feat: remote filesystem support for interactive `cd`

### DIFF
--- a/yazi-actor/src/mgr/cd.rs
+++ b/yazi-actor/src/mgr/cd.rs
@@ -9,8 +9,8 @@ use yazi_fs::{File, FilesOp, path::expand_url};
 use yazi_macro::{act, err, render, succ};
 use yazi_parser::mgr::CdOpt;
 use yazi_proxy::{CmpProxy, InputProxy, MgrProxy};
-use yazi_shared::{Debounce, data::Data, errors::InputError, url::{UrlBuf, UrlLike}};
-use yazi_vfs::VfsFile;
+use yazi_shared::{Debounce, data::Data, errors::InputError, url::{AsUrl, UrlBuf, UrlLike}};
+use yazi_vfs::{VfsFile, provider};
 
 use crate::{Actor, Ctx};
 
@@ -24,7 +24,7 @@ impl Actor for Cd {
 	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
 		act!(mgr:escape_visual, cx)?;
 		if opt.interactive {
-			return Self::cd_interactive();
+			return Self::cd_interactive(cx);
 		}
 
 		let tab = cx.tab_mut();
@@ -59,8 +59,8 @@ impl Actor for Cd {
 }
 
 impl Cd {
-	fn cd_interactive() -> Result<Data> {
-		let input = InputProxy::show(InputCfg::cd());
+	fn cd_interactive(cx: &Ctx) -> Result<Data> {
+		let input = InputProxy::show(InputCfg::cd(cx.cwd().as_url()));
 
 		tokio::spawn(async move {
 			let rx = Debounce::new(UnboundedReceiverStream::new(input), Duration::from_millis(50));
@@ -70,6 +70,7 @@ impl Cd {
 				match result {
 					Ok(s) => {
 						let Ok(url) = UrlBuf::try_from(s).map(expand_url) else { return };
+						let Ok(url) = provider::absolute(&url).await else { return };
 
 						let Ok(file) = File::new(&url).await else { return };
 						if file.is_dir() {
@@ -79,10 +80,10 @@ impl Cd {
 						if let Some(p) = url.parent() {
 							FilesOp::Upserting(p.into(), [(url.urn().into(), file)].into()).emit();
 						}
-						MgrProxy::reveal(&url);
+						MgrProxy::reveal(url);
 					}
 					Err(InputError::Completed(before, ticket)) => {
-						CmpProxy::trigger(&before, ticket);
+						CmpProxy::trigger(before, ticket);
 					}
 					_ => break,
 				}

--- a/yazi-actor/src/mgr/displace.rs
+++ b/yazi-actor/src/mgr/displace.rs
@@ -1,7 +1,6 @@
-use anyhow::{Result, bail};
-use yazi_fs::FilesOp;
-use yazi_macro::{act, succ};
-use yazi_parser::{VoidOpt, mgr::{CdSource, DisplaceDoOpt}};
+use anyhow::Result;
+use yazi_macro::succ;
+use yazi_parser::{VoidOpt, mgr::DisplaceDoOpt};
 use yazi_proxy::MgrProxy;
 use yazi_shared::{data::Data, url::UrlLike};
 use yazi_vfs::provider;
@@ -23,42 +22,9 @@ impl Actor for Displace {
 		let tab = cx.tab().id;
 		let from = cx.cwd().to_owned();
 		tokio::spawn(async move {
-			MgrProxy::displace_do(tab, DisplaceDoOpt {
-				to: provider::absolute(&from).await.map(|u| u.into_owned()),
-				from,
-			});
+			MgrProxy::displace_do(tab, DisplaceDoOpt { to: provider::canonicalize(&from).await, from });
 		});
 
 		succ!();
-	}
-}
-
-// --- Do
-pub struct DisplaceDo;
-
-impl Actor for DisplaceDo {
-	type Options = DisplaceDoOpt;
-
-	const NAME: &str = "displace_do";
-
-	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
-		if cx.cwd() != opt.from {
-			succ!()
-		}
-
-		let to = match opt.to {
-			Ok(url) => url,
-			Err(e) => return act!(mgr:update_files, cx, FilesOp::IOErr(opt.from, e.into())),
-		};
-
-		if !to.is_absolute() {
-			bail!("Target URL must be absolute");
-		} else if let Some(hovered) = cx.hovered()
-			&& let Ok(url) = to.try_join(hovered.urn())
-		{
-			act!(mgr:reveal, cx, (url, CdSource::Displace))
-		} else {
-			act!(mgr:cd, cx, (to, CdSource::Displace))
-		}
 	}
 }

--- a/yazi-actor/src/mgr/displace_do.rs
+++ b/yazi-actor/src/mgr/displace_do.rs
@@ -1,0 +1,36 @@
+use anyhow::{Result, bail};
+use yazi_fs::FilesOp;
+use yazi_macro::{act, succ};
+use yazi_parser::mgr::{CdSource, DisplaceDoOpt};
+use yazi_shared::{data::Data, url::UrlLike};
+
+use crate::{Actor, Ctx};
+
+pub struct DisplaceDo;
+
+impl Actor for DisplaceDo {
+	type Options = DisplaceDoOpt;
+
+	const NAME: &str = "displace_do";
+
+	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
+		if cx.cwd() != opt.from {
+			succ!()
+		}
+
+		let to = match opt.to {
+			Ok(url) => url,
+			Err(e) => return act!(mgr:update_files, cx, FilesOp::IOErr(opt.from, e.into())),
+		};
+
+		if !to.is_absolute() {
+			bail!("Target URL must be absolute");
+		} else if let Some(hovered) = cx.hovered()
+			&& let Ok(url) = to.try_join(hovered.urn())
+		{
+			act!(mgr:reveal, cx, (url, CdSource::Displace))
+		} else {
+			act!(mgr:cd, cx, (to, CdSource::Displace))
+		}
+	}
+}

--- a/yazi-actor/src/mgr/mod.rs
+++ b/yazi-actor/src/mgr/mod.rs
@@ -7,6 +7,7 @@ yazi_macro::mod_flat!(
 	copy
 	create
 	displace
+	displace_do
 	download
 	enter
 	escape

--- a/yazi-actor/src/mgr/search.rs
+++ b/yazi-actor/src/mgr/search.rs
@@ -8,7 +8,7 @@ use yazi_fs::{FilesOp, cha::Cha};
 use yazi_macro::{act, succ};
 use yazi_parser::{VoidOpt, mgr::{CdSource, SearchOpt, SearchOptVia}};
 use yazi_plugin::external;
-use yazi_proxy::{InputProxy, MgrProxy};
+use yazi_proxy::{AppProxy, InputProxy, MgrProxy};
 use yazi_shared::{data::Data, url::UrlLike};
 
 use crate::{Actor, Ctx};
@@ -52,8 +52,10 @@ impl Actor for SearchDo {
 			handle.abort();
 		}
 
-		let cwd = tab.cwd().to_search(&opt.subject)?;
 		let hidden = tab.pref.show_hidden;
+		let Ok(cwd) = tab.cwd().to_search(&opt.subject) else {
+			succ!(AppProxy::notify_warn("Search", "Only local filesystem searches are supported"));
+		};
 
 		tab.search = Some(tokio::spawn(async move {
 			let rx = match opt.via {

--- a/yazi-actor/src/mgr/stash.rs
+++ b/yazi-actor/src/mgr/stash.rs
@@ -14,7 +14,7 @@ impl Actor for Stash {
 	const NAME: &str = "stash";
 
 	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
-		if opt.target.is_internal() {
+		if opt.target.is_absolute() && opt.target.is_internal() {
 			cx.tab_mut().backstack.push(opt.target.as_url());
 		}
 

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -1,5 +1,5 @@
 use ratatui::{text::{Line, Text}, widgets::{Paragraph, Wrap}};
-use yazi_shared::{strand::ToStrand, url::UrlBuf};
+use yazi_shared::{scheme::Encode as EncodeScheme, strand::ToStrand, url::{Url, UrlBuf}};
 
 use super::{Offset, Position};
 use crate::YAZI;
@@ -31,9 +31,10 @@ pub struct ConfirmCfg {
 }
 
 impl InputCfg {
-	pub fn cd() -> Self {
+	pub fn cd(cwd: Url) -> Self {
 		Self {
 			title: YAZI.input.cd_title.clone(),
+			value: if cwd.kind().is_local() { String::new() } else { EncodeScheme(cwd).to_string() },
 			position: Position::new(YAZI.input.cd_origin, YAZI.input.cd_offset),
 			completion: true,
 			..Default::default()

--- a/yazi-plugin/src/external/fd.rs
+++ b/yazi-plugin/src/external/fd.rs
@@ -2,8 +2,8 @@ use std::process::Stdio;
 
 use anyhow::Result;
 use tokio::{io::{AsyncBufReadExt, BufReader}, process::{Child, Command}, sync::mpsc::{self, UnboundedReceiver}};
-use yazi_fs::File;
-use yazi_shared::url::{UrlBuf, UrlLike};
+use yazi_fs::{File, FsUrl};
+use yazi_shared::url::{AsUrl, UrlBuf, UrlLike};
 use yazi_vfs::VfsFile;
 
 pub struct FdOpt {
@@ -34,16 +34,9 @@ pub fn fd(opt: FdOpt) -> Result<UnboundedReceiver<File>> {
 }
 
 fn spawn(program: &str, opt: &FdOpt) -> std::io::Result<Child> {
-	let Some(path) = opt.cwd.as_local() else {
-		return Err(std::io::Error::new(
-			std::io::ErrorKind::InvalidInput,
-			"fd can only search local filesystem",
-		));
-	};
-
 	Command::new(program)
 		.arg("--base-directory")
-		.arg(path)
+		.arg(&*opt.cwd.as_url().unified_path())
 		.arg("--regex")
 		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(&opt.args)

--- a/yazi-plugin/src/external/rg.rs
+++ b/yazi-plugin/src/external/rg.rs
@@ -1,9 +1,9 @@
 use std::process::Stdio;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use tokio::{io::{AsyncBufReadExt, BufReader}, process::Command, sync::mpsc::{self, UnboundedReceiver}};
-use yazi_fs::File;
-use yazi_shared::url::{UrlBuf, UrlLike};
+use yazi_fs::{File, FsUrl};
+use yazi_shared::url::{AsUrl, UrlBuf, UrlLike};
 use yazi_vfs::VfsFile;
 
 pub struct RgOpt {
@@ -14,16 +14,12 @@ pub struct RgOpt {
 }
 
 pub fn rg(opt: RgOpt) -> Result<UnboundedReceiver<File>> {
-	let Some(path) = opt.cwd.as_local() else {
-		bail!("rg can only search local filesystem");
-	};
-
 	let mut child = Command::new("rg")
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
 		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(opt.args)
 		.arg(opt.subject)
-		.arg(path)
+		.arg(&*opt.cwd.as_url().unified_path())
 		.kill_on_drop(true)
 		.stdout(Stdio::piped())
 		.stderr(Stdio::null())

--- a/yazi-plugin/src/external/rga.rs
+++ b/yazi-plugin/src/external/rga.rs
@@ -1,9 +1,9 @@
 use std::process::Stdio;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use tokio::{io::{AsyncBufReadExt, BufReader}, process::Command, sync::mpsc::{self, UnboundedReceiver}};
-use yazi_fs::File;
-use yazi_shared::url::{UrlBuf, UrlLike};
+use yazi_fs::{File, FsUrl};
+use yazi_shared::url::{AsUrl, UrlBuf, UrlLike};
 use yazi_vfs::VfsFile;
 
 pub struct RgaOpt {
@@ -14,16 +14,12 @@ pub struct RgaOpt {
 }
 
 pub fn rga(opt: RgaOpt) -> Result<UnboundedReceiver<File>> {
-	let Some(path) = opt.cwd.as_local() else {
-		bail!("rga can only search local filesystem");
-	};
-
 	let mut child = Command::new("rga")
 		.args(["--color=never", "--files-with-matches", "--smart-case"])
 		.arg(if opt.hidden { "--hidden" } else { "--no-hidden" })
 		.args(opt.args)
 		.arg(opt.subject)
-		.arg(path)
+		.arg(&*opt.cwd.as_url().unified_path())
 		.kill_on_drop(true)
 		.stdout(Stdio::piped())
 		.stderr(Stdio::null())

--- a/yazi-proxy/src/cmp.rs
+++ b/yazi-proxy/src/cmp.rs
@@ -9,7 +9,7 @@ impl CmpProxy {
 		emit!(Call(relay!(cmp:show).with_any("opt", opt)));
 	}
 
-	pub fn trigger(word: &str, ticket: Id) {
-		emit!(Call(relay!(cmp:trigger, [word]).with("ticket", ticket)));
+	pub fn trigger(word: impl Into<String>, ticket: Id) {
+		emit!(Call(relay!(cmp:trigger, [word.into()]).with("ticket", ticket)));
 	}
 }

--- a/yazi-proxy/src/mgr.rs
+++ b/yazi-proxy/src/mgr.rs
@@ -11,8 +11,8 @@ impl MgrProxy {
 		emit!(Call(relay!(mgr:arrow, [step.into()])));
 	}
 
-	pub fn cd(target: &UrlBuf) {
-		emit!(Call(relay!(mgr:cd, [target]).with("raw", true)));
+	pub fn cd(target: impl Into<UrlBuf>) {
+		emit!(Call(relay!(mgr:cd, [target.into()]).with("raw", true)));
 	}
 
 	pub fn displace_do(tab: Id, opt: DisplaceDoOpt) {
@@ -41,8 +41,8 @@ impl MgrProxy {
 		));
 	}
 
-	pub fn reveal(target: &UrlBuf) {
-		emit!(Call(relay!(mgr:reveal, [target]).with("raw", true).with("no-dummy", true)));
+	pub fn reveal(target: impl Into<UrlBuf>) {
+		emit!(Call(relay!(mgr:reveal, [target.into()]).with("raw", true).with("no-dummy", true)));
 	}
 
 	pub fn search_do(opt: SearchOpt) {

--- a/yazi-shared/src/scheme/cow.rs
+++ b/yazi-shared/src/scheme/cow.rs
@@ -169,6 +169,14 @@ impl<'a> SchemeCow<'a> {
 
 impl<'a> SchemeCow<'a> {
 	#[inline]
+	pub fn into_domain(self) -> Option<SymbolCow<'a, str>> {
+		Some(match self {
+			SchemeCow::Borrowed(s) => s.domain()?.into(),
+			SchemeCow::Owned(s) => s.into_domain()?.into(),
+		})
+	}
+
+	#[inline]
 	pub fn into_owned(self) -> Scheme {
 		match self {
 			Self::Borrowed(s) => s.to_owned(),
@@ -176,13 +184,15 @@ impl<'a> SchemeCow<'a> {
 		}
 	}
 
-	#[inline]
-	pub fn into_domain(self) -> Option<SymbolCow<'a, str>> {
-		Some(match self {
-			SchemeCow::Borrowed(s) => s.domain()?.into(),
-			SchemeCow::Owned(s) => s.into_domain()?.into(),
-		})
+	pub fn with_ports(self, uri: usize, urn: usize) -> Self {
+		match self {
+			Self::Borrowed(s) => s.with_ports(uri, urn).into(),
+			Self::Owned(s) => s.with_ports(uri, urn).into(),
+		}
 	}
+
+	#[inline]
+	pub fn zeroed(self) -> Self { self.with_ports(0, 0) }
 }
 
 #[cfg(test)]

--- a/yazi-shared/src/scheme/ref.rs
+++ b/yazi-shared/src/scheme/ref.rs
@@ -43,13 +43,9 @@ impl From<SchemeRef<'_>> for Scheme {
 
 impl<'a> SchemeRef<'a> {
 	#[inline]
-	pub const fn kind(self) -> SchemeKind {
-		match self {
-			Self::Regular { .. } => SchemeKind::Regular,
-			Self::Search { .. } => SchemeKind::Search,
-			Self::Archive { .. } => SchemeKind::Archive,
-			Self::Sftp { .. } => SchemeKind::Sftp,
-		}
+	pub fn covariant(self, other: impl AsScheme) -> bool {
+		let other = other.as_scheme();
+		if self.is_virtual() || other.is_virtual() { self == other } else { true }
 	}
 
 	#[inline]
@@ -63,6 +59,16 @@ impl<'a> SchemeRef<'a> {
 	}
 
 	#[inline]
+	pub const fn kind(self) -> SchemeKind {
+		match self {
+			Self::Regular { .. } => SchemeKind::Regular,
+			Self::Search { .. } => SchemeKind::Search,
+			Self::Archive { .. } => SchemeKind::Archive,
+			Self::Sftp { .. } => SchemeKind::Sftp,
+		}
+	}
+
+	#[inline]
 	pub const fn ports(self) -> (usize, usize) {
 		match self {
 			Self::Regular { uri, urn } => (uri, urn),
@@ -70,22 +76,6 @@ impl<'a> SchemeRef<'a> {
 			Self::Archive { uri, urn, .. } => (uri, urn),
 			Self::Sftp { uri, urn, .. } => (uri, urn),
 		}
-	}
-
-	#[inline]
-	pub const fn zeroed(self) -> Self {
-		match self {
-			Self::Regular { .. } => Self::Regular { uri: 0, urn: 0 },
-			Self::Search { domain, .. } => Self::Search { domain, uri: 0, urn: 0 },
-			Self::Archive { domain, .. } => Self::Archive { domain, uri: 0, urn: 0 },
-			Self::Sftp { domain, .. } => Self::Sftp { domain, uri: 0, urn: 0 },
-		}
-	}
-
-	#[inline]
-	pub fn covariant(self, other: impl AsScheme) -> bool {
-		let other = other.as_scheme();
-		if self.is_virtual() || other.is_virtual() { self == other } else { true }
 	}
 
 	pub fn to_owned(self) -> Scheme {
@@ -96,4 +86,16 @@ impl<'a> SchemeRef<'a> {
 			Self::Sftp { domain, uri, urn } => Scheme::Sftp { domain: domain.intern(), uri, urn },
 		}
 	}
+
+	pub const fn with_ports(self, uri: usize, urn: usize) -> Self {
+		match self {
+			Self::Regular { .. } => Self::Regular { uri, urn },
+			Self::Search { domain, .. } => Self::Search { domain, uri, urn },
+			Self::Archive { domain, .. } => Self::Archive { domain, uri, urn },
+			Self::Sftp { domain, .. } => Self::Sftp { domain, uri, urn },
+		}
+	}
+
+	#[inline]
+	pub const fn zeroed(self) -> Self { self.with_ports(0, 0) }
 }

--- a/yazi-shared/src/scheme/scheme.rs
+++ b/yazi-shared/src/scheme/scheme.rs
@@ -38,4 +38,7 @@ impl Scheme {
 			Self::Sftp { domain, .. } => Self::Sftp { domain, uri, urn },
 		}
 	}
+
+	#[inline]
+	pub fn zeroed(self) -> Self { self.with_ports(0, 0) }
 }

--- a/yazi-vfs/src/provider/copier.rs
+++ b/yazi-vfs/src/provider/copier.rs
@@ -44,15 +44,15 @@ pub(super) fn copy_with_progress_impl(
 			Some(f)
 		};
 
-		let chunks = (cha.len + 10485760 - 1) / 10485760;
+		let chunks = (cha.len + 5242880 - 1) / 5242880;
 		let mut result = futures::stream::iter(0..chunks)
 			.map(|i| {
 				let acc_ = acc_.clone();
 				let (from, to) = (from.clone(), to.clone());
 				let (src, dist) = (src.take(), dist.take());
 				async move {
-					let offset = i * 10485760;
-					let take = cha.len.saturating_sub(offset).min(10485760);
+					let offset = i * 5242880;
+					let take = cha.len.saturating_sub(offset).min(5242880);
 
 					let mut src = BufReader::with_capacity(524288, match src {
 						Some(f) => f,
@@ -93,7 +93,7 @@ pub(super) fn copy_with_progress_impl(
 					}
 				}
 			})
-			.buffer_unordered(3)
+			.buffer_unordered(4)
 			.try_fold(None, |first, file| async { Ok(first.or(file)) })
 			.await;
 

--- a/yazi-watcher/src/local/linked.rs
+++ b/yazi-watcher/src/local/linked.rs
@@ -59,7 +59,7 @@ impl Linked {
 					Ok(to) if to != *from => _ = linked.write().entry_ref(from).insert(to),
 					Ok(_) => _ = linked.write().remove(from),
 					Err(e) if e.kind() == std::io::ErrorKind::NotFound => _ = linked.write().remove(from),
-					Err(_) => {}
+					Err(e) => tracing::error!("Failed to canonicalize watched path {from:?}: {e:?}"),
 				}
 			}
 		})

--- a/yazi-watcher/src/watcher.rs
+++ b/yazi-watcher/src/watcher.rs
@@ -56,9 +56,7 @@ impl Watcher {
 
 			if !to_unwatch.is_empty() || !to_watch.is_empty() {
 				backend = Self::sync(backend, to_unwatch, to_watch).await;
-				if !rx.has_changed().unwrap_or(false) {
-					backend = backend.sync().await;
-				}
+				backend = backend.sync().await;
 			}
 
 			if rx.changed().await.is_err() {


### PR DESCRIPTION
Follow-up to https://github.com/sxyazi/yazi/pull/3396

Now the interactive `cd` (<kbd>g</kbd> => <kbd>Space</kbd> by default) is working with remote filesystems, including the path auto-completion:

https://github.com/user-attachments/assets/013b5e6d-3926-4d0d-a691-990f3a5e0815
