### PR TITLE
feat: install manpages from flake

### DIFF
--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -6,7 +6,7 @@
   lib,
 
   installShellFiles,
-  stdenv,
+  fetchFromGitHub,
   rust-jemalloc-sys,
 
   imagemagick,
@@ -22,7 +22,7 @@ let
     ];
   };
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yazi";
   inherit version src;
 
@@ -60,9 +60,22 @@ rustPlatform.buildRustPackage rec {
       magick assets/logo.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/yazi.png
     done
 
+    installManPage ${finalAttrs.passthru.srcs.man_src}/yazi{.1,-config.5}
+
     mkdir -p $out/share/applications
     install -m644 assets/yazi.desktop $out/share/applications/
   '';
+
+  passthru.srcs = {
+    man_src = fetchFromGitHub {
+      name = "manpages"; # needed to ensure name is unique
+      owner = "yazi-rs";
+      repo = "manpages";
+      rev = "8950e968f4a1ad0b83d5836ec54a070855068dbf";
+      hash = "sha256-kEVXejDg4ChFoMNBvKlwdFEyUuTcY2VuK9j0PdafKus=";
+    };
+  };
+  
 
   meta = {
     description = "Blazing fast terminal file manager written in Rust, based on async I/O";
@@ -70,4 +83,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     mainProgram = "yazi";
   };
-}
+})


### PR DESCRIPTION
## Which issue does this PR resolve?

When using the flake, there is no manpage available (contrary to the nixpgks stable package).
Fixes https://github.com/sxyazi/yazi/issues/2733

I think it would be easier to redefine the yazi package in the flake as an override of the nixpkgs one instead of duplicating everything.
That's what we do in https://github.com/nix-community/neovim-nightly-overlay/blob/master/flake/packages/neovim.nix


<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
