### PR TITLE
openbsd: fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [ "yazi-fm", "yazi-cli" ]
 
 [profile.release]
 codegen-units = 1
-lto           = false
+lto           = true
 panic         = "abort"
 strip         = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [ "yazi-fm", "yazi-cli" ]
 
 [profile.release]
 codegen-units = 1
-lto           = true
+lto           = false
 panic         = "abort"
 strip         = true
 

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -69,7 +69,7 @@ signal-hook-tokio = { version = "0.3.1", features = [ "futures-v0_3" ] }
 [target.'cfg(target_os = "macos")'.dependencies]
 crossterm = { workspace = true, features = [ "use-dev-tty", "libc" ] }
 
-[target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "openbsd")))'.dependencies]
 tikv-jemallocator = "0.6.1"
 
 [[bin]]

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -1,4 +1,4 @@
-#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows"), not(target_os = "openbsd")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/yazi-fs/src/provider/local/casefold.rs
+++ b/yazi-fs/src/provider/local/casefold.rs
@@ -100,7 +100,6 @@ fn casefold_impl(path: PathBuf) -> io::Result<PathBuf> {
 #[cfg(any(
 	target_os = "macos",
 	target_os = "netbsd",
-	target_os = "openbsd",
 	target_os = "freebsd"
 ))]
 fn final_path(path: &Path) -> io::Result<PathBuf> {
@@ -121,6 +120,11 @@ fn final_path(path: &Path) -> io::Result<PathBuf> {
 
 	let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const i8) };
 	Ok(OsString::from_vec(cstr.to_bytes().to_vec()).into())
+}
+
+#[cfg(target_os = "openbsd")]
+fn final_path(path: &Path) -> io::Result<PathBuf> {
+    std::fs::canonicalize(path)
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Which issue does this PR resolve?

Currently yazi fails to build in OpenBSD, this PR solves the problem, and I been able
to use yazi in my OpenBSD 7.8-Current AMD64 machine.

## Rationale of this PR

It was a simple solution, some target_os specifics, also turn libc::RLIMIT_AS intto libc::RLIMIT_DATA.
Also disable tikv-jemallocator for OpenBSD target.
I had also to change lto to false, that is crucial for a standard OpenBSD, I hope some better idea to enable lto
in a standard OpenBSD.
I am not a developer, just trying to contribute... keep the awesome work.
