### PR TITLE
perf: immediate task cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ### Improved
 
+- Make copy, cut, delete, link, hardlink, download, and upload tasks immediately cancellable ([#3429])
 - Make preload tasks discardable ([#2875])
 - Reduce file change event frequency ([#2820])
 - Upload and download of a single file over SFTP in chunks concurrently ([#3393])
@@ -1556,3 +1557,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3396]: https://github.com/sxyazi/yazi/pull/3396
 [#3419]: https://github.com/sxyazi/yazi/pull/3419
 [#3422]: https://github.com/sxyazi/yazi/pull/3422
+[#3429]: https://github.com/sxyazi/yazi/pull/3429

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ resolver        = "2"
 members         = [ "yazi-*" ]
 default-members = [ "yazi-fm", "yazi-cli" ]
 
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
 codegen-units = 1
 lto           = true
@@ -18,6 +21,9 @@ inherits      = "release"
 codegen-units = 256
 incremental   = true
 lto           = false
+
+[profile.dev.package."*"]
+debug = false
 
 [workspace.dependencies]
 ansi-to-tui         = "7.0.0"

--- a/yazi-core/src/tasks/prework.rs
+++ b/yazi-core/src/tasks/prework.rs
@@ -23,7 +23,7 @@ impl Tasks {
 		drop(loaded);
 		for (i, tasks) in tasks.into_iter().enumerate() {
 			if !tasks.is_empty() {
-				self.scheduler.fetch_paged(&YAZI.plugin.fetchers[i], tasks, None);
+				self.scheduler.fetch_paged(&YAZI.plugin.fetchers[i], tasks);
 			}
 		}
 	}

--- a/yazi-parser/src/tasks/process_open.rs
+++ b/yazi-parser/src/tasks/process_open.rs
@@ -2,8 +2,7 @@ use std::ffi::OsString;
 
 use anyhow::anyhow;
 use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
-use tokio::sync::oneshot;
-use yazi_shared::{event::CmdCow, url::UrlCow};
+use yazi_shared::{CompletionToken, event::CmdCow, url::UrlCow};
 
 // --- Exec
 #[derive(Debug)]
@@ -13,7 +12,7 @@ pub struct ProcessOpenOpt {
 	pub args:   Vec<UrlCow<'static>>,
 	pub block:  bool,
 	pub orphan: bool,
-	pub done:   Option<oneshot::Sender<()>>,
+	pub done:   Option<CompletionToken>,
 
 	pub spread: bool, // TODO: remove
 }

--- a/yazi-scheduler/src/file/in.rs
+++ b/yazi-scheduler/src/file/in.rs
@@ -2,7 +2,7 @@ use std::{mem, path::PathBuf};
 
 use tokio::sync::mpsc;
 use yazi_fs::cha::Cha;
-use yazi_shared::{Id, url::UrlBuf};
+use yazi_shared::{CompletionToken, Id, url::UrlBuf};
 
 // --- Copy
 #[derive(Clone, Debug)]
@@ -14,6 +14,7 @@ pub(crate) struct FileInCopy {
 	pub(crate) cha:    Option<Cha>,
 	pub(crate) follow: bool,
 	pub(crate) retry:  u8,
+	pub(crate) done:   CompletionToken,
 }
 
 impl FileInCopy {
@@ -41,6 +42,7 @@ pub(crate) struct FileInCut {
 	pub(crate) cha:    Option<Cha>,
 	pub(crate) follow: bool,
 	pub(crate) retry:  u8,
+	pub(crate) done:   CompletionToken,
 	pub(crate) drop:   Option<mpsc::Sender<()>>,
 }
 
@@ -114,6 +116,7 @@ pub(crate) struct FileInDownload {
 	pub(crate) url:   UrlBuf,
 	pub(crate) cha:   Option<Cha>,
 	pub(crate) retry: u8,
+	pub(crate) done:  CompletionToken,
 }
 
 // --- Upload
@@ -123,4 +126,5 @@ pub(crate) struct FileInUpload {
 	pub(crate) url:   UrlBuf,
 	pub(crate) cha:   Option<Cha>,
 	pub(crate) cache: Option<PathBuf>,
+	pub(crate) done:  CompletionToken,
 }

--- a/yazi-scheduler/src/file/traverse.rs
+++ b/yazi-scheduler/src/file/traverse.rs
@@ -41,6 +41,7 @@ impl Traverse for FileInCopy {
 			cha: Some(cha),
 			follow: self.follow,
 			retry: self.retry,
+			done: self.done.clone(),
 		}
 	}
 
@@ -63,6 +64,7 @@ impl Traverse for FileInCut {
 			cha: Some(cha),
 			follow: self.follow,
 			retry: self.retry,
+			done: self.done.clone(),
 			drop: self.drop.clone(),
 		}
 	}
@@ -113,7 +115,13 @@ impl Traverse for FileInDownload {
 	fn from(&self) -> Url<'_> { self.url.as_url() }
 
 	fn spawn(&self, from: UrlBuf, _to: Option<UrlBuf>, cha: Cha) -> Self {
-		Self { id: self.id, url: from, cha: Some(cha), retry: self.retry }
+		Self {
+			id:    self.id,
+			url:   from,
+			cha:   Some(cha),
+			retry: self.retry,
+			done:  self.done.clone(),
+		}
 	}
 
 	fn to(&self) -> Option<Url<'_>> { None }
@@ -137,7 +145,13 @@ impl Traverse for FileInUpload {
 	}
 
 	fn spawn(&self, from: UrlBuf, _to: Option<UrlBuf>, cha: Cha) -> Self {
-		Self { id: self.id, cha: Some(cha), cache: from.cache(), url: from }
+		Self {
+			id:    self.id,
+			cha:   Some(cha),
+			cache: from.cache(),
+			url:   from,
+			done:  self.done.clone(),
+		}
 	}
 
 	fn to(&self) -> Option<Url<'_>> { None }

--- a/yazi-scheduler/src/hook/in.rs
+++ b/yazi-scheduler/src/hook/in.rs
@@ -1,4 +1,3 @@
-use tokio::sync::{mpsc, oneshot};
 use yazi_shared::{Id, url::UrlBuf};
 
 use crate::{Task, TaskProg, file::FileInCut};
@@ -58,74 +57,12 @@ impl HookInOutTrash {
 // --- Download
 #[derive(Debug)]
 pub(crate) struct HookInOutDownload {
-	pub(crate) id:   Id,
-	pub(crate) done: oneshot::Sender<bool>,
+	pub(crate) id: Id,
 }
 
 impl HookInOutDownload {
 	pub(crate) fn reduce(self, task: &mut Task) {
 		if let TaskProg::FileDownload(_) = &task.prog {
-			task.hook = Some(self.into());
-		}
-	}
-}
-
-// --- Fetch
-#[derive(Debug)]
-pub(crate) struct HookInOutFetch {
-	pub(crate) id:   Id,
-	pub(crate) done: oneshot::Sender<bool>,
-}
-
-impl HookInOutFetch {
-	pub(crate) fn reduce(self, task: &mut Task) {
-		if let TaskProg::PreworkFetch(_) = &task.prog {
-			task.hook = Some(self.into());
-		}
-	}
-}
-
-// --- Block
-#[derive(Debug)]
-pub(crate) struct HookInOutBlock {
-	pub(crate) id:   Id,
-	pub(crate) done: Option<oneshot::Sender<()>>,
-}
-
-impl HookInOutBlock {
-	pub(crate) fn reduce(self, task: &mut Task) {
-		if let TaskProg::ProcessBlock(_) = &task.prog {
-			task.hook = Some(self.into());
-		}
-	}
-}
-
-// --- Orphan
-#[derive(Debug)]
-pub(crate) struct HookInOutOrphan {
-	pub(crate) id:   Id,
-	pub(crate) done: Option<oneshot::Sender<()>>,
-}
-
-impl HookInOutOrphan {
-	pub(crate) fn reduce(self, task: &mut Task) {
-		if let TaskProg::ProcessOrphan(_) = &task.prog {
-			task.hook = Some(self.into());
-		}
-	}
-}
-
-// --- Bg
-#[derive(Debug)]
-pub(crate) struct HookInOutBg {
-	pub(crate) id:     Id,
-	pub(crate) cancel: mpsc::Sender<()>,
-	pub(crate) done:   Option<oneshot::Sender<()>>,
-}
-
-impl HookInOutBg {
-	pub(crate) fn reduce(self, task: &mut Task) {
-		if let TaskProg::ProcessBg(_) = &task.prog {
 			task.hook = Some(self.into());
 		}
 	}

--- a/yazi-scheduler/src/in.rs
+++ b/yazi-scheduler/src/in.rs
@@ -1,6 +1,6 @@
 use yazi_shared::Id;
 
-use crate::{file::{FileInCopy, FileInCut, FileInDelete, FileInDownload, FileInHardlink, FileInLink, FileInTrash, FileInUpload}, hook::{HookInOutBg, HookInOutBlock, HookInOutCut, HookInOutDelete, HookInOutDownload, HookInOutFetch, HookInOutOrphan, HookInOutTrash}, impl_from_in, plugin::PluginInEntry, prework::{PreworkInFetch, PreworkInLoad, PreworkInSize}, process::{ProcessInBg, ProcessInBlock, ProcessInOrphan}};
+use crate::{file::{FileInCopy, FileInCut, FileInDelete, FileInDownload, FileInHardlink, FileInLink, FileInTrash, FileInUpload}, hook::{HookInOutCut, HookInOutDelete, HookInOutDownload, HookInOutTrash}, impl_from_in, plugin::PluginInEntry, prework::{PreworkInFetch, PreworkInLoad, PreworkInSize}, process::{ProcessInBg, ProcessInBlock, ProcessInOrphan}};
 
 #[derive(Debug)]
 pub(crate) enum TaskIn {
@@ -28,10 +28,6 @@ pub(crate) enum TaskIn {
 	HookDelete(HookInOutDelete),
 	HookTrash(HookInOutTrash),
 	HookDownload(HookInOutDownload),
-	HookBlock(HookInOutBlock),
-	HookOrphan(HookInOutOrphan),
-	HookBg(HookInOutBg),
-	HookFetch(HookInOutFetch),
 }
 
 impl_from_in! {
@@ -44,7 +40,7 @@ impl_from_in! {
 	// Process
 	ProcessBlock(ProcessInBlock), ProcessOrphan(ProcessInOrphan), ProcessBg(ProcessInBg),
 	// Hook
-	HookCut(HookInOutCut), HookDelete(HookInOutDelete), HookTrash(HookInOutTrash), HookDownload(HookInOutDownload), HookBlock(HookInOutBlock), HookOrphan(HookInOutOrphan), HookBg(HookInOutBg), HookFetch(HookInOutFetch),
+	HookCut(HookInOutCut), HookDelete(HookInOutDelete), HookTrash(HookInOutTrash), HookDownload(HookInOutDownload),
 }
 
 impl TaskIn {
@@ -74,10 +70,35 @@ impl TaskIn {
 			Self::HookDelete(r#in) => r#in.id,
 			Self::HookTrash(r#in) => r#in.id,
 			Self::HookDownload(r#in) => r#in.id,
-			Self::HookBlock(r#in) => r#in.id,
-			Self::HookOrphan(r#in) => r#in.id,
-			Self::HookBg(r#in) => r#in.id,
-			Self::HookFetch(r#in) => r#in.id,
+		}
+	}
+
+	pub fn is_hook(&self) -> bool {
+		match self {
+			// File
+			Self::FileCopy(_) => false,
+			Self::FileCut(_) => false,
+			Self::FileLink(_) => false,
+			Self::FileHardlink(_) => false,
+			Self::FileDelete(_) => false,
+			Self::FileTrash(_) => false,
+			Self::FileDownload(_) => false,
+			Self::FileUpload(_) => false,
+			// Plugin
+			Self::PluginEntry(_) => false,
+			// Prework
+			Self::PreworkFetch(_) => false,
+			Self::PreworkLoad(_) => false,
+			Self::PreworkSize(_) => false,
+			// Process
+			Self::ProcessBlock(_) => false,
+			Self::ProcessOrphan(_) => false,
+			Self::ProcessBg(_) => false,
+			// Hook
+			Self::HookCut(_) => true,
+			Self::HookDelete(_) => true,
+			Self::HookTrash(_) => true,
+			Self::HookDownload(_) => true,
 		}
 	}
 }

--- a/yazi-scheduler/src/macros.rs
+++ b/yazi-scheduler/src/macros.rs
@@ -25,6 +25,21 @@ macro_rules! ok_or_not_found {
 }
 
 #[macro_export]
+macro_rules! progress_or_break {
+	($rx:ident, $done:expr) => {
+		tokio::select! {
+			r = $rx.recv() => {
+				match r {
+					Some(prog) => prog,
+					None => break,
+				}
+			},
+			false = $done.future() => break,
+		}
+	};
+}
+
+#[macro_export]
 macro_rules! impl_from_in {
 	($($variant:ident($type:ty)),* $(,)?) => {
 		$(

--- a/yazi-scheduler/src/ongoing.rs
+++ b/yazi-scheduler/src/ongoing.rs
@@ -1,15 +1,15 @@
-use hashbrown::HashMap;
+use hashbrown::{HashMap, hash_map::RawEntryMut};
 use ordered_float::OrderedFloat;
 use yazi_config::YAZI;
 use yazi_parser::app::TaskSummary;
-use yazi_shared::{Id, Ids};
+use yazi_shared::{CompletionToken, Id, Ids};
 
 use super::Task;
-use crate::TaskProg;
+use crate::{TaskIn, TaskProg};
 
 #[derive(Default)]
 pub struct Ongoing {
-	pub(super) inner: HashMap<Id, Task>,
+	inner: HashMap<Id, Task>,
 }
 
 impl Ongoing {
@@ -23,10 +23,38 @@ impl Ongoing {
 		self.inner.entry(id).insert(Task::new::<T>(id, name)).into_mut()
 	}
 
+	pub(super) fn cancel(&mut self, id: Id) -> Option<TaskIn> {
+		match self.inner.raw_entry_mut().from_key(&id) {
+			RawEntryMut::Occupied(mut oe) => {
+				let task = oe.get_mut();
+				task.done.complete(false);
+
+				if let Some(hook) = task.hook.take() {
+					return Some(hook);
+				}
+
+				oe.remove();
+			}
+			RawEntryMut::Vacant(_) => {}
+		}
+		None
+	}
+
+	pub(super) fn fulfill(&mut self, id: Id) -> Option<Task> {
+		let task = self.inner.remove(&id)?;
+		task.done.complete(true);
+		Some(task)
+	}
+
 	#[inline]
 	pub fn get_mut(&mut self, id: Id) -> Option<&mut Task> { self.inner.get_mut(&id) }
 
 	pub fn get_id(&self, idx: usize) -> Option<Id> { self.values().nth(idx).map(|t| t.id) }
+
+	#[inline]
+	pub fn get_token(&self, id: Id) -> Option<CompletionToken> {
+		self.inner.get(&id).map(|t| t.done.clone())
+	}
 
 	pub fn len(&self) -> usize {
 		if YAZI.tasks.suppress_preload {
@@ -40,7 +68,9 @@ impl Ongoing {
 	pub fn exists(&self, id: Id) -> bool { self.inner.contains_key(&id) }
 
 	#[inline]
-	pub fn intact(&self, id: Id) -> bool { self.inner.get(&id).is_some_and(|t| !t.canceled) }
+	pub fn intact(&self, id: Id) -> bool {
+		self.inner.get(&id).is_some_and(|t| t.done.completed() != Some(false))
+	}
 
 	pub fn values(&self) -> Box<dyn Iterator<Item = &Task> + '_> {
 		if YAZI.tasks.suppress_preload {

--- a/yazi-scheduler/src/out.rs
+++ b/yazi-scheduler/src/out.rs
@@ -1,4 +1,4 @@
-use crate::{Task, file::{FileOutCopy, FileOutCopyDo, FileOutCut, FileOutCutDo, FileOutDelete, FileOutDeleteDo, FileOutDownload, FileOutDownloadDo, FileOutHardlink, FileOutHardlinkDo, FileOutLink, FileOutTrash, FileOutUpload, FileOutUploadDo}, hook::{HookInOutBg, HookInOutBlock, HookInOutCut, HookInOutDelete, HookInOutDownload, HookInOutFetch, HookInOutOrphan, HookInOutTrash}, impl_from_out, plugin::PluginOutEntry, prework::{PreworkOutFetch, PreworkOutLoad, PreworkOutSize}, process::{ProcessOutBg, ProcessOutBlock, ProcessOutOrphan}};
+use crate::{Task, file::{FileOutCopy, FileOutCopyDo, FileOutCut, FileOutCutDo, FileOutDelete, FileOutDeleteDo, FileOutDownload, FileOutDownloadDo, FileOutHardlink, FileOutHardlinkDo, FileOutLink, FileOutTrash, FileOutUpload, FileOutUploadDo}, hook::{HookInOutCut, HookInOutDelete, HookInOutDownload, HookInOutTrash}, impl_from_out, plugin::PluginOutEntry, prework::{PreworkOutFetch, PreworkOutLoad, PreworkOutSize}, process::{ProcessOutBg, ProcessOutBlock, ProcessOutOrphan}};
 
 #[derive(Debug)]
 pub(super) enum TaskOut {
@@ -32,10 +32,6 @@ pub(super) enum TaskOut {
 	HookDelete(HookInOutDelete),
 	HookTrash(HookInOutTrash),
 	HookDownload(HookInOutDownload),
-	HookBlock(HookInOutBlock),
-	HookOrphan(HookInOutOrphan),
-	HookBg(HookInOutBg),
-	HookFetch(HookInOutFetch),
 }
 
 impl_from_out! {
@@ -48,7 +44,7 @@ impl_from_out! {
 	// Process
 	ProcessBlock(ProcessOutBlock), ProcessOrphan(ProcessOutOrphan), ProcessBg(ProcessOutBg),
 	// Hook
-	HookCut(HookInOutCut), HookDelete(HookInOutDelete), HookTrash(HookInOutTrash), HookDownload(HookInOutDownload), HookBlock(HookInOutBlock), HookOrphan(HookInOutOrphan), HookBg(HookInOutBg), HookFetch(HookInOutFetch),
+	HookCut(HookInOutCut), HookDelete(HookInOutDelete), HookTrash(HookInOutTrash), HookDownload(HookInOutDownload),
 }
 
 impl TaskOut {
@@ -84,10 +80,6 @@ impl TaskOut {
 			Self::HookDelete(out) => out.reduce(task),
 			Self::HookTrash(out) => out.reduce(task),
 			Self::HookDownload(out) => out.reduce(task),
-			Self::HookBlock(out) => out.reduce(task),
-			Self::HookOrphan(out) => out.reduce(task),
-			Self::HookBg(out) => out.reduce(task),
-			Self::HookFetch(out) => out.reduce(task),
 		}
 	}
 }

--- a/yazi-scheduler/src/prework/out.rs
+++ b/yazi-scheduler/src/prework/out.rs
@@ -5,7 +5,6 @@ use crate::{Task, TaskProg};
 pub(crate) enum PreworkOutFetch {
 	Succ,
 	Fail(String),
-	Clean,
 }
 
 impl From<mlua::Error> for PreworkOutFetch {
@@ -22,9 +21,6 @@ impl PreworkOutFetch {
 			Self::Fail(reason) => {
 				prog.state = Some(false);
 				task.log(reason);
-			}
-			Self::Clean => {
-				prog.cleaned = true;
 			}
 		}
 	}

--- a/yazi-scheduler/src/prework/progress.rs
+++ b/yazi-scheduler/src/prework/progress.rs
@@ -4,8 +4,7 @@ use yazi_parser::app::TaskSummary;
 // --- Fetch
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct PreworkProgFetch {
-	pub state:   Option<bool>,
-	pub cleaned: bool,
+	pub state: Option<bool>,
 }
 
 impl From<PreworkProgFetch> for TaskSummary {
@@ -26,7 +25,7 @@ impl PreworkProgFetch {
 
 	pub fn failed(self) -> bool { self.state == Some(false) }
 
-	pub fn cleaned(self) -> bool { self.cleaned }
+	pub fn cleaned(self) -> bool { false }
 
 	pub fn percent(self) -> Option<f32> { None }
 }

--- a/yazi-scheduler/src/process/in.rs
+++ b/yazi-scheduler/src/process/in.rs
@@ -1,7 +1,6 @@
 use std::ffi::OsString;
 
-use tokio::sync::mpsc;
-use yazi_shared::{Id, url::UrlCow};
+use yazi_shared::{CompletionToken, Id, url::UrlCow};
 
 use super::ShellOpt;
 
@@ -38,11 +37,11 @@ impl From<ProcessInOrphan> for ShellOpt {
 // --- Bg
 #[derive(Debug)]
 pub(crate) struct ProcessInBg {
-	pub(crate) id:     Id,
-	pub(crate) cwd:    UrlCow<'static>,
-	pub(crate) cmd:    OsString,
-	pub(crate) args:   Vec<UrlCow<'static>>,
-	pub(crate) cancel: mpsc::Receiver<()>,
+	pub(crate) id:   Id,
+	pub(crate) cwd:  UrlCow<'static>,
+	pub(crate) cmd:  OsString,
+	pub(crate) args: Vec<UrlCow<'static>>,
+	pub(crate) done: CompletionToken,
 }
 
 impl From<ProcessInBg> for ShellOpt {

--- a/yazi-scheduler/src/process/out.rs
+++ b/yazi-scheduler/src/process/out.rs
@@ -4,7 +4,6 @@ use crate::{Task, TaskProg};
 pub(crate) enum ProcessOutBlock {
 	Succ,
 	Fail(String),
-	Clean,
 }
 
 impl From<std::io::Error> for ProcessOutBlock {
@@ -22,9 +21,6 @@ impl ProcessOutBlock {
 				prog.state = Some(false);
 				task.log(reason);
 			}
-			Self::Clean => {
-				prog.cleaned = true;
-			}
 		}
 	}
 }
@@ -34,7 +30,6 @@ impl ProcessOutBlock {
 pub(crate) enum ProcessOutOrphan {
 	Succ,
 	Fail(String),
-	Clean,
 }
 
 impl From<anyhow::Error> for ProcessOutOrphan {
@@ -52,9 +47,6 @@ impl ProcessOutOrphan {
 				prog.state = Some(false);
 				task.log(reason);
 			}
-			Self::Clean => {
-				prog.cleaned = true;
-			}
 		}
 	}
 }
@@ -65,7 +57,6 @@ pub(crate) enum ProcessOutBg {
 	Log(String),
 	Succ,
 	Fail(String),
-	Clean,
 }
 
 impl From<anyhow::Error> for ProcessOutBg {
@@ -85,9 +76,6 @@ impl ProcessOutBg {
 			Self::Fail(reason) => {
 				prog.state = Some(false);
 				task.log(reason);
-			}
-			Self::Clean => {
-				prog.cleaned = true;
 			}
 		}
 	}

--- a/yazi-scheduler/src/process/process.rs
+++ b/yazi-scheduler/src/process/process.rs
@@ -55,14 +55,13 @@ impl Process {
 		})
 		.await?;
 
+		let done = task.done;
 		let mut stdout = BufReader::new(child.stdout.take().unwrap()).lines();
 		let mut stderr = BufReader::new(child.stderr.take().unwrap()).lines();
-		let mut cancel = task.cancel;
 		loop {
 			select! {
-				_ = cancel.recv() => {
+				false = done.future() => {
 					child.start_kill().ok();
-					cancel.close();
 					break;
 				}
 				Ok(Some(line)) = stdout.next_line() => {

--- a/yazi-scheduler/src/process/progress.rs
+++ b/yazi-scheduler/src/process/progress.rs
@@ -4,8 +4,7 @@ use yazi_parser::app::TaskSummary;
 // --- Block
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProcessProgBlock {
-	pub state:   Option<bool>,
-	pub cleaned: bool,
+	pub state: Option<bool>,
 }
 
 impl From<ProcessProgBlock> for TaskSummary {
@@ -26,7 +25,7 @@ impl ProcessProgBlock {
 
 	pub fn failed(self) -> bool { self.state == Some(false) }
 
-	pub fn cleaned(self) -> bool { self.cleaned }
+	pub fn cleaned(self) -> bool { false }
 
 	pub fn percent(self) -> Option<f32> { None }
 }
@@ -34,8 +33,7 @@ impl ProcessProgBlock {
 // --- Orphan
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProcessProgOrphan {
-	pub state:   Option<bool>,
-	pub cleaned: bool,
+	pub state: Option<bool>,
 }
 
 impl From<ProcessProgOrphan> for TaskSummary {
@@ -56,7 +54,7 @@ impl ProcessProgOrphan {
 
 	pub fn failed(self) -> bool { self.state == Some(false) }
 
-	pub fn cleaned(self) -> bool { self.cleaned }
+	pub fn cleaned(self) -> bool { false }
 
 	pub fn percent(self) -> Option<f32> { None }
 }
@@ -64,8 +62,7 @@ impl ProcessProgOrphan {
 // --- Bg
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct ProcessProgBg {
-	pub state:   Option<bool>,
-	pub cleaned: bool,
+	pub state: Option<bool>,
 }
 
 impl From<ProcessProgBg> for TaskSummary {
@@ -86,7 +83,7 @@ impl ProcessProgBg {
 
 	pub fn failed(self) -> bool { self.state == Some(false) }
 
-	pub fn cleaned(self) -> bool { self.cleaned }
+	pub fn cleaned(self) -> bool { false }
 
 	pub fn percent(self) -> Option<f32> { None }
 }

--- a/yazi-scheduler/src/runner.rs
+++ b/yazi-scheduler/src/runner.rs
@@ -38,10 +38,6 @@ impl Runner {
 			TaskIn::HookDelete(r#in) => Ok(self.hook.delete(r#in).await),
 			TaskIn::HookTrash(r#in) => Ok(self.hook.trash(r#in).await),
 			TaskIn::HookDownload(r#in) => Ok(self.hook.download(r#in).await),
-			TaskIn::HookBlock(r#in) => Ok(self.hook.block(r#in).await),
-			TaskIn::HookOrphan(r#in) => Ok(self.hook.orphan(r#in).await),
-			TaskIn::HookBg(r#in) => Ok(self.hook.bg(r#in).await),
-			TaskIn::HookFetch(r#in) => Ok(self.hook.fetch(r#in).await),
 		}
 	}
 
@@ -71,10 +67,6 @@ impl Runner {
 			TaskIn::HookDelete(_in) => unreachable!(),
 			TaskIn::HookTrash(_in) => unreachable!(),
 			TaskIn::HookDownload(_in) => unreachable!(),
-			TaskIn::HookBlock(_in) => unreachable!(),
-			TaskIn::HookOrphan(_in) => unreachable!(),
-			TaskIn::HookBg(_in) => unreachable!(),
-			TaskIn::HookFetch(_in) => unreachable!(),
 		}
 	}
 }

--- a/yazi-scheduler/src/task.rs
+++ b/yazi-scheduler/src/task.rs
@@ -1,5 +1,5 @@
 use tokio::sync::mpsc;
-use yazi_shared::Id;
+use yazi_shared::{CompletionToken, Id};
 
 use crate::{TaskIn, TaskProg};
 
@@ -9,7 +9,7 @@ pub struct Task {
 	pub name:        String,
 	pub(crate) prog: TaskProg,
 	pub(crate) hook: Option<TaskIn>,
-	pub canceled:    bool,
+	pub done:        CompletionToken,
 
 	pub logs:   String,
 	pub logger: Option<mpsc::UnboundedSender<String>>,
@@ -25,7 +25,7 @@ impl Task {
 			name,
 			prog: T::default().into(),
 			hook: None,
-			canceled: false,
+			done: CompletionToken::new(),
 
 			logs: Default::default(),
 			logger: Default::default(),

--- a/yazi-shared/src/completion_token.rs
+++ b/yazi-shared/src/completion_token.rs
@@ -1,0 +1,38 @@
+use std::sync::{Arc, atomic::{AtomicU8, Ordering}};
+
+use tokio::sync::Notify;
+
+#[derive(Clone, Debug)]
+pub struct CompletionToken {
+	inner: Arc<(AtomicU8, Notify)>,
+}
+
+impl CompletionToken {
+	pub fn new() -> Self { Self { inner: Arc::new((AtomicU8::new(0), Notify::new())) } }
+
+	pub fn complete(&self, success: bool) {
+		let new = if success { 1 } else { 2 };
+		self.inner.0.compare_exchange(0, new, Ordering::Relaxed, Ordering::Relaxed).ok();
+		self.inner.1.notify_waiters();
+	}
+
+	pub fn completed(&self) -> Option<bool> {
+		let state = self.inner.0.load(Ordering::Relaxed);
+		if state == 0 { None } else { Some(state == 1) }
+	}
+
+	pub async fn future(&self) -> bool {
+		loop {
+			if let Some(state) = self.completed() {
+				return state;
+			}
+
+			let notified = self.inner.1.notified();
+			if let Some(state) = self.completed() {
+				return state;
+			}
+
+			notified.await;
+		}
+	}
+}

--- a/yazi-shared/src/lib.rs
+++ b/yazi-shared/src/lib.rs
@@ -1,6 +1,6 @@
 yazi_macro::mod_pub!(data errors event loc path pool scheme shell strand translit url wtf8);
 
-yazi_macro::mod_flat!(alias bytes chars condition debounce either env id layer localset natsort os predictor ro_cell source sync_cell terminal tests throttle time utf8);
+yazi_macro::mod_flat!(alias bytes chars completion_token condition debounce either env id layer localset natsort os predictor ro_cell source sync_cell terminal tests throttle time utf8);
 
 pub fn init() {
 	LOCAL_SET.with(tokio::task::LocalSet::new);


### PR DESCRIPTION
Follow-up to https://github.com/sxyazi/yazi/pull/3396

Previously, cancelling a task only guaranteed that its subsequent subtasks would not be executed. For example, when copying a directory containing 100 files, if the task is cancelled during the 30th file, Yazi would ensure the remaining 70 files are not copied, but the 30th file that is already being copied would continue since the OS doesn't provide an API to cancel a blocking I/O operation in progress.

With the introduction of remote file management, the situation changed: it's clearly possible to cancel an ongoing remote file upload/download by closing its socket connection. With this PR, when a user cancels a remote task in the task manager, it will be aborted immediately. This is especially important for the upload/download task of a single large file, as it prevents unnecessary consumption of bandwidth.

This PR improves local filesystem operations as well: when a local directory copy, cut, delete, or hardlink task is cancelled, Yazi can now immediately abort the directory traversal/collection