### PR TITLE
fix: `Command:output()` should set `stderr` to piped instead of `stdin`

### DIFF
--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -3,7 +3,7 @@ local M = {}
 function M:peek(job)
 	local cmd = os.getenv("YAZI_FILE_ONE") or "file"
 	local path = tostring(job.file.cache or job.file.url)
-	local output, err = Command(cmd):arg({ "-bL", "--", path }):stdout(Command.PIPED):output()
+	local output, err = Command(cmd):arg({ "-bL", "--", path }):output()
 
 	local text
 	if output then

--- a/yazi-plugin/preset/plugins/pdf.lua
+++ b/yazi-plugin/preset/plugins/pdf.lua
@@ -42,7 +42,6 @@ function M:preload(job)
 			"-jpeg", "-jpegopt", "quality=" .. rt.preview.image_quality,
 			tostring(job.file.url), tostring(cache),
 		})
-		:stderr(Command.PIPED)
 		:output()
 
 	if not output then

--- a/yazi-plugin/src/process/command.rs
+++ b/yazi-plugin/src/process/command.rs
@@ -97,8 +97,8 @@ impl Command {
 	}
 
 	async fn output(&mut self) -> io::Result<std::process::Output> {
-		self.inner.stdin(Stdio::piped());
 		self.inner.stdout(Stdio::piped());
+		self.inner.stderr(Stdio::piped());
 		self.spawn()?.wait_with_output().await
 	}
 


### PR DESCRIPTION
`Command:output()` is used to capture a command's output and it should [set `stderr` to piped](https://github.com/tokio-rs/tokio/blob/1b17a7e241989520704ce408045904bc2e275e3c/tokio/src/process/mod.rs#L1066-L1067) so that `stderr` output can be collected rather than `stdin`. 

I just found this bug while working on clarifying the behavior of `output()` in https://github.com/yazi-rs/yazi-rs.github.io/commit/f44dfeb651c9293a864bd638baaaabfc0cb82427
