### PR TITLE
feat: ISO 8601 date format for spotter

### DIFF
--- a/yazi-plugin/preset/plugins/file.lua
+++ b/yazi-plugin/preset/plugins/file.lua
@@ -49,8 +49,8 @@ function M:spot_base(job)
 
 	return {
 		ui.Row({ "Base" }):style(ui.Style():fg("green")),
-		ui.Row { "  Created:", cha.btime and os.date("%Y-%m-%d %H:%M", math.floor(cha.btime)) or "-" },
-		ui.Row { "  Modified:", cha.mtime and os.date("%Y-%m-%d %H:%M", math.floor(cha.mtime)) or "-" },
+		ui.Row { "  Created:", cha.btime and os.date("%Y-%m-%d %H:%M:%S", math.floor(cha.btime)) or "-" },
+		ui.Row { "  Modified:", cha.mtime and os.date("%Y-%m-%d %H:%M:%S", math.floor(cha.mtime)) or "-" },
 		ui.Row { "  Mimetype:", job.mime },
 		ui.Row {},
 


### PR DESCRIPTION
Changed the file creation and modification date display to use the ISO 8601 format (%Y-%m-%d %H:%M) instead of the previous short format (%y/%m/%d H:%M).

## Which issue does this PR resolve?

Resolves #3462 
