### PR TITLE
fix: wl-clipboard pipe bug mitigation

### DIFF
--- a/yazi-widgets/src/clipboard.rs
+++ b/yazi-widgets/src/clipboard.rs
@@ -63,7 +63,7 @@ impl Clipboard {
 		let all = [
 			("pbcopy", &[][..]),
 			("termux-clipboard-set", &[]),
-			("wl-copy", &["-t", "text/plain; charset=utf-8"]),
+			("wl-copy", &["-t", "text/plain"]),
 			("xclip", &["-selection", "clipboard"]),
 			("xsel", &["-ib"]),
 		];


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #3468

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
Fixes https://github.com/bugaevc/wl-clipboard/issues/277
Simply adding mime type fixes piped behavior.
Instead of using plain `wl-copy` -> `wl-copy -t "text/plain"`