### PR TITLE
fix: `ya pkg` fails to write `package.toml` when the config directory does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 - Support VFS for preset previewers that rely on external commands ([#3477])
 
+### Fixed
+
+- `ya pkg` fails to write `package.toml` when the config directory does not exist ([#3482])
+
 ## [v25.12.29]
 
 ### Added
@@ -1571,3 +1575,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3456]: https://github.com/sxyazi/yazi/pull/3456
 [#3467]: https://github.com/sxyazi/yazi/pull/3467
 [#3477]: https://github.com/sxyazi/yazi/pull/3477
+[#3482]: https://github.com/sxyazi/yazi/pull/3482

--- a/yazi-cli/src/package/mod.rs
+++ b/yazi-cli/src/package/mod.rs
@@ -4,13 +4,13 @@ use anyhow::Context;
 use yazi_fs::Xdg;
 
 pub(super) fn init() -> anyhow::Result<()> {
-	let packages_root = Xdg::state_dir().join("packages");
-	std::fs::create_dir_all(&packages_root)
-		.with_context(|| format!("failed to create packages directory: {packages_root:?}"))?;
+	let packages_dir = Xdg::state_dir().join("packages");
+	std::fs::create_dir_all(&packages_dir)
+		.with_context(|| format!("failed to create packages directory: {packages_dir:?}"))?;
 
-	let config_root = Xdg::config_dir();
-	std::fs::create_dir_all(&config_root)
-		.with_context(|| format!("failed to create config directory: {config_root:?}"))?;
+	let config_dir = Xdg::config_dir();
+	std::fs::create_dir_all(&config_dir)
+		.with_context(|| format!("failed to create config directory: {config_dir:?}"))?;
 
 	Ok(())
 }


### PR DESCRIPTION
## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

Create the config directory for Yazi to resolve the issue where `package.toml` cannot be created when the config directory is missing.

```
Failed to write package.toml: No such file or directory (os error 2)
```