### PR TITLE
refactor: make partition heuristic predicate a positive match

### DIFF
--- a/yazi-fs/src/mounts/partition.rs
+++ b/yazi-fs/src/mounts/partition.rs
@@ -14,9 +14,11 @@ pub struct Partition {
 }
 
 impl Partition {
+	// Match mount types that do not reliably emit change notifications, or update directory
+	// metadata on changes, and should be refreshed frequently / heuristically.
 	pub fn heuristic(&self) -> bool {
 		let b: &[u8] = self.fstype.as_ref().map_or(b"", |s| s.as_encoded_bytes());
-		!matches!(b, b"exfat" | b"fuse.rclone")
+		matches!(b, b"exfat" | b"fuse.rclone")
 	}
 
 	#[rustfmt::skip]

--- a/yazi-vfs/src/files.rs
+++ b/yazi-vfs/src/files.rs
@@ -70,7 +70,7 @@ impl VfsFiles for Files {
 		use std::io::ErrorKind;
 		match Cha::from_url(dir).await {
 			Ok(c) if !c.is_dir() => FilesOp::issue_error(dir, ErrorKind::NotADirectory).await,
-			Ok(c) if c.hits(cha) && PARTITIONS.read().heuristic(cha) => {}
+			Ok(c) if c.hits(cha) && !PARTITIONS.read().heuristic(cha) => {}
 			Ok(c) => return Some(c),
 			Err(e) => FilesOp::issue_error(dir, e).await,
 		}


### PR DESCRIPTION
Make the partition "heuristic" predicate a positive match, in line with the "systemic" predicate, and document its expected semantics for future readers. Update the only call site to match.

Related to the NFS - specific investigation at #2500, but will not resolve the issue discussed there.
