### PR TITLE
fix: trust directory stats outside of Linux and macOS

### DIFF
--- a/yazi-fs/src/mounts/partition.rs
+++ b/yazi-fs/src/mounts/partition.rs
@@ -14,8 +14,9 @@ pub struct Partition {
 }
 
 impl Partition {
-    // Match mount types that do not reliably emit change notifications, or do not update directory
-    // metadata on changes, and should be refreshed frequently / heuristically.
+	// Match mount types that do not reliably emit change notifications, or do not
+	// update directory metadata on changes, and should be refreshed frequently /
+	// heuristically.
 	pub fn heuristic(&self) -> bool {
 		let b: &[u8] = self.fstype.as_ref().map_or(b"", |s| s.as_encoded_bytes());
 		matches!(b, b"exfat" | b"fuse.rclone")

--- a/yazi-fs/src/mounts/partitions.rs
+++ b/yazi-fs/src/mounts/partitions.rs
@@ -38,8 +38,8 @@ impl Partitions {
 		}
 		#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 		{
-			// For now, assume other targets update directory stat data correctly & do not need
-			// heuristic polling.
+			// For now, assume other targets update directory stat data correctly & do not
+			// need heuristic polling.
 			false
 		}
 	}


### PR DESCRIPTION
Restore the previous default of trusting directory stat updates to reflect directory changes on platforms other than linux & mac, without checking for mount types.

Also clarify wording in heuristic comment slightly.

## Which issue does this PR resolve?
#3526 