### PR TITLE
EXPERIMENT: Nfs update experiment for #2500

### DIFF
--- a/yazi-fs/src/mounts/partition.rs
+++ b/yazi-fs/src/mounts/partition.rs
@@ -18,7 +18,7 @@ impl Partition {
 	// metadata on changes, and should be refreshed frequently / heuristically.
 	pub fn heuristic(&self) -> bool {
 		let b: &[u8] = self.fstype.as_ref().map_or(b"", |s| s.as_encoded_bytes());
-		matches!(b, b"exfat" | b"fuse.rclone")
+		matches!(b, b"exfat" | b"fuse.rclone" | b"nfs4")
 	}
 
 	#[rustfmt::skip]


### PR DESCRIPTION
See if nfs4 update issues do indeed need to be addressed by heuristic polling.

NOTE: I am not positive this is needed, only putting this up for actual nfs users to test.
For testers: As a manual test, you can also compare `stat <directory>` output before / after directory changes (file creation / removal). If the stat times do not change, then heuristic polling will be needed. If they do change, then the issue will likely be elsewhere.