### PR TITLE
feat: make rg search more convenient

### DIFF
--- a/yazi-actor/src/mgr/peek.rs
+++ b/yazi-actor/src/mgr/peek.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use yazi_macro::succ;
 use yazi_parser::mgr::PeekOpt;
 use yazi_proxy::HIDER;
-use yazi_shared::data::Data;
+use yazi_shared::{data::Data, url::AsUrl};
 
 use crate::{Actor, Ctx};
 
@@ -25,7 +25,8 @@ impl Actor for Peek {
 		let folder = cx.tab().hovered_folder().map(|f| (f.offset, f.cha));
 
 		if !cx.tab().preview.same_url(&hovered.url) {
-			cx.tab_mut().preview.skip = folder.map(|f| f.0).unwrap_or_default();
+			// set matched line on the top of preview window
+			cx.tab_mut().preview.skip = folder.map(|f| f.0).unwrap_or_else(|| hovered.url.as_url().line().map_or(0, |l| l.saturating_sub(1)));
 		}
 		if !cx.tab().preview.same_file(&hovered, &mime) {
 			cx.tab_mut().preview.reset();

--- a/yazi-actor/src/mgr/reveal.rs
+++ b/yazi-actor/src/mgr/reveal.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use yazi_fs::{File, FilesOp};
 use yazi_macro::{act, render, succ};
 use yazi_parser::mgr::RevealOpt;
-use yazi_shared::{data::Data, url::UrlLike};
+use yazi_shared::{data::Data, url::{AsUrl, UrlLike}};
 
 use crate::{Actor, Ctx};
 
@@ -14,6 +14,15 @@ impl Actor for Reveal {
 	const NAME: &str = "reveal";
 
 	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
+		match cx.cwd().is_search() {
+			true => Self::reveal_search(cx, opt),
+			false => Self::reveal_regular(cx, opt),
+		}
+	}
+}
+
+impl Reveal {
+	fn reveal_regular(cx: &mut Ctx, opt: RevealOpt) -> Result<Data> {
 		let Some((parent, child)) = opt.target.pair() else { succ!() };
 
 		// Cd to the parent directory
@@ -33,6 +42,30 @@ impl Actor for Reveal {
 		// Now, we can safely hover over the target
 		act!(mgr:hover, cx, Some(child.into()))?;
 
+		act!(mgr:peek, cx)?;
+		act!(mgr:watch, cx)?;
+		succ!();
+	}
+
+	fn reveal_search(cx: &mut Ctx, opt: RevealOpt) -> Result<Data> {
+		let cwd = cx.cwd().clone();
+		let tab = cx.tab_mut();
+		let pos = tab.current.files.iter().position(|f| f.url == opt.target);
+
+		if let Some(pos) = pos {
+			let delta = pos as isize - tab.current.cursor as isize;
+			tab.current.arrow(delta);
+		} else if !opt.no_dummy {
+			let op = FilesOp::Creating(cwd, vec![File::from_dummy(&opt.target, None)]);
+			tab.current.update_pub(tab.id, op);
+
+			if let Some(pos) = tab.current.files.iter().position(|f| f.url == opt.target) {
+				let delta = pos as isize - tab.current.cursor as isize;
+				tab.current.arrow(delta);
+			}
+		}
+
+		act!(mgr:hover, cx, None)?;
 		act!(mgr:peek, cx)?;
 		act!(mgr:watch, cx)?;
 		succ!();

--- a/yazi-binding/src/macros.rs
+++ b/yazi-binding/src/macros.rs
@@ -238,5 +238,10 @@ macro_rules! impl_file_methods {
 			// TODO: use a cache
 			Ok(yazi_config::THEME.icon.matches(me).map(Icon::from))
 		});
+
+		$methods.add_method("line", |_, me, ()| {
+			use yazi_shared::url::AsUrl;
+			Ok(me.url.as_url().line().map(|v| v as i64))
+		});
 	};
 }

--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -43,6 +43,13 @@ end
 
 function Entity:highlights()
 	local name, p = self._file.name, ui.printable
+
+	local ok, line = pcall(function() return self._file:line() end)
+	if ok and line then
+		local path_str = tostring(self._file.path)
+		name = name .. ":" .. line .. " (" .. path_str .. ")"
+	end
+
 	local highlights = self._file:highlights()
 	if not highlights or #highlights == 0 then
 		return p(name)

--- a/yazi-plugin/src/utils/preview.rs
+++ b/yazi-plugin/src/utils/preview.rs
@@ -18,10 +18,7 @@ impl Utils {
 			let path = lock.url.as_url().unified_path();
 			let inner = match Highlighter::new(path).highlight(lock.skip, area.size()).await {
 				Ok(text) => text,
-				Err(e @ PeekError::Exceed(max)) => return (e.to_string(), max).into_lua_multi(&lua),
-				Err(e @ PeekError::Unexpected(_)) => {
-					return e.to_string().into_lua_multi(&lua);
-				}
+				Err(e) => return e.to_string().into_lua_multi(&lua),
 			};
 
 			lock.data = vec![Renderable::Text(Text {

--- a/yazi-shared/src/scheme/encode.rs
+++ b/yazi-shared/src/scheme/encode.rs
@@ -14,7 +14,7 @@ impl<'a> From<crate::url::Encode<'a>> for Encode<'a> {
 impl<'a> Encode<'a> {
 	#[inline]
 	pub fn domain<'s>(s: &'s str) -> PercentEncode<'s> {
-		const SET: &AsciiSet = &CONTROLS.add(b'/').add(b':');
+		const SET: &AsciiSet = &CONTROLS.add(b'/').add(b':').add(b'#');
 		percent_encode(s.as_bytes(), SET)
 	}
 

--- a/yazi-shared/src/url/url.rs
+++ b/yazi-shared/src/url/url.rs
@@ -87,6 +87,36 @@ impl<'a> Url<'a> {
 	}
 
 	#[inline]
+	pub fn line(self) -> Option<usize> {
+		let Self::Search { domain, .. } = self else { return None };
+		let Some(hash_pos) = domain.find('#') else {
+			return None
+		};
+
+		let frag = &domain[hash_pos + 1..];
+		if let Some(colon_pos) = frag.find(':') {
+			frag[..colon_pos].parse::<usize>().ok()
+		} else {
+			frag.parse::<usize>().ok()
+		}
+	}
+
+	#[inline]
+	pub fn column(self) -> Option<usize> {
+		let Self::Search { domain, .. } = self else { return None };
+		let Some(hash_pos) = domain.find('#') else {
+			return None
+		};
+
+		let frag = &domain[hash_pos + 1..];
+		if let Some(colon_pos) = frag.find(':') {
+			frag[colon_pos + 1..].parse::<usize>().ok()
+		} else {
+			None
+		}
+	}
+
+	#[inline]
 	pub fn has_base(self) -> bool {
 		match self {
 			Self::Regular(loc) => loc.has_base(),


### PR DESCRIPTION
Amazing tool! Try to improve the rg search experience.

## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #3521  

## Rationale of this PR
See the issue for more details.

- URL supports #line:column in domain
  - Added Url::line() and Url::column() methods to parse line/column from search URL fragments (e.g., keyword#123:45)
  - Updated scheme::encode::domain() to include # in the encode set
- Enhanced rg plugin
  - Changed rg args to --line-number --no-heading --column for detailed match positions
  - Added parse_rg_line_column() parser function
  - Search results now include line and column in the URL
- Preview improvements
  - When opening a file with line info, preview automatically scrolls to show the matched line at the top
- Search reveal support
  - Added Reveal::reveal_search() to handle revealing files within search results
- Splatter format support
  - Added %l/%L for line number
  - Added %c/%C for column number
- Lua bindings
  - Added file:line() method to get line number from URL

I changed the reveal logic to account for Search URL.