### PR TITLE
fix: remove fg property from the directory icons

### DIFF
--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -266,20 +266,20 @@ rules = [
 [icon]
 globs = []
 dirs  = [
-	{ name = ".config", text = "", fg = "blue" },
-	{ name = ".git", text = "", fg = "blue" },
-	{ name = ".github", text = "", fg = "blue" },
-	{ name = ".npm", text = "", fg = "blue" },
-	{ name = "Desktop", text = "", fg = "blue" },
-	{ name = "Development", text = "", fg = "blue" },
-	{ name = "Documents", text = "", fg = "blue" },
-	{ name = "Downloads", text = "", fg = "blue" },
-	{ name = "Library", text = "", fg = "blue" },
-	{ name = "Movies", text = "", fg = "blue" },
-	{ name = "Music", text = "", fg = "blue" },
-	{ name = "Pictures", text = "", fg = "blue" },
-	{ name = "Public", text = "", fg = "blue" },
-	{ name = "Videos", text = "", fg = "blue" },
+	{ name = ".config", text = "" },
+	{ name = ".git", text = "" },
+	{ name = ".github", text = "" },
+	{ name = ".npm", text = "" },
+	{ name = "Desktop", text = "" },
+	{ name = "Development", text = "" },
+	{ name = "Documents", text = "" },
+	{ name = "Downloads", text = "" },
+	{ name = "Library", text = "" },
+	{ name = "Movies", text = "" },
+	{ name = "Music", text = "" },
+	{ name = "Pictures", text = "" },
+	{ name = "Public", text = "" },
+	{ name = "Videos", text = "" },
 ]
 files = [
 	{ name = ".babelrc", text = "", fg = "#cbcb41" },
@@ -996,7 +996,7 @@ conds = [
 	{ if = "dummy", text = "" },
 
 	# Fallback
-	{ if = "dir", text = "", fg = "blue" },
+	{ if = "dir", text = "" },
 	{ if = "exec", text = "" },
 	{ if = "!dir", text = "" },
 ]

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -266,20 +266,20 @@ rules = [
 [icon]
 globs = []
 dirs  = [
-	{ name = ".config", text = "", fg = "blue" },
-	{ name = ".git", text = "", fg = "blue" },
-	{ name = ".github", text = "", fg = "blue" },
-	{ name = ".npm", text = "", fg = "blue" },
-	{ name = "Desktop", text = "", fg = "blue" },
-	{ name = "Development", text = "", fg = "blue" },
-	{ name = "Documents", text = "", fg = "blue" },
-	{ name = "Downloads", text = "", fg = "blue" },
-	{ name = "Library", text = "", fg = "blue" },
-	{ name = "Movies", text = "", fg = "blue" },
-	{ name = "Music", text = "", fg = "blue" },
-	{ name = "Pictures", text = "", fg = "blue" },
-	{ name = "Public", text = "", fg = "blue" },
-	{ name = "Videos", text = "", fg = "blue" },
+	{ name = ".config", text = "" },
+	{ name = ".git", text = "" },
+	{ name = ".github", text = "" },
+	{ name = ".npm", text = "" },
+	{ name = "Desktop", text = "" },
+	{ name = "Development", text = "" },
+	{ name = "Documents", text = "" },
+	{ name = "Downloads", text = "" },
+	{ name = "Library", text = "" },
+	{ name = "Movies", text = "" },
+	{ name = "Music", text = "" },
+	{ name = "Pictures", text = "" },
+	{ name = "Public", text = "" },
+	{ name = "Videos", text = "" },
 ]
 files = [
 	{ name = ".babelrc", text = "", fg = "#666620" },
@@ -996,7 +996,7 @@ conds = [
 	{ if = "dummy", text = "" },
 
 	# Fallback
-	{ if = "dir", text = "", fg = "blue" },
+	{ if = "dir", text = "" },
 	{ if = "exec", text = "" },
 	{ if = "!dir", text = "" },
 ]


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #3556

## Rationale of this PR

Revert the added `fg` property added to directories in https://github.com/sxyazi/yazi/commit/41e5717930141c574442ecc53bd4db5f96188d50 which breaks directory icon colours in flavours.