### PR TITLE
fix: remove duplicate categories in the `.desktop` file

### DIFF
--- a/assets/yazi.desktop
+++ b/assets/yazi.desktop
@@ -7,5 +7,5 @@ TryExec=yazi
 Exec=yazi %u
 Type=Application
 MimeType=inode/directory
-Categories=Utility;Core;System;FileTools;FileManager;ConsoleOnly
+Categories=System;FileManager;FileTools;ConsoleOnly
 Keywords=File;Manager;Explorer;Browser;Launcher


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #3601 

## Rationale of this PR

Avoids duplicate of yazi in Desktop categories. 

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
