### PR TITLE
fix: archive extraction fails for target paths with non-ASCII characters on Windows

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
 	"runtime.version": "Lua 5.4",
+	"runtime.special": {
+		"fail": "error"
+	},
 	"workspace.library": ["~/.config/yazi/plugins/types.yazi/"],
 	"diagnostics.disable": ["redefined-local"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ## [Unreleased]
 
+### Fixed
+
+- Archive extraction fails for target paths with non-ASCII characters on Windows ([#3607])
+
 ## [v26.1.22]
 
 ### Added
@@ -1612,3 +1616,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3566]: https://github.com/sxyazi/yazi/pull/3566
 [#3582]: https://github.com/sxyazi/yazi/pull/3582
 [#3594]: https://github.com/sxyazi/yazi/pull/3594
+[#3607]: https://github.com/sxyazi/yazi/pull/3607

--- a/yazi-plugin/preset/plugins/extract.lua
+++ b/yazi-plugin/preset/plugins/extract.lua
@@ -99,17 +99,10 @@ function M:tidy(from, to, tmp)
 		fail("Failed to determine a target for '%s'", from)
 	end
 
-	local move
-	if only then
-		move = fs.rename(outs[1].url, target)
-		if not move then
-			fail('Failed to move "%s"', outs[1].url)
-		end
-	else
-		move = fs.rename(tmp, target)
-		if not move then
-			fail('Failed to move "%s"', tmp)
-		end
+	if only and not fs.rename(outs[1].url, target) then
+		fail('Failed to move "%s" to "%s"', outs[1].url, target)
+	elseif not only and not fs.rename(tmp, target) then
+		fail('Failed to move "%s" to "%s"', tmp, target)
 	end
 	fs.remove("dir", tmp)
 end


### PR DESCRIPTION
- Replace os.rename() with fs.rename() to properly handle UTF-8 characters in file paths on Windows (e.g., José, München)
- Remove unnecessary tostring() conversions as fs.rename() accepts Url objects

Fixes extraction failures when target paths contain non-ASCII characters on Windows systems.

## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #3606 

## Rationale of this PR

### Fix UTF-8 path handling in extract plugin on Windows:
The extract plugin fails to move extracted files when the target path contains non-ASCII characters (e.g., `José`, `München`) on Windows. This is because `os.rename()` doesn't properly handle `UTF-8` encoding on Windows.

### Solution

- Replace os.rename() with fs.rename() which properly handles UTF-8 paths across all platforms
- Remove unnecessary tostring() conversions since fs.rename() accepts Url objects directly

### Testing

- Tested extraction on Windows and Linux with paths containing: á, ñ, ü, José, etc.
- Verified compatibility on Linux
- Tested both single-file and multi-file archive extractions

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->
