### PR TITLE
fix: account for border when calculating message widths

### DIFF
--- a/yazi-core/src/notify/message.rs
+++ b/yazi-core/src/notify/message.rs
@@ -40,7 +40,7 @@ impl Message {
 	pub fn height(&self, width: u16) -> usize {
 		let lines = ratatui::widgets::Paragraph::new(self.content.as_str())
 			.wrap(ratatui::widgets::Wrap { trim: false })
-			.line_count(width);
+			.line_count(width.saturating_sub(NOTIFY_BORDER));
 
 		lines + NOTIFY_BORDER as usize
 	}


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/3614