### PR TITLE
feat: add `sort_dir_by` option for separate directory sorting

### DIFF
--- a/yazi-actor/src/lives/preference.rs
+++ b/yazi-actor/src/lives/preference.rs
@@ -11,7 +11,8 @@ pub(super) struct Preference {
 	v_name:     Option<Value>,
 	v_linemode: Option<Value>,
 
-	v_sort_by: Option<Value>,
+	v_sort_by:     Option<Value>,
+	v_sort_dir_by: Option<Value>,
 }
 
 impl Deref for Preference {
@@ -28,7 +29,8 @@ impl Preference {
 			v_name:     None,
 			v_linemode: None,
 
-			v_sort_by: None,
+			v_sort_by:     None,
+			v_sort_dir_by: None,
 		})
 	}
 }
@@ -46,5 +48,8 @@ impl UserData for Preference {
 		fields.add_field_method_get("sort_reverse", |_, me| Ok(me.sort_reverse));
 		fields.add_field_method_get("sort_dir_first", |_, me| Ok(me.sort_dir_first));
 		fields.add_field_method_get("sort_translit", |_, me| Ok(me.sort_translit));
+		cached_field!(fields, sort_dir_by, |_, me| {
+			Ok(me.sort_dir_by.map(|s| s.to_string()).unwrap_or_default())
+		});
 	}
 }

--- a/yazi-actor/src/mgr/sort.rs
+++ b/yazi-actor/src/mgr/sort.rs
@@ -22,6 +22,12 @@ impl Actor for Sort {
 		pref.sort_dir_first = opt.dir_first.unwrap_or(pref.sort_dir_first);
 		pref.sort_sensitive = opt.sensitive.unwrap_or(pref.sort_sensitive);
 		pref.sort_translit = opt.translit.unwrap_or(pref.sort_translit);
+		pref.sort_dir_by = match (opt.by, opt.dir_by) {
+			(_, Some(yazi_fs::SortBy::None)) => None,
+			(_, Some(v)) => Some(v),
+			(Some(_), None) => None,
+			(None, None) => pref.sort_dir_by,
+		};
 
 		let sorter = FilesSorter::from(&*pref);
 		let hovered = cx.hovered().map(|f| f.urn().to_owned());

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -123,6 +123,8 @@ keymap = [
 	{ on = [ ",", "S" ], run = [ "sort size --reverse=yes", "linemode size" ],   desc = "Sort by size (reverse)" },
 	{ on = [ ",", "r" ], run = "sort random --reverse=no",                       desc = "Sort randomly" },
 
+	{ on = [ ",", "d" ], run = [ "sort mtime --reverse=yes --dir-by=natural", "linemode mtime" ], desc = "Sort by modified time, dirs naturally" },
+
 	# Goto
 	{ on = [ "g", "h" ],       run = "cd ~",             desc = "Go home" },
 	{ on = [ "g", "c" ],       run = "cd ~/.config",     desc = "Go ~/.config" },

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -9,6 +9,7 @@ sort_sensitive = false
 sort_reverse 	 = false
 sort_dir_first = true
 sort_translit  = false
+sort_dir_by    = "none"
 linemode       = "none"
 show_hidden    = false
 show_symlink   = true

--- a/yazi-config/src/mgr/mgr.rs
+++ b/yazi-config/src/mgr/mgr.rs
@@ -16,6 +16,7 @@ pub struct Mgr {
 	pub sort_reverse:   SyncCell<bool>,
 	pub sort_dir_first: SyncCell<bool>,
 	pub sort_translit:  SyncCell<bool>,
+	pub sort_dir_by:    SyncCell<SortBy>,
 
 	// Display
 	pub linemode:     String,

--- a/yazi-core/src/tab/preference.rs
+++ b/yazi-core/src/tab/preference.rs
@@ -14,6 +14,7 @@ pub struct Preference {
 	pub sort_reverse:   bool,
 	pub sort_dir_first: bool,
 	pub sort_translit:  bool,
+	pub sort_dir_by:    Option<SortBy>,
 }
 
 impl Default for Preference {
@@ -30,6 +31,10 @@ impl Default for Preference {
 			sort_reverse:   YAZI.mgr.sort_reverse.get(),
 			sort_dir_first: YAZI.mgr.sort_dir_first.get(),
 			sort_translit:  YAZI.mgr.sort_translit.get(),
+			sort_dir_by:    match YAZI.mgr.sort_dir_by.get() {
+				SortBy::None => None,
+				v => Some(v),
+			},
 		}
 	}
 }
@@ -42,6 +47,7 @@ impl From<&Preference> for FilesSorter {
 			reverse:   value.sort_reverse,
 			dir_first: value.sort_dir_first,
 			translit:  value.sort_translit,
+			dir_by:    value.sort_dir_by,
 		}
 	}
 }

--- a/yazi-parser/src/mgr/sort.rs
+++ b/yazi-parser/src/mgr/sort.rs
@@ -10,6 +10,7 @@ pub struct SortOpt {
 	pub dir_first: Option<bool>,
 	pub sensitive: Option<bool>,
 	pub translit:  Option<bool>,
+	pub dir_by:    Option<SortBy>,
 }
 
 impl TryFrom<CmdCow> for SortOpt {
@@ -22,6 +23,7 @@ impl TryFrom<CmdCow> for SortOpt {
 			dir_first: c.get("dir-first").ok(),
 			sensitive: c.get("sensitive").ok(),
 			translit:  c.get("translit").ok(),
+			dir_by:    c.get::<&str>("dir-by").ok().map(str::parse).transpose()?,
 		})
 	}
 }


### PR DESCRIPTION
I want to be able to sort directories in alphabetical order while sorting files by modification time - sorting folders by the latter is confusing, and I frequently want to mess with the last file I changed in a given directory. Right now `sort_by` applies to both, so I added a `sort_dir_by` option that lets directories have their own sort key.

## What it does

When set (and when `sort_dir_first = true`), directories sort by that key independently from files.

```toml
[mgr]
sort_by        = "mtime"
sort_reverse   = true
sort_dir_first = true
sort_dir_by    = "natural"   # dirs alphabetical, files by mtime
```

Also added a `,d` keybinding; a sort mode that combines alphabetical directory sorting with mtime file sorting. All other sort keys (`,m`, `,n`, etc.) clear the dir override and work as before.

## Changes

- `FilesSorter::sort()` partitions into dirs/files when `dir_by` is active, sorts each group separately
- Changing `sort_by` (via `,m` etc.) automatically clears `dir_by` so other modes aren't affected