### PR TITLE
feat: new `marker_symbol` option to specify the symbol used for marking files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - New `fs.access()` API to access the filesystem ([#3668])
 - New `relay-notify-push` DDS event to customize the notification handler ([#3642])
 - New `ind-app-title` DDS event to customize the app title ([#3684])
+- New `marker_symbol` option to specify the symbol used for marking files ([#3689])
 - New `fs.unique()` creates a unique file or directory ([#3677])
 - New `download` DDS event fires when remote files are downloaded ([#3687])
 - New `cx.which` API to access the which component state ([#3617])
@@ -1662,3 +1663,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3678]: https://github.com/sxyazi/yazi/pull/3678
 [#3684]: https://github.com/sxyazi/yazi/pull/3684
 [#3687]: https://github.com/sxyazi/yazi/pull/3687
+[#3689]: https://github.com/sxyazi/yazi/pull/3689

--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -41,6 +41,7 @@ marker_copied   = { fg = "lightgreen",  bg = "lightgreen" }
 marker_cut      = { fg = "lightred",    bg = "lightred" }
 marker_marked   = { fg = "lightcyan",   bg = "lightcyan" }
 marker_selected = { fg = "lightyellow", bg = "lightyellow" }
+marker_symbol   = "│"
 
 # Count
 count_copied   = { fg = "white", bg = "green" }

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -41,6 +41,7 @@ marker_copied   = { fg = "lightgreen",  bg = "lightgreen" }
 marker_cut      = { fg = "lightred",    bg = "lightred" }
 marker_marked   = { fg = "lightcyan",   bg = "lightcyan" }
 marker_selected = { fg = "lightyellow", bg = "lightyellow" }
+marker_symbol   = "│"
 
 # Count
 count_copied   = { fg = "white", bg = "green" }

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -55,6 +55,7 @@ pub struct Mgr {
 	pub marker_cut:      Style,
 	pub marker_marked:   Style,
 	pub marker_selected: Style,
+	pub marker_symbol:   String,
 
 	// Count
 	pub count_copied:   Style,

--- a/yazi-plugin/preset/components/marker.lua
+++ b/yazi-plugin/preset/components/marker.lua
@@ -29,7 +29,7 @@ function Marker:redraw()
 			w = 1,
 			h = math.min(1 + last[2] - last[1], self._area.y + self._area.h - y),
 		}
-		elements[#elements + 1] = ui.Bar(ui.Edge.LEFT):area(rect):style(last[3])
+		elements[#elements + 1] = ui.Bar(ui.Edge.LEFT):area(rect):style(last[3]):symbol(th.mgr.marker_symbol)
 	end
 
 	local last = { 0, 0, nil } -- start, end, style

--- a/yazi-plugin/preset/components/tab.lua
+++ b/yazi-plugin/preset/components/tab.lua
@@ -22,11 +22,12 @@ function Tab:layout()
 end
 
 function Tab:build()
+	local c = self._chunks
 	self._children = {
-		Parent:new(self._chunks[1]:pad(ui.Pad.x(1)), self._tab),
-		Current:new(self._chunks[2], self._tab),
-		Preview:new(self._chunks[3]:pad(ui.Pad.x(1)), self._tab),
-		Rail:new(self._chunks, self._tab),
+		Parent:new(c[1]:pad(ui.Pad.x(1)), self._tab),
+		Current:new(c[2]:pad(ui.Pad(0, c[3].w > 0 and 0 or 1, 0, c[1].w > 0 and 0 or 1)), self._tab),
+		Preview:new(c[3]:pad(ui.Pad.x(1)), self._tab),
+		Rail:new(c, self._tab),
 	}
 end
 

--- a/yazi-plugin/src/theme/theme.rs
+++ b/yazi-plugin/src/theme/theme.rs
@@ -60,6 +60,7 @@ fn mgr() -> Composer<ComposerGet, ComposerSet> {
 			b"marker_cut" => Style::from(m.marker_cut).into_lua(lua),
 			b"marker_marked" => Style::from(m.marker_marked).into_lua(lua),
 			b"marker_selected" => Style::from(m.marker_selected).into_lua(lua),
+			b"marker_symbol" => lua.create_string(&m.marker_symbol)?.into_lua(lua),
 
 			b"count_copied" => Style::from(m.count_copied).into_lua(lua),
 			b"count_cut" => Style::from(m.count_cut).into_lua(lua),


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/3409

Closes https://github.com/sxyazi/yazi/issues/3409

This PR also fixes https://github.com/sxyazi/yazi/issues/3409#issuecomment-3720049435 when there's only the middle pane (CWD) enabled, the marker and the file line get way too tight.

## Example

```toml
# theme.toml
[mgr]
marker_selected = { fg = "yellow" }
marker_symbol   = "+"
```

![zu8tVQh5](https://github.com/user-attachments/assets/da8b4739-d208-495d-a57b-7ae758a283a5)
