### PR TITLE
fix: reset cursor to default in fallback

### DIFF
--- a/yazi-shim/src/crossterm/restore_cursor.rs
+++ b/yazi-shim/src/crossterm/restore_cursor.rs
@@ -18,9 +18,7 @@ impl crossterm::Command for RestoreCursor {
 			2 if !blink => SetCursorStyle::SteadyUnderScore.write_ansi(f)?,
 			3 if blink => SetCursorStyle::BlinkingBar.write_ansi(f)?,
 			3 if !blink => SetCursorStyle::SteadyBar.write_ansi(f)?,
-			_ if blink => SetCursorStyle::DefaultUserShape.write_ansi(f)?,
-			_ if !blink => SetCursorStyle::SteadyBlock.write_ansi(f)?,
-			_ => unreachable!(),
+			_ => SetCursorStyle::DefaultUserShape.write_ansi(f)?,
 		})
 	}
 


### PR DESCRIPTION
## Which issue does this PR resolve?

On Konsole, yazi incorrectly set my cursor to "block" at exit, while my previous cursor is "vertical bar + blink".

## Rationale of this PR

It seems like Konsole doesn't support both `"\x1bP$q q\x1b\\"` (request cursor shape) and `"\x1b[?12$p"` (request cursor blink status). But it supports `"\x1b[0 q"` (reset cursor to default). In this case, use `"\x1b[0 q"` as fallback seems to be more reasonable.
