### PR TITLE
feat: new `ind-hidden` and `key-hidden` DDS events to change hidden status in Lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - New `fs.access()` API to access the filesystem ([#3668])
 - New `relay-notify-push` DDS event to customize the notification handler ([#3642])
 - New `ind-app-title` DDS event to customize the app title ([#3684])
+- New `ind-hidden` and `key-hidden` DDS events to change hidden status in Lua ([#3748])
 - New `marker_symbol` option to specify the symbol used for marking files ([#3689])
 - New `fs.unique()` creates a unique file or directory ([#3677])
 - New `download` DDS event fires when remote files are downloaded ([#3687])
@@ -1678,3 +1679,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3728]: https://github.com/sxyazi/yazi/pull/3728
 [#3733]: https://github.com/sxyazi/yazi/pull/3733
 [#3744]: https://github.com/sxyazi/yazi/pull/3744
+[#3748]: https://github.com/sxyazi/yazi/pull/3748

--- a/yazi-actor/src/mgr/cd.rs
+++ b/yazi-actor/src/mgr/cd.rs
@@ -50,7 +50,6 @@ impl Actor for Cd {
 
 		err!(Pubsub::pub_after_cd(tab.id, tab.cwd()));
 		act!(mgr:displace, cx)?;
-		cx.source = yazi_shared::Source::Ind;
 		act!(mgr:hidden, cx)?;
 		act!(mgr:sort, cx).ok();
 		act!(mgr:hover, cx)?;

--- a/yazi-actor/src/mgr/cd.rs
+++ b/yazi-actor/src/mgr/cd.rs
@@ -50,6 +50,7 @@ impl Actor for Cd {
 
 		err!(Pubsub::pub_after_cd(tab.id, tab.cwd()));
 		act!(mgr:displace, cx)?;
+		cx.source = yazi_shared::Source::Ind;
 		act!(mgr:hidden, cx)?;
 		act!(mgr:sort, cx).ok();
 		act!(mgr:hover, cx)?;

--- a/yazi-actor/src/mgr/hidden.rs
+++ b/yazi-actor/src/mgr/hidden.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use yazi_core::tab::Folder;
+use yazi_dds::spark::SparkKind;
 use yazi_fs::FolderStage;
 use yazi_macro::{act, render, render_and, succ};
 use yazi_parser::mgr::HiddenOpt;
-use yazi_shared::data::Data;
+use yazi_shared::{Source, data::Data};
 
 use crate::{Actor, Ctx};
 
@@ -49,5 +50,13 @@ impl Actor for Hidden {
 		}
 
 		succ!()
+	}
+
+	fn hook(cx: &Ctx, _: &Self::Options) -> Option<SparkKind> {
+		match cx.source() {
+			Source::Ind => Some(SparkKind::IndHidden),
+			Source::Key => Some(SparkKind::KeyHidden),
+			_ => None,
+		}
 	}
 }

--- a/yazi-dds/src/spark/kind.rs
+++ b/yazi-dds/src/spark/kind.rs
@@ -5,6 +5,9 @@ pub enum SparkKind {
 	// app:title
 	IndAppTitle,
 
+	// mgr:hidden
+	KeyHidden,
+	IndHidden,
 	// mgr:sort
 	KeySort,
 	IndSort,
@@ -27,6 +30,9 @@ impl AsRef<str> for SparkKind {
 			// app:title
 			Self::IndAppTitle => "ind-app-title",
 
+			// mgr:hidden
+			Self::KeyHidden => "key-hidden",
+			Self::IndHidden => "ind-hidden",
 			// mgr:sort
 			Self::KeySort => "key-sort",
 			Self::IndSort => "ind-sort",

--- a/yazi-dds/src/spark/spark.rs
+++ b/yazi-dds/src/spark/spark.rs
@@ -161,6 +161,9 @@ impl<'a> Spark<'a> {
 			// app:title
 			IndAppTitle => Self::AppTitle(<_>::from_lua(value, lua)?),
 
+			// mgr:hidden
+			KeyHidden => Self::Hidden(<_>::from_lua(value, lua)?),
+			IndHidden => Self::Hidden(<_>::from_lua(value, lua)?),
 			// mgr:sort
 			KeySort => Self::Sort(<_>::from_lua(value, lua)?),
 			IndSort => Self::Sort(<_>::from_lua(value, lua)?),

--- a/yazi-parser/src/mgr/hidden.rs
+++ b/yazi-parser/src/mgr/hidden.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
-use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use mlua::{FromLua, IntoLua, Lua, LuaSerdeExt, Value};
 use serde::{Deserialize, Serialize};
+use yazi_binding::SER_OPT;
 use yazi_shared::event::ActionCow;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct HiddenOpt {
 	pub state: HiddenOptState,
 }
@@ -18,11 +19,11 @@ impl TryFrom<ActionCow> for HiddenOpt {
 }
 
 impl FromLua for HiddenOpt {
-	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
+	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> { lua.from_value(value) }
 }
 
 impl IntoLua for HiddenOpt {
-	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> { lua.to_value_with(&self, SER_OPT) }
 }
 
 // --- State


### PR DESCRIPTION
## Which issue does this PR resolve?

This PR introduces preflight hooks for the `hidden` command, similar to the existing `ind-sort` implementation.

## Rationale of this PR

Currently, dynamic visibility rules (e.g., "hide hidden files only in the Home directory") must rely on subscribing to the `cd` event and then reactively emitting a `hidden` command.

```lua
-- ~/.config/yazi/plugins/folder-rules.yazi/main.lua
local function setup()
	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
	ps.sub("cd", function(opt)
		local cwd = cx.active.current.cwd
		if tostring(cwd.path) == home then
			ya.emit("hidden", { "hide" })
		else
			ya.emit("hidden", { "show" })
		end
	end)
end

return { setup = setup }
```

This approach is reactive rather than proactive. Yazi first renders the directory with the old hidden state and then re-renders it after the Lua script emits the new command, leading to a visible "flicker" of hidden files.

By adding `ind-hidden` and `key-hidden` preflight hooks, Lua plugins are allowed to intercept and modify the hidden command's parameters before execution. This enables atomic rendering, where the directory is displayed with the correct visibility state from the very first frame.

```lua
-- ~/.config/yazi/plugins/folder-rules.yazi/main.lua
local function setup()
	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
	ps.sub("ind-hidden", function(opt)
		local cwd = cx.active.current.cwd
		if tostring(cwd.path) == home then
			opt.state = "hide"
		else
			opt.state = "show"
		end
		return opt
	end)
end

return { setup = setup }
```

## Changes
- `yazi-dds`: Added `KeyHidden` and `IndHidden` variants to `SparkKind`.
- `yazi-actor`: Implemented the `hook` method for the `Hidden` actor and ensured `cd` sets the source to `Ind` before calling `hidden`.
- `yazi-parser`: Added `Serialize`/`Deserialize` and Lua conversion support for `HiddenOpt` to allow parameter passing between Rust and Lua.
