### PR TITLE
feat: link to the quick-start in `yazi --help` where lists all common keybinds

### DIFF
--- a/yazi-actor/src/mgr/cd.rs
+++ b/yazi-actor/src/mgr/cd.rs
@@ -50,7 +50,7 @@ impl Actor for Cd {
 
 		err!(Pubsub::pub_after_cd(tab.id, tab.cwd()));
 		act!(mgr:displace, cx)?;
-		act!(mgr:hidden, cx)?;
+		act!(mgr:hidden, cx).ok();
 		act!(mgr:sort, cx).ok();
 		act!(mgr:hover, cx)?;
 		act!(mgr:refresh, cx)?;

--- a/yazi-actor/src/mgr/update_files.rs
+++ b/yazi-actor/src/mgr/update_files.rs
@@ -25,7 +25,7 @@ impl Actor for UpdateFiles {
 		}
 
 		render!(cx.mgr.yanked.catchup_revision(false));
-		act!(mgr:hidden, cx)?;
+		act!(mgr:hidden, cx).ok();
 		act!(mgr:sort, cx).ok();
 
 		if revision != cx.current().files.revision {

--- a/yazi-boot/src/args.rs
+++ b/yazi-boot/src/args.rs
@@ -5,6 +5,7 @@ use yazi_shared::{Id, url::UrlBuf};
 
 #[derive(Debug, Default, Parser)]
 #[command(name = "yazi")]
+#[command(after_help = "See https://yazi-rs.github.io/docs/quick-start for a quick starter.")]
 pub struct Args {
 	/// Set the current working entry
 	#[arg(index = 1, num_args = 1..=9)]

--- a/yazi-plugin/preset/plugins/multi.lua
+++ b/yazi-plugin/preset/plugins/multi.lua
@@ -39,8 +39,8 @@ function M:spot_multi(job, comp)
 
 	local rows = {
 		ui.Row({ "Multi" }):style(ui.Style():fg("green")),
-		ui.Row { "  Count:", string.format("%d selected", #self.selected) },
 		ui.Row { "  Size:", ya.readable_size(self.sum) .. (comp and "" or " (?)") },
+		ui.Row { "  Count:", string.format("%d selected", #self.selected) },
 	}
 
 	ya.spot_table(


### PR DESCRIPTION
An implementation of the feature request: #3753

Closes #3753