### PR TITLE
feat(bulk_rename): added --no-prompt opt

### DIFF
--- a/yazi-actor/src/mgr/bulk_rename.rs
+++ b/yazi-actor/src/mgr/bulk_rename.rs
@@ -3,14 +3,14 @@ use std::{hash::Hash, io::{Read, Write}, ops::Deref, path::Path};
 use anyhow::{Result, anyhow};
 use crossterm::{execute, style::Print};
 use hashbrown::HashMap;
-use scopeguard::defer;
 use tokio::io::AsyncWriteExt;
+use scopeguard::defer;
 use yazi_binding::Permit;
 use yazi_config::{YAZI, opener::OpenerRule};
 use yazi_dds::Pubsub;
 use yazi_fs::{File, FilesOp, Splatter, max_common_root, path::skip_url, provider::{FileBuilder, Provider, local::{Gate, Local}}};
 use yazi_macro::{err, succ};
-use yazi_parser::VoidOpt;
+use yazi_parser::mgr::BulkRenameOpt;
 use yazi_proxy::{AppProxy, NotifyProxy, TasksProxy};
 use yazi_shared::{data::Data, path::PathDyn, strand::{AsStrand, AsStrandJoin, Strand, StrandBuf, StrandLike}, terminal_clear, url::{AsUrl, UrlBuf, UrlCow, UrlLike}};
 use yazi_term::YIELD_TO_SUBPROCESS;
@@ -23,11 +23,11 @@ use crate::{Actor, Ctx};
 pub struct BulkRename;
 
 impl Actor for BulkRename {
-	type Options = VoidOpt;
+	type Options = BulkRenameOpt;
 
 	const NAME: &str = "bulk_rename";
 
-	fn act(cx: &mut Ctx, _: Self::Options) -> Result<Data> {
+	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
 		let Some(opener) = Self::opener() else {
 			succ!(NotifyProxy::push_warn("Bulk rename", "No text opener found"));
 		};
@@ -79,7 +79,7 @@ impl Actor for BulkRename {
 				.map(|(i, s)| Tuple::new(i, s))
 				.collect();
 
-			Self::r#do(root, old, new, selected).await
+			Self::r#do(root, old, new, selected, opt.no_prompt).await
 		});
 		succ!();
 	}
@@ -91,6 +91,7 @@ impl BulkRename {
 		old: Vec<Tuple>,
 		new: Vec<Tuple>,
 		selected: Vec<UrlBuf>,
+		no_prompt: bool,
 	) -> Result<()> {
 		terminal_clear(TTY.writer())?;
 		if old.len() != new.len() {
@@ -108,19 +109,18 @@ impl BulkRename {
 			return Ok(());
 		}
 
-		{
+		if !no_prompt {
 			let mut w = TTY.lockout();
 			for (old, new) in &todo {
 				writeln!(w, "{} -> {}", old.display(), new.display())?;
 			}
 			write!(w, "Continue to rename? (y/N): ")?;
 			w.flush()?;
-		}
-
-		let mut buf = [0; 10];
-		_ = TTY.reader().read(&mut buf)?;
-		if buf[0] != b'y' && buf[0] != b'Y' {
-			return Ok(());
+			let mut buf = [0; 10];
+			_ = TTY.reader().read(&mut buf)?;
+			if buf[0] != b'y' && buf[0] != b'Y' {
+				return Ok(());
+			}
 		}
 
 		let permit = WATCHER.acquire().await.unwrap();

--- a/yazi-dds/src/spark/spark.rs
+++ b/yazi-dds/src/spark/spark.rs
@@ -26,7 +26,7 @@ pub enum Spark<'a> {
 	// Mgr
 	Arrow(yazi_parser::ArrowOpt),
 	Back(yazi_parser::VoidOpt),
-	BulkRename(yazi_parser::VoidOpt),
+	BulkRename(yazi_parser::mgr::BulkRenameOpt),
 	Cd(yazi_parser::mgr::CdOpt),
 	Close(yazi_parser::mgr::CloseOpt),
 	Copy(yazi_parser::mgr::CopyOpt),
@@ -341,7 +341,6 @@ try_from_spark!(
 	app:bootstrap,
 	app:focus,
 	mgr:back,
-	mgr:bulk_rename,
 	mgr:enter,
 	mgr:escape_filter,
 	mgr:escape_find,
@@ -378,6 +377,7 @@ try_from_spark!(yazi_parser::confirm::ShowOpt, confirm:show);
 try_from_spark!(yazi_parser::help::ToggleOpt, help:toggle);
 try_from_spark!(yazi_parser::input::CloseOpt, input:close);
 try_from_spark!(yazi_widgets::input::InputOpt, input:show);
+try_from_spark!(yazi_parser::mgr::BulkRenameOpt, mgr:bulk_rename);
 try_from_spark!(yazi_parser::mgr::CdOpt, mgr:cd);
 try_from_spark!(yazi_parser::mgr::CloseOpt, mgr:close);
 try_from_spark!(yazi_parser::mgr::CopyOpt, mgr:copy);

--- a/yazi-parser/src/mgr/bulk_rename.rs
+++ b/yazi-parser/src/mgr/bulk_rename.rs
@@ -1,0 +1,25 @@
+use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use yazi_shared::event::ActionCow;
+
+#[derive(Debug, Default)]
+pub struct BulkRenameOpt {
+	pub no_prompt: bool,
+}
+
+impl From<ActionCow> for BulkRenameOpt {
+	fn from(a: ActionCow) -> Self {
+		Self { no_prompt: a.bool("no-prompt") }
+	}
+}
+
+impl FromLua for BulkRenameOpt {
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> {
+		Err("unsupported".into_lua_err())
+	}
+}
+
+impl IntoLua for BulkRenameOpt {
+	fn into_lua(self, _: &Lua) -> mlua::Result<Value> {
+		Err("unsupported".into_lua_err())
+	}
+}

--- a/yazi-parser/src/mgr/mod.rs
+++ b/yazi-parser/src/mgr/mod.rs
@@ -1,4 +1,5 @@
 yazi_macro::mod_flat!(
+	bulk_rename
 	cd
 	close
 	copy


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #3755.

## Rationale of this PR

Creates `BulkRenameOpt` with `no-prompt` option that disables bulk rename confirmation prompt.
