### PR TITLE
fix: strip leftover suffix when completing with cursor not at end

### DIFF
--- a/yazi-widgets/src/input/commands/complete.rs
+++ b/yazi-widgets/src/input/commands/complete.rs
@@ -15,6 +15,17 @@ const SEPARATOR: char = std::path::MAIN_SEPARATOR;
 impl Input {
 	pub fn complete(&mut self, opt: CompleteOpt) -> Result<Data> {
 		let (before, after) = self.partition();
+
+		// Strip the remainder of the current path component from `after`, so that
+		// completing when the cursor is in the middle of a word replaces the entire
+		// word instead of appending the completion before the leftover suffix.
+		// e.g. input "/home/user/D|oc" (cursor at |) completing "Documents/" should
+		// yield "/home/user/Documents/", not "/home/user/Documents/oc".
+		let after = match after.find(SEPARATOR) {
+			Some(i) => &after[i..],
+			None => "",
+		};
+
 		let new = if let Some((prefix, _)) = before.rsplit_once(SEPARATOR) {
 			format!("{prefix}/{}{after}", opt.completable()).replace(SEPARATOR, MAIN_SEPARATOR_STR)
 		} else {


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #2943

## Rationale of this PR

When the input cursor is not at the end of the text and a completion is submitted (via `cmp:close --submit` triggered by pressing Enter in the completion menu), the `Input::complete()` method preserves the text after the cursor and appends it to the completed path. This causes the directory change to silently fail because the resulting path is invalid.

### Example

Given input `/home/user/Doc` with cursor positioned after `D` (i.e., `D|oc`):

- **Before fix**: selecting `Documents/` from the completion menu produces `/home/user/Documents/oc`
- **After fix**: selecting `Documents/` correctly produces `/home/user/Documents/`

### Root cause

`Input::complete()` calls `self.partition()` which splits the input value at the cursor position into `(before, after)`. The `before` part is correctly handled — `rsplit_once(SEPARATOR)` extracts the parent prefix and discards the partial word. However, the `after` part (the text to the right of the cursor that belongs to the same path component being completed) was unconditionally appended to the completed name.

### Fix

Before constructing the new value, strip the leading portion of `after` up to the next path separator. This removes the leftover suffix of the word being completed while preserving any subsequent path components (if present).