### PR TITLE
feat: new `bulk_exit` action that customizes the prompt for bulk operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - New `ind-hidden` and `key-hidden` DDS events to change hidden status in Lua ([#3748])
 - New `marker_symbol` option to specify the symbol used for marking files ([#3689])
 - New `--discard` for `ya pkg` that discard local changes made to packages ([#3781])
+- New `bulk_exit` action that customizes the prompt for bulk operations ([#3792])
 - New `fs.unique()` creates a unique file or directory ([#3677])
 - New `download` DDS event fires when remote files are downloaded ([#3687])
 - New `ind-which-activate` DDS event to change the which component behavior ([#3608])
@@ -1688,3 +1689,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3765]: https://github.com/sxyazi/yazi/pull/3765
 [#3780]: https://github.com/sxyazi/yazi/pull/3780
 [#3781]: https://github.com/sxyazi/yazi/pull/3781
+[#3792]: https://github.com/sxyazi/yazi/pull/3792

--- a/yazi-actor/src/mgr/bulk_exit.rs
+++ b/yazi-actor/src/mgr/bulk_exit.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use yazi_macro::succ;
+use yazi_parser::mgr::BulkExitOpt;
+use yazi_shared::data::Data;
+
+use crate::{Actor, Ctx};
+
+pub struct BulkExit;
+
+impl Actor for BulkExit {
+	type Options = BulkExitOpt;
+
+	const NAME: &str = "bulk_exit";
+
+	fn act(cx: &mut Ctx, opt: Self::Options) -> Result<Data> {
+		cx.mgr.batcher.decide(opt.target, opt.accept);
+		succ!();
+	}
+}

--- a/yazi-actor/src/mgr/bulk_rename.rs
+++ b/yazi-actor/src/mgr/bulk_rename.rs
@@ -46,7 +46,6 @@ impl Actor for BulkRename {
 		tokio::spawn(async move {
 			let tmp = YAZI.preview.tmpfile("bulk");
 
-			batcher.prime(&tmp);
 			Gate::default()
 				.write(true)
 				.create_new(true)
@@ -62,6 +61,8 @@ impl Actor for BulkRename {
 					Local::regular(&tmp).remove_file().await
 				});
 			}
+
+			batcher.prime(&tmp);
 			TasksProxy::process_exec(
 				cwd.into(),
 				Splatter::new(&[UrlCow::default(), tmp.as_url().into()]).splat(&opener.run),

--- a/yazi-actor/src/mgr/bulk_rename.rs
+++ b/yazi-actor/src/mgr/bulk_rename.rs
@@ -42,8 +42,11 @@ impl Actor for BulkRename {
 			selected.iter().enumerate().map(|(i, u)| Tuple::new(i, skip_url(u, root))).collect();
 
 		let cwd = cx.cwd().clone();
+		let batcher = cx.core.mgr.batcher.clone();
 		tokio::spawn(async move {
 			let tmp = YAZI.preview.tmpfile("bulk");
+
+			batcher.prime(&tmp);
 			Gate::default()
 				.write(true)
 				.create_new(true)
@@ -54,6 +57,7 @@ impl Actor for BulkRename {
 
 			defer! {
 				let tmp = tmp.clone();
+				batcher.drain(&tmp);
 				tokio::spawn(async move {
 					Local::regular(&tmp).remove_file().await
 				});
@@ -79,7 +83,8 @@ impl Actor for BulkRename {
 				.map(|(i, s)| Tuple::new(i, s))
 				.collect();
 
-			Self::r#do(root, old, new, selected).await
+			let decision = batcher.drain(&tmp);
+			Self::r#do(root, old, new, selected, decision).await
 		});
 		succ!();
 	}
@@ -91,6 +96,7 @@ impl BulkRename {
 		old: Vec<Tuple>,
 		new: Vec<Tuple>,
 		selected: Vec<UrlBuf>,
+		decision: Option<bool>,
 	) -> Result<()> {
 		terminal_clear(TTY.writer())?;
 		if old.len() != new.len() {
@@ -108,18 +114,7 @@ impl BulkRename {
 			return Ok(());
 		}
 
-		{
-			let mut w = TTY.lockout();
-			for (old, new) in &todo {
-				writeln!(w, "{} -> {}", old.display(), new.display())?;
-			}
-			write!(w, "Continue to rename? (y/N): ")?;
-			w.flush()?;
-		}
-
-		let mut buf = [0; 10];
-		_ = TTY.reader().read(&mut buf)?;
-		if buf[0] != b'y' && buf[0] != b'Y' {
+		if !Self::ask_continue(&todo, decision)? {
 			return Ok(());
 		}
 
@@ -163,6 +158,25 @@ impl BulkRename {
 
 	fn replace_url(url: &UrlBuf, take: usize, rep: &StrandBuf) -> Result<UrlBuf> {
 		Ok(url.try_replace(take, PathDyn::with(url.kind(), rep)?)?.into_owned())
+	}
+
+	fn ask_continue(todo: &[(Tuple, Tuple)], decision: Option<bool>) -> Result<bool> {
+		if let Some(decision) = decision {
+			return Ok(decision);
+		}
+
+		{
+			let mut w = TTY.lockout();
+			for (old, new) in todo {
+				writeln!(w, "{} -> {}", old.display(), new.display())?;
+			}
+			write!(w, "Continue to rename? (y/N): ")?;
+			w.flush()?;
+		}
+
+		let mut buf = [0; 10];
+		_ = TTY.reader().read(&mut buf)?;
+		Ok(buf[0] == b'y' || buf[0] == b'Y')
 	}
 
 	async fn output_failed(failed: Vec<(Tuple, Tuple, anyhow::Error)>) -> Result<()> {

--- a/yazi-actor/src/mgr/mod.rs
+++ b/yazi-actor/src/mgr/mod.rs
@@ -1,6 +1,7 @@
 yazi_macro::mod_flat!(
 	arrow
 	back
+	bulk_exit
 	bulk_rename
 	cd
 	close

--- a/yazi-core/src/mgr/batcher.rs
+++ b/yazi-core/src/mgr/batcher.rs
@@ -27,7 +27,7 @@ impl Batcher {
 	{
 		let Some(path) = target.as_url().as_local() else { return };
 		if let Some(value) = self.pending.lock().get_mut(path) {
-			*value = Some(decision);
+			*value = value.or(Some(decision));
 		}
 	}
 }

--- a/yazi-core/src/mgr/batcher.rs
+++ b/yazi-core/src/mgr/batcher.rs
@@ -1,11 +1,12 @@
 use std::{path::{Path, PathBuf}, sync::Arc};
 
+use hashbrown::HashMap;
 use parking_lot::Mutex;
 use yazi_shared::url::AsUrl;
 
 #[derive(Clone, Default)]
 pub struct Batcher {
-	pending: Arc<Mutex<(PathBuf, Option<bool>)>>,
+	pending: Arc<Mutex<HashMap<PathBuf, Option<bool>>>>,
 }
 
 impl Batcher {
@@ -13,26 +14,20 @@ impl Batcher {
 	where
 		T: Into<PathBuf>,
 	{
-		*self.pending.lock() = (target.into(), None);
+		self.pending.lock().insert(target.into(), None);
 	}
 
 	pub fn drain(&self, target: &Path) -> Option<bool> {
-		let mut pending = self.pending.lock();
-		if pending.0 != target {
-			return None;
-		}
-
-		pending.0 = PathBuf::default();
-		pending.1.take()
+		self.pending.lock().remove(target).flatten()
 	}
 
 	pub fn decide<T>(&self, target: T, decision: bool)
 	where
 		T: AsUrl,
 	{
-		let mut pending = self.pending.lock();
-		if target.as_url() == pending.0.as_url() {
-			pending.1 = Some(decision);
+		let Some(path) = target.as_url().as_local() else { return };
+		if let Some(value) = self.pending.lock().get_mut(path) {
+			*value = Some(decision);
 		}
 	}
 }

--- a/yazi-core/src/mgr/batcher.rs
+++ b/yazi-core/src/mgr/batcher.rs
@@ -1,0 +1,38 @@
+use std::{path::{Path, PathBuf}, sync::Arc};
+
+use parking_lot::Mutex;
+use yazi_shared::url::AsUrl;
+
+#[derive(Clone, Default)]
+pub struct Batcher {
+	pending: Arc<Mutex<(PathBuf, Option<bool>)>>,
+}
+
+impl Batcher {
+	pub fn prime<T>(&self, target: T)
+	where
+		T: Into<PathBuf>,
+	{
+		*self.pending.lock() = (target.into(), None);
+	}
+
+	pub fn drain(&self, target: &Path) -> Option<bool> {
+		let mut pending = self.pending.lock();
+		if pending.0 != target {
+			return None;
+		}
+
+		pending.0 = PathBuf::default();
+		pending.1.take()
+	}
+
+	pub fn decide<T>(&self, target: T, decision: bool)
+	where
+		T: AsUrl,
+	{
+		let mut pending = self.pending.lock();
+		if target.as_url() == pending.0.as_url() {
+			pending.1 = Some(decision);
+		}
+	}
+}

--- a/yazi-core/src/mgr/mgr.rs
+++ b/yazi-core/src/mgr/mgr.rs
@@ -7,13 +7,14 @@ use yazi_fs::Splatable;
 use yazi_shared::url::{AsUrl, Url, UrlBuf};
 use yazi_watcher::Watcher;
 
-use super::{Mimetype, Tabs, Yanked};
+use super::{Batcher, Mimetype, Tabs, Yanked};
 use crate::tab::{Folder, Tab};
 
 pub struct Mgr {
 	pub tabs:   Tabs,
 	pub yanked: Yanked,
 
+	pub batcher:  Batcher,
 	pub watcher:  Watcher,
 	pub mimetype: Mimetype,
 }
@@ -24,6 +25,7 @@ impl Mgr {
 			tabs:   Default::default(),
 			yanked: Default::default(),
 
+			batcher:  Default::default(),
 			watcher:  Watcher::serve(),
 			mimetype: Default::default(),
 		}

--- a/yazi-core/src/mgr/mod.rs
+++ b/yazi-core/src/mgr/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(mgr mimetype tabs yanked);
+yazi_macro::mod_flat!(batcher mgr mimetype tabs yanked);

--- a/yazi-dds/src/spark/spark.rs
+++ b/yazi-dds/src/spark/spark.rs
@@ -26,6 +26,7 @@ pub enum Spark<'a> {
 	// Mgr
 	Arrow(yazi_parser::ArrowOpt),
 	Back(yazi_parser::VoidOpt),
+	BulkExit(yazi_parser::mgr::BulkExitOpt),
 	BulkRename(yazi_parser::VoidOpt),
 	Cd(yazi_parser::mgr::CdOpt),
 	Close(yazi_parser::mgr::CloseOpt),
@@ -207,6 +208,7 @@ impl<'a> IntoLua for Spark<'a> {
 			// Mgr
 			Self::Arrow(b) => b.into_lua(lua),
 			Self::Back(b) => b.into_lua(lua),
+			Self::BulkExit(b) => b.into_lua(lua),
 			Self::BulkRename(b) => b.into_lua(lua),
 			Self::Cd(b) => b.into_lua(lua),
 			Self::Close(b) => b.into_lua(lua),
@@ -378,6 +380,7 @@ try_from_spark!(yazi_parser::confirm::ShowOpt, confirm:show);
 try_from_spark!(yazi_parser::help::ToggleOpt, help:toggle);
 try_from_spark!(yazi_parser::input::CloseOpt, input:close);
 try_from_spark!(yazi_widgets::input::InputOpt, input:show);
+try_from_spark!(yazi_parser::mgr::BulkExitOpt, mgr:bulk_exit);
 try_from_spark!(yazi_parser::mgr::CdOpt, mgr:cd);
 try_from_spark!(yazi_parser::mgr::CloseOpt, mgr:close);
 try_from_spark!(yazi_parser::mgr::CopyOpt, mgr:copy);

--- a/yazi-fm/src/executor.rs
+++ b/yazi-fm/src/executor.rs
@@ -124,6 +124,7 @@ impl<'a> Executor<'a> {
 		on!(linemode);
 		on!(search);
 		on!(search_do);
+		on!(bulk_exit);
 		on!(bulk_rename);
 
 		// Filter

--- a/yazi-parser/src/mgr/bulk_exit.rs
+++ b/yazi-parser/src/mgr/bulk_exit.rs
@@ -1,0 +1,29 @@
+use anyhow::bail;
+use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use yazi_shared::{event::ActionCow, url::UrlCow};
+
+#[derive(Debug)]
+pub struct BulkExitOpt {
+	pub target: UrlCow<'static>,
+	pub accept: bool,
+}
+
+impl TryFrom<ActionCow> for BulkExitOpt {
+	type Error = anyhow::Error;
+
+	fn try_from(mut a: ActionCow) -> Result<Self, Self::Error> {
+		let Ok(target) = a.take_first::<UrlCow>() else {
+			bail!("invalid target in BulkExitOpt");
+		};
+
+		Ok(Self { target, accept: a.bool("accept") })
+	}
+}
+
+impl FromLua for BulkExitOpt {
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
+}
+
+impl IntoLua for BulkExitOpt {
+	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+}

--- a/yazi-parser/src/mgr/mod.rs
+++ b/yazi-parser/src/mgr/mod.rs
@@ -1,4 +1,5 @@
 yazi_macro::mod_flat!(
+	bulk_exit
 	cd
 	close
 	copy


### PR DESCRIPTION
With this PR, you can use the new `bulk_exit` action in a [custom bulk rename command](https://yazi-rs.github.io/docs/tips#bulk-editor) to customize the behavior of the prompts for bulk operations.

## Demo1: Always "yes" to "Continue to rename?"

Resolves https://github.com/sxyazi/yazi/issues/3755, resolves https://github.com/sxyazi/yazi/pull/3756

```toml
[[open.prepend_rules]]
url = "bulk-rename.txt"
use = "bulk-rename"

[[opener.bulk-rename]]
block = true
run   = "nvim %s; ya exec bulk_exit %s --accept"
```

## Demo2: `git diff` as the filename differ

Resolves https://github.com/sxyazi/yazi/issues/3775

```toml
[[open.prepend_rules]]
url = "bulk-rename.txt"
use = "bulk-rename"

[[opener.bulk-rename]]
for   = "unix"
block = true
run   = '''
old="$(cat %s1)"
nvim %s

if echo "$old" | git diff --no-index --color=always --word-diff=color --word-diff-regex='[^\\W]' - %s1; then
  ya exec bulk_exit %s
  exit 0  # No changes, just exit
fi

read -r -n 1 -p "Continue to rename? (y/N) " answer
case "$answer" in
  [Yy]) ya exec bulk_exit %s --accept ;;
  *) ya exec bulk_exit %s ;;
esac
exit 0
'''
```

Windows version (untested, translated from the Unix version above by ChatGPT):

<details><summary>Details</summary>

```toml
[[opener.bulk-rename]]
for   = "windows"
block = true
run   = '''
@echo off
setlocal

set "old=%TEMP%\yazi-bulk-rename-%RANDOM%.tmp"
copy /y %s1 "%old%" >nul
nvim %s

git diff --no-index --color=always --word-diff=color --word-diff-regex=[^\W] "%old%" %s1
if not errorlevel 1 (
  ya exec bulk_exit %s
  exit /b 0
)

set /p "answer=Continue to rename? (y/N) "
if /i "%answer%"=="y" (
  ya exec bulk_exit %s --accept
) else (
  ya exec bulk_exit %s
)
exit /b 0
'''
```

</details> 