### PR TITLE
fix: ensure the status bar always has the directory length available

### DIFF
--- a/yazi-plugin/preset/components/status.lua
+++ b/yazi-plugin/preset/components/status.lua
@@ -7,7 +7,7 @@ Status = {
 	_inc = 1000,
 	_left = {
 		{ "mode", id = 1, order = 1000 },
-		{ "size", id = 2, order = 2000 },
+		{ "length", id = 2, order = 2000 },
 		{ "name", id = 3, order = 3000 },
 	},
 	_right = {
@@ -47,9 +47,9 @@ function Status:mode()
 	}
 end
 
-function Status:size()
+function Status:length()
 	local h = self._current.hovered
-	local size = h and (h:size() or h.cha.len) or 0
+	local size = h and h.cha.len or 0
 
 	local style = self:style()
 	return ui.Line {


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/3809

Directories have two attributes: length and size. Length is the space the directory entry itself takes, while size is the total space used by all the files inside the directory.

Length is always available, but there's no API to get a directory's size, which means it requires heavy, time-consuming work and is only done on demand, e.g when you spot a directory.

This PR changes the status bar to always show length:

- Right now the status bar shows a directory's length, then after you spot it shows the size. That's confusing because both just look like "123K", so it's hard to tell which is which, and once you've spotted it you can no longer see the directory's length.
- Directory sizes only show up if the user spots the directory or sorts by size, which triggers the directory size calculation:
  - If you spot the directory the spotter already shows that size info.
  - If you sort by size, the default keybinding (`,s`) automatically switches linemode to size, so you can see sizes for each file.
  - So there's no point in duplicating the size in the status bar.
