### PR TITLE
feat: allow active tab's inner separator to blend with its background

### DIFF
--- a/yazi-plugin/preset/components/tabs.lua
+++ b/yazi-plugin/preset/components/tabs.lua
@@ -26,9 +26,9 @@ function Tabs:redraw()
 		local name = ui.truncate(string.format(" %d %s ", i, cx.tabs[i].name), { max = max })
 		if i == cx.tabs.idx then
 			lines[#lines + 1] = ui.Line {
-				ui.Span(th.tabs.sep_inner.open):style(th.tabs.inactive),
+				ui.Span(th.tabs.sep_inner.open):fg(th.tabs.active:bg()):bg(th.tabs.inactive:bg()),
 				ui.Span(name):style(th.tabs.active),
-				ui.Span(th.tabs.sep_inner.close):style(th.tabs.inactive),
+				ui.Span(th.tabs.sep_inner.close):fg(th.tabs.active:bg()):bg(th.tabs.inactive:bg()),
 			}
 		else
 			lines[#lines + 1] = ui.Line(name):style(th.tabs.inactive)


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #3816

## Rationale of this PR

The tab inner separator now uses the background colors of the active tab and the inactive tab for its colors. So it can blend with them regardless of the tabs` text color.
