### PR TITLE
fix: avoid ffmpeg no-frame error when seeking with nokey

### DIFF
--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -46,7 +46,7 @@ function M:preload(job)
 	end
 
 	local pic = M.has_pic(meta)
-	local percent = (pic and 0 or 5) + job.skip
+	local percent = (pic and 0 or 10) + job.skip
 	if percent > 95 then
 		ya.emit("peek", { pic and 95 or 90, only_if = job.file.url, upper_bound = true })
 		return false
@@ -58,8 +58,12 @@ function M:preload(job)
 
 	if percent ~= 0 then
 		cmd:arg { "-ss", math.floor(meta.format.duration * percent / 100) }
+    else
+	    cmd:arg { "-skip_frame", "nokey" }
 	end
-	cmd:arg { "-skip_frame", "nokey", "-i", tostring(job.file.path) }
+
+	cmd:arg { "-i", tostring(job.file.path) }
+
 	if percent == 0 then
 		cmd:arg { "-map", "disp:attached_pic" }
 	end

--- a/yazi-plugin/preset/plugins/video.lua
+++ b/yazi-plugin/preset/plugins/video.lua
@@ -58,8 +58,8 @@ function M:preload(job)
 
 	if percent ~= 0 then
 		cmd:arg { "-ss", math.floor(meta.format.duration * percent / 100) }
-    else
-	    cmd:arg { "-skip_frame", "nokey" }
+	else
+		cmd:arg { "-skip_frame", "nokey" }
 	end
 
 	cmd:arg { "-i", tostring(job.file.path) }


### PR DESCRIPTION
## Problem
Using -ss with -skip_frame nokey sometimes causes:
"No filtered frames for output stream"

## Cause
Seeking may land on non-keyframe → nokey skips all frames ("No more keyframes available" err)

## Fix
- disable skip_frame, nokey when seeking

## Result
Stable frame extraction without empty output