### PR TITLE
use kitty image protocol for Rio terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Yazi is currently in heavy development, expect breaking changes.
 | [Warp](https://www.warp.dev) (macOS/Linux only)                              | [Inline images protocol][iip]          | ✅ Built-in                              |
 | [Tabby](https://github.com/Eugeny/tabby)                                     | [Inline images protocol][iip]          | ✅ Built-in                              |
 | [VSCode](https://github.com/microsoft/vscode)                                | [Inline images protocol][iip]          | ✅ Built-in                              |
-| [Rio](https://github.com/raphamorim/rio)                                     | [Inline images protocol][iip]          | ❌ Rio renders images at incorrect sizes |
+| [Rio](https://github.com/raphamorim/rio)                                     | [Kitty unicode placeholders][kgp]      | ✅ Built-in                              |
 | [Black Box](https://gitlab.gnome.org/raggesilver/blackbox)                   | [Sixel graphics format][sixel]         | ✅ Built-in                              |
 | [Bobcat](https://github.com/ismail-yilmaz/Bobcat)                            | [Inline images protocol][iip]          | ✅ Built-in                              |
 | X11 / Wayland                                                                | Window system protocol                 | ☑️ [Überzug++][ueberzug] required        |

--- a/yazi-adapter/src/adapters.rs
+++ b/yazi-adapter/src/adapters.rs
@@ -33,7 +33,7 @@ impl From<yazi_emulator::Brand> for Adapters {
 			B::Ghostty => vec![A::Kgp],
 			B::Microsoft => vec![A::Sixel],
 			B::Warp => vec![A::Iip, A::KgpOld],
-			B::Rio => vec![A::Iip, A::Sixel],
+			B::Rio => vec![A::Kgp],
 			B::BlackBox => vec![A::Sixel],
 			B::VSCode => vec![A::Iip, A::Sixel],
 			B::Tabby => vec![A::Iip, A::Sixel],


### PR DESCRIPTION
<img width="912" height="602" alt="Screenshot 2026-04-11 at 09 30 52" src="https://github.com/user-attachments/assets/821fbb58-6f87-4ac2-a957-e567cd868ee1" />
