### PR TITLE
fix: use cspell package in devShell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,7 +2,7 @@
   mkShell,
   yazi,
   toolchain,
-  nodePackages,
+  cspell,
   yazi-unwrapped,
 }:
 
@@ -16,7 +16,7 @@ mkShell {
         "clippy"
       ];
     })
-    nodePackages.cspell
+    cspell
   ];
 
   inputsFrom = [ yazi-unwrapped ];


### PR DESCRIPTION
## Rationale of this PR

`nix develop` is currently broken with the nixpkgs revision pinned in `flake.lock` because the devShell still uses `nodePackages.cspell`.
This follows upstream nixpkgs changes: `nodePackages` was dropped in NixOS/nixpkgs#496365, and `cspell` was migrated out of `nodePackages` in NixOS/nixpkgs@f3fa5ff106d9b6b7a48a5bdb0348155a17e3f088. Switching to the top-level `cspell` package restores the devShell.