### PR TITLE
docs: rename `id` of the fetcher rule to `group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Make `ui.Style` immutable ([#3862])
 - Remove `title_format` in favor of new `ind-app-title` DDS event for flexible title customization ([#3684])
 - Remove `micro_workers` and `macro_workers` in favor of finer control over concurrent workers ([#3661])
-- Rename `id` of the fetcher rule to `group`
+- Rename `id` of the fetcher rule to `group` ([#3943])
 
 ### Deprecated
 
@@ -1715,3 +1715,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3901]: https://github.com/sxyazi/yazi/pull/3901
 [#3906]: https://github.com/sxyazi/yazi/pull/3906
 [#3934]: https://github.com/sxyazi/yazi/pull/3934
+[#3943]: https://github.com/sxyazi/yazi/pull/3943

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Make `ui.Style` immutable ([#3862])
 - Remove `title_format` in favor of new `ind-app-title` DDS event for flexible title customization ([#3684])
 - Remove `micro_workers` and `macro_workers` in favor of finer control over concurrent workers ([#3661])
+- Rename `id` of the fetcher rule to `group`
 
 ### Deprecated
 


### PR DESCRIPTION
Resolves https://github.com/sxyazi/yazi/discussions/3942

The fetcher is still [experimental and subject to change](https://yazi-rs.github.io/docs/configuration/yazi/#plugin.fetchers), but since there are a few known plugins that depend on it already, this PR makes an exception and adds it to the changelog so the change is easier to spot.