### PR TITLE
fix: keep repeated `!` negations in a condition right-associative

### DIFF
--- a/yazi-shared/src/condition.rs
+++ b/yazi-shared/src/condition.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{cmp::Ordering, str::FromStr};
 
 use anyhow::bail;
 use serde_with::DeserializeFromStr;
@@ -33,13 +33,24 @@ impl ConditionOp {
 		}
 	}
 
-	#[inline]
-	pub fn prec(&self) -> u8 {
+	fn prec(&self) -> u8 {
 		match self {
 			Self::Or => 1,
 			Self::And => 2,
 			Self::Not => 3,
 			_ => 0,
+		}
+	}
+}
+
+impl PartialOrd for ConditionOp {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		use Ordering::*;
+
+		match self.prec().cmp(&other.prec()) {
+			// Keep repeated `!` right-associative by making `! >= !` false.
+			Equal if matches!((self, other), (Self::Not, Self::Not)) => None,
+			ordering => Some(ordering),
 		}
 	}
 }
@@ -72,10 +83,7 @@ impl Condition {
 			let op = ConditionOp::new(token);
 			match op {
 				ConditionOp::Or | ConditionOp::And | ConditionOp::Not => {
-					while matches!(
-						stack.last(),
-						Some(last) if last.prec() > op.prec() || (op != ConditionOp::Not && last.prec() == op.prec())
-					) {
+					while matches!(stack.last(), Some(last) if last >= &op) {
 						output.push(stack.pop().unwrap());
 					}
 					stack.push(op);
@@ -139,13 +147,13 @@ mod tests {
 
 	#[test]
 	fn test_condition_not() -> anyhow::Result<()> {
+		let cond: Condition = "!dir".parse()?;
+		assert!(!cond.eval(|s| s == "dir").unwrap());
+		assert!(cond.eval(|_| false).unwrap());
+
 		let cond: Condition = "!!dir".parse()?;
 		assert!(cond.eval(|s| s == "dir").unwrap());
 		assert!(!cond.eval(|_| false).unwrap());
-
-		let cond: Condition = "!!!dir".parse()?;
-		assert!(!cond.eval(|s| s == "dir").unwrap());
-		assert!(cond.eval(|_| false).unwrap());
 
 		Ok(())
 	}

--- a/yazi-shared/src/condition.rs
+++ b/yazi-shared/src/condition.rs
@@ -72,7 +72,10 @@ impl Condition {
 			let op = ConditionOp::new(token);
 			match op {
 				ConditionOp::Or | ConditionOp::And | ConditionOp::Not => {
-					while matches!(stack.last(), Some(last) if last.prec() >= op.prec()) {
+					while matches!(
+						stack.last(),
+						Some(last) if last.prec() > op.prec() || (op != ConditionOp::Not && last.prec() == op.prec())
+					) {
 						output.push(stack.pop().unwrap());
 					}
 					stack.push(op);
@@ -127,5 +130,23 @@ impl Condition {
 		}
 
 		if stack.len() == 1 { Some(stack[0]) } else { None }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_condition_not() -> anyhow::Result<()> {
+		let cond: Condition = "!!dir".parse()?;
+		assert!(cond.eval(|s| s == "dir").unwrap());
+		assert!(!cond.eval(|_| false).unwrap());
+
+		let cond: Condition = "!!!dir".parse()?;
+		assert!(!cond.eval(|s| s == "dir").unwrap());
+		assert!(cond.eval(|_| false).unwrap());
+
+		Ok(())
 	}
 }


### PR DESCRIPTION
## Which issue does this PR resolve?

No direct issue found. Searched issues/PRs for `!!dir`, `condition parser`, and `theme condition`.

## Rationale of this PR

`!` is unary, so repeated negation should stack right-to-left. On main, parsing `!!dir` errors with `Invalid condition: !!dir`, while `!dir` works. a bit goofy for theme conditions, ngl.

Repro:
- run the included `!!dir` test
- before: `cargo +nightly test -p yazi-shared condition::tests::test_condition_not` fails
- after: it passes

This keeps `&` and `|` left-assoc, and only lets `!` stack properly. tiny fix, no big refactor.