### PR TITLE
fix: reset double-width chars at overlay left edge to prevent border corruption

### DIFF
--- a/yazi-widgets/src/clear.rs
+++ b/yazi-widgets/src/clear.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
-use unicode_width::UnicodeWidthStr;
+use unicode_width::UnicodeWidthChar;
 use yazi_adapter::ADAPTOR;
 
 pub static COLLISION: AtomicBool = AtomicBool::new(false);
@@ -14,13 +14,18 @@ impl Widget for Clear {
 	where
 		Self: Sized,
 	{
-		// Reset any double-width characters just outside the left edge whose
-		// second half would overlap into the cleared area, which would otherwise
-		// obscure the border drawn at area.x.
-		if area.x > 0 {
+		// Reset double-width characters straddling the overlay boundary.
+		//
+		// A wide char (e.g. CJK) just outside the left edge occupies two
+		// columns; its second half falls on the border column, and the
+		// terminal renders the wide char over the border. Invalidating
+		// the owning cell is the correct fix — terminals cannot render
+		// half a wide glyph.
+		if area.x > buf.area.x {
 			let left = area.x - 1;
 			for y in area.top()..area.bottom() {
-				if buf[(left, y)].symbol().width() > 1 {
+				let ch = buf[(left, y)].symbol().chars().next();
+				if ch.is_some_and(|c| c.width().unwrap_or(0) > 1) {
 					buf[(left, y)].reset();
 				}
 			}

--- a/yazi-widgets/src/clear.rs
+++ b/yazi-widgets/src/clear.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
-use unicode_width::UnicodeWidthChar;
+use unicode_width::UnicodeWidthStr;
 use yazi_adapter::ADAPTOR;
 
 pub static COLLISION: AtomicBool = AtomicBool::new(false);
@@ -24,8 +24,7 @@ impl Widget for Clear {
 		if area.x > buf.area.x {
 			let left = area.x - 1;
 			for y in area.top()..area.bottom() {
-				let ch = buf[(left, y)].symbol().chars().next();
-				if ch.is_some_and(|c| c.width().unwrap_or(0) > 1) {
+				if buf[(left, y)].symbol().width() > 1 {
 					buf[(left, y)].reset();
 				}
 			}

--- a/yazi-widgets/src/clear.rs
+++ b/yazi-widgets/src/clear.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
+use unicode_width::UnicodeWidthStr;
 use yazi_adapter::ADAPTOR;
 
 pub static COLLISION: AtomicBool = AtomicBool::new(false);
@@ -13,6 +14,18 @@ impl Widget for Clear {
 	where
 		Self: Sized,
 	{
+		// Reset any double-width characters just outside the left edge whose
+		// second half would overlap into the cleared area, which would otherwise
+		// obscure the border drawn at area.x.
+		if area.x > 0 {
+			let left = area.x - 1;
+			for y in area.top()..area.bottom() {
+				if buf[(left, y)].symbol().width() > 1 {
+					buf[(left, y)].reset();
+				}
+			}
+		}
+
 		ratatui::widgets::Clear.render(area, buf);
 
 		let Some(r) = ADAPTOR.get().shown_load().and_then(|r| overlap(area, r)) else {


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/3947

When an overlay (input box, task manager) lands on top of a CJK/double-width character, the wide char's second column falls on the border column. The terminal renders the full wide glyph over the border, breaking the left edge.

The fix resets the cell immediately left of the overlay area when it holds a wide character. This is the standard ratatui approach -- terminals cannot render half a wide glyph, so invalidating the owning cell is correct.

Repro from the issue: create directories with odd-count ASCII prefix + CJK chars, press `f` or `w` to open an overlay, observe the left border corruption. After this fix the border renders cleanly.