### PR TITLE
fix: restrict preview cache directory permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -421,7 +421,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -440,7 +440,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
  "cipher",
 ]
@@ -608,12 +608,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
  "zeroize",
 ]
@@ -749,12 +749,6 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -914,19 +908,19 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "typenum",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
@@ -956,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -1118,7 +1112,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "const-oid 0.10.2",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1202,8 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
 ]
 
 [[package]]
@@ -1213,8 +1206,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "const-oid",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1236,7 +1229,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1309,7 +1302,7 @@ checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "digest 0.11.3",
  "hkdf",
  "hybrid-array",
@@ -1386,7 +1379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1638,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1652,7 +1645,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
  "rustversion",
  "typenum",
 ]
@@ -1850,7 +1843,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1972,7 +1965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding 0.3.3",
- "generic-array 0.14.7",
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -2091,7 +2084,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
 ]
 
@@ -2525,7 +2518,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2540,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2756,18 +2749,19 @@ dependencies = [
 
 [[package]]
 name = "pageant"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
 dependencies = [
+ "base16ct",
  "byteorder",
  "bytes",
  "delegate",
  "futures",
  "log",
- "rand 0.8.6",
- "sha2 0.10.9",
- "thiserror 1.0.69",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
  "tokio",
  "windows 0.62.2",
  "windows-strings",
@@ -3113,7 +3107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
 dependencies = [
  "crypto-bigint",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
@@ -3258,8 +3252,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
 ]
@@ -3270,7 +3262,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3283,16 +3275,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3311,7 +3293,6 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
  "serde",
 ]
 
@@ -3448,7 +3429,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -3594,7 +3575,7 @@ version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-bigint",
  "crypto-primes",
  "digest 0.11.3",
@@ -3768,7 +3749,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3915,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4144,7 +4125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4801,7 +4782,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -5161,7 +5142,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5896,7 +5877,6 @@ dependencies = [
  "anyhow",
  "better-panic",
  "fdlimit",
- "futures",
  "libc",
  "mlua",
  "paste",
@@ -6107,7 +6087,6 @@ dependencies = [
  "yazi-runner",
  "yazi-shared",
  "yazi-term",
- "yazi-tui",
  "yazi-vfs",
 ]
 
@@ -6207,7 +6186,6 @@ dependencies = [
  "anyhow",
  "ratatui",
  "tokio",
- "tracing",
  "yazi-config",
  "yazi-emulator",
  "yazi-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ regex               = "1.12.3"
 russh               = { version = "0.61.0", default-features = false, features = [ "ring", "rsa" ] }
 scopeguard          = "1.2.0"
 serde               = { version = "1.0.228", features = [ "derive" ] }
-serde_json          = "1.0.149"
+serde_json          = "1.0.150"
 serde_with          = "3.20.0"
 strum               = { version = "0.28.0", features = [ "derive" ] }
 syntect             = { version = "5.3.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -49,12 +49,46 @@ impl Preview {
 
 impl DeserializeOverHook for Preview {
 	fn deserialize_over_hook(self) -> Result<Self, toml::de::Error> {
-		std::fs::create_dir_all(&self.cache_dir)
-			.context(format!("Failed to create cache directory: {}", self.cache_dir.display()))
-			.map_err(serde::de::Error::custom)?;
+		create_cache_dir(&self.cache_dir).map_err(serde::de::Error::custom)?;
 
 		Ok(self)
 	}
+}
+
+fn create_cache_dir(path: &Path) -> Result<()> {
+	create_cache_dir_all(path)?;
+	restrict_cache_dir_permissions(path)?;
+	Ok(())
+}
+
+#[cfg(unix)]
+fn create_cache_dir_all(path: &Path) -> Result<()> {
+	use std::os::unix::fs::DirBuilderExt;
+
+	std::fs::DirBuilder::new()
+		.recursive(true)
+		.mode(0o700)
+		.create(path)
+		.context(format!("Failed to create cache directory: {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn create_cache_dir_all(path: &Path) -> Result<()> {
+	std::fs::create_dir_all(path)
+		.context(format!("Failed to create cache directory: {}", path.display()))
+}
+
+#[cfg(unix)]
+fn restrict_cache_dir_permissions(path: &Path) -> Result<()> {
+	use std::os::unix::fs::PermissionsExt;
+
+	std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+		.context(format!("Failed to set cache directory permissions: {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn restrict_cache_dir_permissions(_: &Path) -> Result<()> {
+	Ok(())
 }
 
 fn deserialize_cache_dir<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
@@ -92,5 +126,26 @@ where
 		Ok(value)
 	} else {
 		Err(serde::de::Error::custom("image_quality must be between 50 and 90."))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[cfg(unix)]
+	#[test]
+	fn create_cache_dir_restricts_permissions_on_unix() {
+		use std::os::unix::fs::PermissionsExt;
+
+		let cache_dir = std::env::temp_dir().join(format!("yazi-cache-test-{}", timestamp_us()));
+		std::fs::create_dir_all(&cache_dir).unwrap();
+		std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+		create_cache_dir(&cache_dir).unwrap();
+		let mode = std::fs::metadata(&cache_dir).unwrap().permissions().mode() & 0o777;
+		let _ = std::fs::remove_dir_all(&cache_dir);
+
+		assert_eq!(mode, 0o700);
 	}
 }

--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -1,4 +1,6 @@
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::os::unix::fs::DirBuilderExt;
+use std::{fs::DirBuilder, path::PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -49,46 +51,17 @@ impl Preview {
 
 impl DeserializeOverHook for Preview {
 	fn deserialize_over_hook(self) -> Result<Self, toml::de::Error> {
-		create_cache_dir(&self.cache_dir).map_err(serde::de::Error::custom)?;
+		#[cfg(unix)]
+		let result = DirBuilder::new().mode(0o700).recursive(true).create(&self.cache_dir);
+		#[cfg(not(unix))]
+		let result = DirBuilder::new().recursive(true).create(&self.cache_dir);
+
+		result
+			.context(format!("Failed to create cache directory: {}", self.cache_dir.display()))
+			.map_err(serde::de::Error::custom)?;
 
 		Ok(self)
 	}
-}
-
-fn create_cache_dir(path: &Path) -> Result<()> {
-	create_cache_dir_all(path)?;
-	restrict_cache_dir_permissions(path)?;
-	Ok(())
-}
-
-#[cfg(unix)]
-fn create_cache_dir_all(path: &Path) -> Result<()> {
-	use std::os::unix::fs::DirBuilderExt;
-
-	std::fs::DirBuilder::new()
-		.recursive(true)
-		.mode(0o700)
-		.create(path)
-		.context(format!("Failed to create cache directory: {}", path.display()))
-}
-
-#[cfg(not(unix))]
-fn create_cache_dir_all(path: &Path) -> Result<()> {
-	std::fs::create_dir_all(path)
-		.context(format!("Failed to create cache directory: {}", path.display()))
-}
-
-#[cfg(unix)]
-fn restrict_cache_dir_permissions(path: &Path) -> Result<()> {
-	use std::os::unix::fs::PermissionsExt;
-
-	std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
-		.context(format!("Failed to set cache directory permissions: {}", path.display()))
-}
-
-#[cfg(not(unix))]
-fn restrict_cache_dir_permissions(_: &Path) -> Result<()> {
-	Ok(())
 }
 
 fn deserialize_cache_dir<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
@@ -126,26 +99,5 @@ where
 		Ok(value)
 	} else {
 		Err(serde::de::Error::custom("image_quality must be between 50 and 90."))
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[cfg(unix)]
-	#[test]
-	fn create_cache_dir_restricts_permissions_on_unix() {
-		use std::os::unix::fs::PermissionsExt;
-
-		let cache_dir = std::env::temp_dir().join(format!("yazi-cache-test-{}", timestamp_us()));
-		std::fs::create_dir_all(&cache_dir).unwrap();
-		std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
-
-		create_cache_dir(&cache_dir).unwrap();
-		let mode = std::fs::metadata(&cache_dir).unwrap().permissions().mode() & 0o777;
-		let _ = std::fs::remove_dir_all(&cache_dir);
-
-		assert_eq!(mode, 0o700);
 	}
 }

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -44,7 +44,6 @@ yazi-widgets   = { path = "../yazi-widgets", version = "26.5.6" }
 anyhow             = { workspace = true }
 better-panic       = "0.3.0"
 fdlimit            = "0.3.0"
-futures            = { workspace = true }
 mlua               = { workspace = true }
 paste              = { workspace = true }
 ratatui            = { workspace = true }

--- a/yazi-scheduler/Cargo.toml
+++ b/yazi-scheduler/Cargo.toml
@@ -25,7 +25,6 @@ yazi-macro   = { path = "../yazi-macro", version = "26.5.6" }
 yazi-runner  = { path = "../yazi-runner", version = "26.5.6" }
 yazi-shared  = { path = "../yazi-shared", version = "26.5.6" }
 yazi-term    = { path = "../yazi-term", version = "26.5.6" }
-yazi-tui     = { path = "../yazi-tui", version = "26.5.6" }
 yazi-vfs     = { path = "../yazi-vfs", version = "26.5.6" }
 
 # External dependencies

--- a/yazi-tui/Cargo.toml
+++ b/yazi-tui/Cargo.toml
@@ -23,6 +23,5 @@ yazi-tty      = { path = "../yazi-tty", version = "26.5.9" }
 
 # External dependencies
 anyhow  = { workspace = true }
-tracing = { workspace = true }
 ratatui = { workspace = true }
 tokio   = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #3983

## Rationale of this PR

The preview cache can contain generated content from user files. This keeps the existing cache directory path and config semantics, but makes Unix cache directory setup owner-only by creating the directory with `0700` mode and then applying `0700` to the final directory as well. Non-Unix behavior remains unchanged.

I added a Unix-only regression test for an existing `0755` cache directory being restricted to `0700`. Before the production change, the new regression observed `0755` instead of `0700`; after the change it passes.

Verification:

- `cargo test -p yazi-config create_cache_dir_restricts_permissions_on_unix`
- `cargo test -p yazi-config`
- `cargo test --workspace --verbose`
- `cargo +nightly-2026-05-06 fmt --check`
- `git diff --check`

Note: I used Codex to inspect the code path and draft the regression test, then reviewed the final diff and ran the listed checks locally.
