### PR TITLE
Double-Click Support

### DIFF
--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -11,11 +11,12 @@ sort_reverse 	 = false
 sort_dir_first = true
 sort_translit  = false
 sort_fallback  = "alphabetical"
-linemode       = "none"
-show_hidden    = false
-show_symlink   = true
-scrolloff      = 5
-mouse_events   = [ "click", "scroll", "drag" ]
+linemode                    = "none"
+show_hidden                 = false
+show_symlink                = true
+scrolloff                   = 5
+mouse_events                = [ "click", "scroll", "drag" ]
+mouse_double_click_delay    = 300
 
 [preview]
 wrap            = "no"

--- a/yazi-config/src/mgr/mgr.rs
+++ b/yazi-config/src/mgr/mgr.rs
@@ -22,10 +22,11 @@ pub struct Mgr {
 	// Display
 	#[serde(deserialize_with = "deserialize_linemode")]
 	pub linemode:     ArcSwap<String>,
-	pub show_hidden:  SyncCell<bool>,
-	pub show_symlink: SyncCell<bool>,
-	pub scrolloff:    SyncCell<u8>,
-	pub mouse_events: SyncCell<MouseEvents>,
+	pub show_hidden:           SyncCell<bool>,
+	pub show_symlink:          SyncCell<bool>,
+	pub scrolloff:             SyncCell<u8>,
+	pub mouse_events:          SyncCell<MouseEvents>,
+	pub mouse_double_click_delay: SyncCell<u16>,
 }
 
 fn deserialize_linemode<'de, D>(deserializer: D) -> Result<ArcSwap<String>, D::Error>

--- a/yazi-plugin/preset/components/current.lua
+++ b/yazi-plugin/preset/components/current.lua
@@ -2,6 +2,8 @@ Current = {
 	_id = "current",
 }
 
+local last_click = { time = 0, url = nil }
+
 function Current:new(area, tab)
 	return setmetatable({
 		_area = area,
@@ -54,9 +56,27 @@ function Current:click(event, up)
 	end
 
 	local y = event.y - self._area.y + 1
-	if self._folder.window[y] then
-		Entity:new(self._folder.window[y]):click(event, up)
+	local f = self._folder.window[y]
+	if not f then
+		return
 	end
+
+	if event.is_left then
+		local delay = rt.mgr.mouse_double_click_delay or 0
+		local now = ya.time()
+		local url = tostring(f.url)
+		if delay > 0
+			and (now - last_click.time) * 1000 <= delay
+			and last_click.url == url
+		then
+			last_click.time = 0
+			ya.emit("open", {})
+			return
+		end
+		last_click = { time = now, url = url }
+	end
+
+	Entity:new(f):click(event, up)
 end
 
 function Current:scroll(event, step) ya.emit("arrow", { step }) end

--- a/yazi-plugin/src/runtime/runtime.rs
+++ b/yazi-plugin/src/runtime/runtime.rs
@@ -70,6 +70,7 @@ fn mgr() -> Composer<ComposerGet, ComposerSet> {
 			b"show_symlink" => m.show_symlink.get().into_lua(lua)?,
 			b"scrolloff" => m.scrolloff.get().into_lua(lua)?,
 			b"mouse_events" => lua.to_value_with(&m.mouse_events, SER_OPT)?,
+			b"mouse_double_click_delay" => m.mouse_double_click_delay.get().into_lua(lua)?,
 			_ => return Ok(Value::Nil),
 		}
 		.into_lua(lua)


### PR DESCRIPTION
## Which issue does this PR resolve?

// no existing GitHub issue

Resolves #

## Rationale of this PR

Yazi supports clicking a file to select/reveal it, so the mouse support is there. However, running/opening a file or navigating to a directory still requires a follow-up `Enter` keypress (or a right-click, which is only for directories and not for files). 

In my opinion, if Yazi supports mouse clicking to select files, it might as well support double clicks as well. I see no reason to not go a step further. 

In fact, it's confusing. "I can click to select a file, but I can't double-click to open it??"

Double-click is the conventional gesture that every file manager supports, and it's natural for people to expect this behaviour. I think adding this feature can help GUI users migrate to and adopt a terminal-based workflow and help increase Yazi's popularity.

--- technical explanation below ---

## Behavior

On a left-button mouse-down in the current pane:
- If the same file URL was clicked within the configured threshold → emit `open` (the same command `Enter` runs). Files open in the default opener; directories are entered.
- Otherwise → existing behavior (reveal the entry). The click is recorded as the new "last click".

Right-click, middle-click, and the parent pane are intentionally untouched. The parent pane already has its own single-click semantics (empty-area click emits `leave`), so adding double-click there would conflict.

## Configuration

New optional key under `[mgr]` in `yazi.toml`:

```
mouse_double_click_delay = 300  # milliseconds; 0 disables
```

Default 300 matches common OS thresholds. Setting 0 disables the feature.

## Implementation notes

- Detection lives in Current:click (Lua), not in the Rust mouse actor — a module-local last_click = { time, url } table persists across redraws.
- The config field (SyncCell<u16>) is exposed read-only to Lua via the existing rt.mgr.* composer, alongside scrolloff, mouse_events, etc.
- Wall-clock timing uses ya.time(), matching the pattern in yazi-plugin/preset/plugins/mime-local.lua.
- After firing open, last_click.time is reset so a third quick click doesn't chain into another open.

~25-line diff across three commits.

## Tested

It works nicely in my experience.

Double-click on file opens it; double-click on dir enters it; slow clicks don't open; clicks on different files don't open; triple-click opens once; right-click and parent-pane behavior unchanged; delay = 0 disables; delay = 600 honors the wider window.
