### PR TITLE
feat: image preview with Überzug++ on Niri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 ### Added
 
 - Bulk create ([#3793])
-- Support Niri for Wayland image previews ([#3990])
+- Image preview with Überzug++ on Niri ([#3990])
 
 ### Changed
 
@@ -1728,3 +1728,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#3934]: https://github.com/sxyazi/yazi/pull/3934
 [#3943]: https://github.com/sxyazi/yazi/pull/3943
 [#3989]: https://github.com/sxyazi/yazi/pull/3989
+[#3990]: https://github.com/sxyazi/yazi/pull/3990

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 ### Added
 
 - Bulk create ([#3793])
+- Support Niri for Wayland image previews ([#3990])
 
 ### Changed
 

--- a/yazi-adapter/src/drivers/ueberzug.rs
+++ b/yazi-adapter/src/drivers/ueberzug.rs
@@ -76,11 +76,12 @@ impl Ueberzug {
 		}
 	}
 
-	// Currently Überzug++'s Wayland output only supports Sway, Hyprland and Wayfire
-	// as it requires information from specific compositor socket directly.
+	// Currently Überzug++'s Wayland output only supports Niri, Sway, Hyprland and
+	// Wayfire as it requires information from specific compositor socket directly.
 	// These environment variables are from ueberzugpp src/canvas/wayland/config.cpp
 	pub(crate) fn supported_compositor() -> bool {
-		env_exists("SWAYSOCK")
+		env_exists("NIRI_SOCKET")
+			|| env_exists("SWAYSOCK")
 			|| env_exists("HYPRLAND_INSTANCE_SIGNATURE")
 			|| env_exists("WAYFIRE_SOCKET")
 	}

--- a/yazi-boot/src/actions/debug.rs
+++ b/yazi-boot/src/actions/debug.rs
@@ -46,6 +46,7 @@ impl Actions {
 		writeln!(s, "    XDG_SESSION_TYPE           : {:?}", env::var_os("XDG_SESSION_TYPE"))?;
 		writeln!(s, "    WAYLAND_DISPLAY            : {:?}", env::var_os("WAYLAND_DISPLAY"))?;
 		writeln!(s, "    DISPLAY                    : {:?}", env::var_os("DISPLAY"))?;
+		writeln!(s, "    NIRI_SOCKET                : {:?}", env::var_os("NIRI_SOCKET"))?;
 		writeln!(s, "    SWAYSOCK                   : {:?}", env::var_os("SWAYSOCK"))?;
 		#[rustfmt::skip]
 		writeln!(s, "    HYPRLAND_INSTANCE_SIGNATURE: {:?}", env::var_os("HYPRLAND_INSTANCE_SIGNATURE"))?;


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #3914

## Rationale of this PR

Überzug++ 2.9.9+ includes niri Wayland support via NIRI_SOCKET, so Yazi can treat NIRI_SOCKET as a supported Wayland compositor signal and keep the debug output aligned with adapter detection.