### PR TITLE
fix: don't require a TTY for `--version`

### DIFF
--- a/yazi-boot/src/actions/actions.rs
+++ b/yazi-boot/src/actions/actions.rs
@@ -3,14 +3,17 @@ use std::process;
 pub struct Actions;
 
 impl Actions {
+	// Actions that require no terminal/config initialization, handled before it.
+	pub(crate) fn act_early(args: &crate::Args) {
+		if args.version {
+			println!("Yazi {}", Self::version());
+			process::exit(0);
+		}
+	}
+
 	pub(crate) fn act(args: &crate::Args) {
 		if args.debug {
 			println!("{}", Self::debug().unwrap());
-			process::exit(0);
-		}
-
-		if args.version {
-			println!("Yazi {}", Self::version());
 			process::exit(0);
 		}
 

--- a/yazi-boot/src/lib.rs
+++ b/yazi-boot/src/lib.rs
@@ -8,8 +8,12 @@ use yazi_shim::cell::RoCell;
 pub static ARGS: RoCell<Args> = RoCell::new();
 pub static BOOT: RoCell<Boot> = RoCell::new();
 
-pub fn init() {
+pub fn preflight() {
 	ARGS.with(<_>::parse);
+	actions::Actions::act_early(&ARGS);
+}
+
+pub fn init() {
 	BOOT.init(<_>::from(&*ARGS));
 
 	actions::Actions::act(&ARGS);

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -14,6 +14,8 @@ async fn main() -> anyhow::Result<()> {
 	Logs::start()?;
 	_ = fdlimit::raise_fd_limit();
 
+	yazi_boot::preflight();
+
 	yazi_tty::init();
 
 	yazi_term::init()?;


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #3992

## Rationale of this PR

Since the new virtual terminal backend (#3989), `yazi --version` fails in a non-TTY context (e.g. CI pipelines, containers) with `Error: Not a tty (os error 25)`.

The cause is ordering: `yazi_term::init()` runs before the `--version` flag is handled. Terminal init calls `Restorer::new`, which runs `termios::tcgetattr` on the tty handle; when neither stdout nor `/dev/tty` is a terminal that returns `ENOTTY`, aborting before the version action ever runs.

`--version` needs no terminal or config initialization, so this moves it into a new `yazi_boot::preflight()` that parses the args and handles the version action before any terminal setup. `--debug` (which reports `TERM.dimension()`) and `--clear-cache` (which needs the config) keep their existing placement after init.

Verified with a piped/detached invocation: `yazi --version </dev/null` now prints the version and exits 0 instead of erroring.