### PR TITLE
fix: drain delayed tmux terminal replies before events

### DIFF
--- a/yazi-tty/src/tty.rs
+++ b/yazi-tty/src/tty.rs
@@ -58,4 +58,32 @@ impl Tty {
 		let result = read();
 		(buf, result)
 	}
+
+	pub fn drain_until_quiet(&self, timeout: Duration, quiet: Duration) -> std::io::Result<usize> {
+		let mut drained = 0;
+		let until = Instant::now() + timeout;
+		let mut stdin = self.stdin.lock();
+
+		while Instant::now() < until {
+			match stdin.poll(quiet) {
+				Ok(true) => {}
+				Ok(false) => break,
+				Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+				Err(e) => return Err(e),
+			}
+
+			let mut b = [0u8];
+			loop {
+				match stdin.read_exact(&mut b) {
+					Ok(()) => {
+						drained += 1;
+						break;
+					}
+					Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+					Err(e) => return Err(e),
+				}
+			}
+		}
+		Ok(drained)
+	}
 }

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -1,4 +1,4 @@
-use std::{io::{self, Write}, ops::Deref};
+use std::{io::{self, Write}, ops::Deref, time::Duration};
 
 use anyhow::Result;
 use ratatui::{CompletedFrame, Frame, Terminal, buffer::Buffer, layout::Rect};
@@ -63,7 +63,15 @@ impl Raterm {
 
 		let mut term = Self {
 			inner:       Terminal::new(RatermBackend::new(TTY.writer()))?,
-			stream:      EventStream::from(&*TERM),
+			stream:      {
+				if TMUX.get() {
+					// tmux passthrough can deliver terminal query replies out of order.
+					// Keep them out of EventStream, where DCS/CSI payload bytes
+					// such as `r`, `f`, or `z` are indistinguishable from keys.
+					let _ = TTY.drain_until_quiet(Duration::from_millis(1000), Duration::from_millis(100));
+				}
+				EventStream::from(&*TERM)
+			},
 			last_area:   Default::default(),
 			last_buffer: Default::default(),
 		};


### PR DESCRIPTION
## Which issue does this PR resolve?

Related: [#3997](https://github.com/sxyazi/yazi/issues/3997)

## Rationale of this PR

This fixes a startup input race seen in slow tmux passthrough setups, reproduced on WSL2 + tmux 3.6b + WezTerm.

Yazi sends terminal capability queries during TUI startup, then creates the terminal `EventStream`. In this environment, some terminal replies can arrive after the DA1/DSR waits have completed. Those delayed replies contain printable payload bytes, for example:

```text
ESC P > | WezTerm 20240203-110809-5046fc22 ESC \
ESC P 1 $ r  q 0  q ESC \
ESC [ ? 12 ; 2 $ y
```

If those bytes are still pending when `EventStream` starts, they can be interpreted as user keypresses. In practice this caused Yazi to start with a random action already active, such as filter, rename, or an fzf plugin binding.

The fix adds a small tty helper to drain pending bytes until input has been quiet, and calls it under tmux immediately before constructing `EventStream`. This keeps delayed terminal replies out of the user input stream.

Verified locally:

```sh
cargo build --release --bin yazi
```

Smoke-tested the rebuilt binary in fresh tmux panes under WSL2 + WezTerm. Startup opened normal Yazi UI without the previous auto-triggered prompt.
