### PR TITLE
fix(snap): make bundled magick find libgomp at runtime

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -133,9 +133,16 @@ parts:
       - --prefix=/usr
     build-attributes:
       - enable-patchelf
+    organize:
+      # `libgomp1` installs libgomp into the multiarch directory, but the
+      # `magick` binary's RPATH only searches `$ORIGIN/../lib` (i.e. usr/lib).
+      # Move it alongside the Magick libraries so the bundled binary can load
+      # it at runtime; otherwise magick fails with:
+      #   "libgomp.so.1: cannot open shared object file: No such file or directory"
+      usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgomp.so*: usr/lib/
     prime:
       - usr/bin/magick
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgomp.so.1
+      - usr/lib/libgomp.so*
       - usr/lib/libMagickCore-7.Q16HDRI.so*
       - usr/lib/libMagickWand-7.Q16HDRI.so*
 


### PR DESCRIPTION
## Problem

On the snap build, the bundled `magick` binary fails to start, so Font / HEIC / JPEG-XL previews don't work. `yazi --debug` reports:

```
magick : ExitStatus(unix_wait_status(32512)), "magick: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory"
```

Reproduced on `latest/stable` (rev 908) and `latest/edge` (rev 904), amd64. All other previewers (chafa, ffmpeg, poppler, 7-Zip, resvg) work fine.

## Root cause

The `magick` part builds ImageMagick from source with `--prefix=/usr`, so its own libraries land in `usr/lib/`, and `enable-patchelf` sets the binary's `RPATH` to:

```
$ORIGIN/../lib : /snap/core24/current/lib/x86_64-linux-gnu
```

i.e. it searches `usr/lib` (where `libMagickCore`/`libMagickWand` live) and the core24 base. But `libgomp1` is pulled in as a `stage-package`, which installs `libgomp.so.1` into the **multiarch** dir `usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/` — which is on neither RPATH entry. core24 doesn't ship `libgomp` either, so at runtime the loader can't resolve it.

```
$ ldd /snap/yazi/908/usr/bin/magick | grep gomp
        libgomp.so.1 => not found
$ find /snap/yazi/908 -name 'libgomp.so.1'
/snap/yazi/908/usr/lib/x86_64-linux-gnu/libgomp.so.1   # bundled, but not on the RPATH
```

## Fix

`organize` the bundled `libgomp` into `usr/lib/`, alongside the Magick libraries, so the existing `$ORIGIN/../lib` RPATH resolves it (and update the `prime` path to match). No new `RPATH`/`LD_LIBRARY_PATH` plumbing needed.

I deliberately avoided the `apps.*.environment: LD_LIBRARY_PATH` approach because `$CRAFT_ARCH_TRIPLET_BUILD_FOR` is not expanded inside the `environment` block on core22/core24 (canonical/snapcraft#4486), which would ship a literal, broken path. `$CRAFT_ARCH_TRIPLET_BUILD_FOR` *is* expanded in `organize`/`prime` (already used here).

## Verification

I couldn't run a full `snapcraft pack` in my environment (no LXD/Multipass), but I verified the mechanism directly against the shipped snap: reconstruct the prime layout with `libgomp` placed in `usr/lib/` next to the Magick libs, then run the **unmodified** shipped `magick` binary with **no** `LD_LIBRARY_PATH`:

```
$ env -u LD_LIBRARY_PATH ./usr/bin/magick --version
Version: ImageMagick 7.1.2-0 Q16-HDRI x86_64 ...   # loads via $ORIGIN/../lib
```

A maintainer CI build would be the real confirmation.

I couldn't find an existing issue or PR tracking this.