### PR TITLE
fix: magick preview of multiframe files

### DIFF
--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,11 +25,11 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_limit()
+	local cmd = M.with_limit():arg(tostring(job.file.path))
 	if job.args.flatten then
-		cmd:arg(tostring(job.file.path)):arg("-flatten")
+		cmd:arg("-flatten")
 	else
-		cmd:arg(tostring(job.file.path) .. "[0]")
+		cmd:arg { "-delete", "1--1" }
 	end
 	cmd:arg { "-auto-orient", "-strip" }
 

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,11 +25,13 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_limit():arg(tostring(job.file.path))
+	local cmd = M.with_limit()
+	cmd:arg { "-define", "filename:literal=true" }
+	local path = tostring(job.file.path)
 	if job.args.flatten then
-		cmd:arg("-flatten")
+		cmd:arg { path, "-flatten" }
 	else
-		cmd:arg { "-delete", "1--1" }
+		cmd:arg { "-define", "image:frames=0", path }
 	end
 	cmd:arg { "-auto-orient", "-strip" }
 

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,7 +25,7 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_limit():arg({ "-define", "filename:literal=true" })
+	local cmd = M.with_limit():arg { "-define", "filename:literal=true" }
 	if job.args.flatten then
 		cmd:arg { tostring(job.file.path), "-flatten" }
 	else

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,13 +25,11 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_limit()
-	cmd:arg { "-define", "filename:literal=true" }
-	local path = tostring(job.file.path)
+	local cmd = M.with_limit():arg({ "-define", "filename:literal=true" })
 	if job.args.flatten then
-		cmd:arg { path, "-flatten" }
+		cmd:arg { tostring(job.file.path), "-flatten" }
 	else
-		cmd:arg { "-define", "image:frames=0", path }
+		cmd:arg { "-define", "image:frames=0", tostring(job.file.path) }
 	end
 	cmd:arg { "-auto-orient", "-strip" }
 

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -25,9 +25,11 @@ function M:preload(job)
 		return true
 	end
 
-	local cmd = M.with_limit():arg(tostring(job.file.path))
+	local cmd = M.with_limit()
 	if job.args.flatten then
-		cmd:arg("-flatten")
+		cmd:arg(tostring(job.file.path)):arg("-flatten")
+	else
+		cmd:arg(tostring(job.file.path) .. "[0]")
 	end
 	cmd:arg { "-auto-orient", "-strip" }
 


### PR DESCRIPTION
## Rationale of this PR

### What changed

If the `magick` previewer is used without the `--flatten` argument, it now processes only the first frame of the file. For example, instead of running `magick` with `input.jpg`, it will run it with `input.jpg[0]` (which discards all frames but first and for files with only single frame it changes nothing).

### Why do you need this?

Two reasons.

**1st reason.** If you set the yazi previewer to `magick` and try to preview a file with several frames (layered image or animation), it generates preview JPEGs for each frame and names them `<hash>-0`, `<hash>-1`, etc. As a result, preview still won't be displayed (because no file named just `<hash>` was created). It seems that this logic has no use case and simply punishes a user who forgot to add `--flatten` argument to the `magick` previewer, by creating a bunch of unnecessary files and not showing preview anyway. 

**2nd reason.** Moreover sometimes for a useful preview you need the first frame instead of a flattened image.

_Example 1._  
Animated `.avif` with transparent background.  
On the left: preview generated after this PR with the previewer `magick --bg=gray`.  
On the right: preview generated with `magick --flatten --bg=gray` (you forced to use `--flatten` before this PR, otherwise a valid preview file would not be generated at all as described above).

| fish.avif[0]  --bg=gray | fish.avif --flatten --bg=gray |
| --- | --- |
| <img width="498" height="374" alt="6d13eb6fd8a9b31329844a65bccced74(avif 0  --bg=gray)" src="https://github.com/user-attachments/assets/c014e953-3cf1-40b7-bd54-74fb1121b48c" /> | <img width="498" height="374" alt="6d13eb6fd8a9b31329844a65bccced74(avif --flatten --bg=gray)" src="https://github.com/user-attachments/assets/1932b8fc-c994-4441-9423-79d2df4f6c21" /> |

So before this PR you could only get a preview of all frames mingled together.  
(Furthermore, the `--bg` argument is not respected. This is likely because in `magick.lua` the background color is set after flattening, but that's another issue that I don't touch here.)

_Example 2._  
Layered `.psd` file with usage of layer masks.

| lorem.psd[0] | lorem.psd --flatten |
| --- | --- |
| <img width="600" height="253" alt="90705e64c14be5eb549defd27c09913e" src="https://github.com/user-attachments/assets/470837be-a7e2-40a0-ac2c-6fa9d5215a00" /> | <img width="600" height="253" alt="90705e64c14be5eb549defd27c09913e flatten" src="https://github.com/user-attachments/assets/2558753b-34e1-4910-9c99-8845437ce1d2" /> |

ImageMagick's flatten does not respect layer masks (which should hide parts of a layer). But you don't really even need to flatten `.psd` files because they already have a preview which is stored as the first frame.

Files used for examples: [examples.zip](https://github.com/user-attachments/files/28689417/examples.zip)


## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
