### PR TITLE
adapter: allow opt-in Kitty graphics passthrough under Zellij

### DIFF
--- a/yazi-adapter/src/adapter.rs
+++ b/yazi-adapter/src/adapter.rs
@@ -9,6 +9,9 @@ use yazi_shared::env_exists;
 
 use crate::{Adapters, SHOWN, drivers};
 
+const ZELLIJ_SESSION_NAME_ENV: &str = "ZELLIJ_SESSION_NAME";
+pub const ZELLIJ_KITTY_PASSTHROUGH_ENV: &str = "YAZI_ZELLIJ_KITTY_PASSTHROUGH";
+
 #[derive(Clone, Copy, Debug, Display, Eq, IntoStaticStr, PartialEq)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Adapter {
@@ -75,8 +78,8 @@ impl Adapter {
 impl Adapter {
 	pub fn matches(emulator: &Emulator) -> Self {
 		let mut adapters: Adapters = emulator.into();
-		if env_exists("ZELLIJ_SESSION_NAME") {
-			adapters.retain(|p| *p == Self::Sixel);
+		if env_exists(ZELLIJ_SESSION_NAME_ENV) {
+			adapters.retain(|p| p.supported_in_zellij());
 		} else if TMUX.get() {
 			adapters.retain(|p| *p != Self::KgpOld);
 		}
@@ -101,5 +104,75 @@ impl Adapter {
 
 		warn!("[Adapter] Falling back to chafa");
 		Self::Chafa
+	}
+
+	fn supported_in_zellij(self) -> bool {
+		self == Self::Sixel
+			|| (env_exists(ZELLIJ_KITTY_PASSTHROUGH_ENV)
+				&& matches!(self, Self::Kgp | Self::KgpOld))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{env, ffi::OsString, sync::Mutex};
+
+	use super::*;
+
+	static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	struct EnvVarGuard {
+		name: &'static str,
+		old:  Option<OsString>,
+	}
+
+	impl EnvVarGuard {
+		fn set(name: &'static str, value: &str) -> Self {
+			let old = env::var_os(name);
+			unsafe { env::set_var(name, value) };
+			Self { name, old }
+		}
+
+		fn remove(name: &'static str) -> Self {
+			let old = env::var_os(name);
+			unsafe { env::remove_var(name) };
+			Self { name, old }
+		}
+	}
+
+	impl Drop for EnvVarGuard {
+		fn drop(&mut self) {
+			unsafe {
+				if let Some(value) = self.old.take() {
+					env::set_var(self.name, value);
+				} else {
+					env::remove_var(self.name);
+				}
+			}
+		}
+	}
+
+	#[test]
+	fn zellij_uses_sixel_by_default() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		let _session = EnvVarGuard::set(ZELLIJ_SESSION_NAME_ENV, "test-session");
+		let _passthrough = EnvVarGuard::remove(ZELLIJ_KITTY_PASSTHROUGH_ENV);
+
+		assert!(Adapter::Sixel.supported_in_zellij());
+		assert!(!Adapter::Kgp.supported_in_zellij());
+		assert!(!Adapter::KgpOld.supported_in_zellij());
+		assert!(!Adapter::Iip.supported_in_zellij());
+	}
+
+	#[test]
+	fn zellij_kitty_passthrough_adds_kitty_adapters_only() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		let _session = EnvVarGuard::set(ZELLIJ_SESSION_NAME_ENV, "test-session");
+		let _passthrough = EnvVarGuard::set(ZELLIJ_KITTY_PASSTHROUGH_ENV, "1");
+
+		assert!(Adapter::Sixel.supported_in_zellij());
+		assert!(Adapter::Kgp.supported_in_zellij());
+		assert!(Adapter::KgpOld.supported_in_zellij());
+		assert!(!Adapter::Iip.supported_in_zellij());
 	}
 }

--- a/yazi-cli/src/env/env.rs
+++ b/yazi-cli/src/env/env.rs
@@ -86,6 +86,12 @@ impl Env {
 		writeln!(s, "    tmux version       : {}", Self::dep_version("tmux", "-V"))?;
 		writeln!(s, "    tmux build flags   : enable-sixel={}", Mux::tmux_sixel_flag())?;
 		writeln!(s, "    ZELLIJ_SESSION_NAME: {:?}", env::var_os("ZELLIJ_SESSION_NAME"))?;
+		writeln!(
+			s,
+			"    {}: {:?}",
+			yazi_adapter::ZELLIJ_KITTY_PASSTHROUGH_ENV,
+			env::var_os(yazi_adapter::ZELLIJ_KITTY_PASSTHROUGH_ENV)
+		)?;
 		writeln!(s, "    Zellij version     : {}", Self::dep_version("zellij", "--version"))?;
 
 		writeln!(s, "\nDependencies")?;


### PR DESCRIPTION
## What

Yazi currently forces the Sixel adapter whenever `ZELLIJ_SESSION_NAME` is set.

This adds an explicit opt-in environment variable:

```sh
YAZI_ZELLIJ_KITTY_PASSTHROUGH=1
```

When set, Yazi keeps Kitty graphics adapters available under Zellij while preserving the existing safe default for normal Zellij sessions.

## Why

The default Sixel fallback is still the right behavior for upstream Zellij today.

However, downstream integrations can provide a Zellij build that passes Kitty graphics through to the outer terminal. Yazelix currently carries a small Zellij fork for that path:

https://github.com/luccahuguet/yazelix-zellij

That fork lets Yazi image previews work through Zellij in Kitty-graphics-capable terminals. Without this opt-in, Yazi still forces Sixel just because `ZELLIJ_SESSION_NAME` is present, even when the surrounding Zellij/terminal stack can handle Kitty graphics correctly.

This should also make the eventual upstream Zellij transition easier for Yazi. When Zellij itself starts supporting Kitty graphics passthrough, Yazi maintainers can switch from “always force Sixel under Zellij” to a capability-aware path incrementally, with this narrow opt-in already isolating the adapter-filtering behavior that needs to change.

## Details

- `ZELLIJ_SESSION_NAME` still triggers Zellij-specific adapter filtering
- without `YAZI_ZELLIJ_KITTY_PASSTHROUGH`, only Sixel remains allowed
- with `YAZI_ZELLIJ_KITTY_PASSTHROUGH`, Kitty graphics adapters are also allowed
- non-Kitty protocols such as IIP remain filtered under Zellij
- `ya env` reports the new variable for diagnostics

## Checks

- `cargo test -p yazi-adapter zellij -- --test-threads=1`
- `cargo check -p yazi-adapter -p yazi-cli`
