### PR TITLE
fix: quit once event stream closes in case terminal won't send a `SIGHUP` signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5316,6 +5316,7 @@ dependencies = [
  "yazi-config",
  "yazi-emulator",
  "yazi-macro",
+ "yazi-proxy",
  "yazi-shared",
  "yazi-shim",
  "yazi-term",

--- a/yazi-term/src/source/unix.rs
+++ b/yazi-term/src/source/unix.rs
@@ -55,12 +55,16 @@ impl<'a> EventSource<'a> {
 		// More input is ready.
 		if read_ready {
 			let mut buf = [0u8; 1024];
+
 			let len = read_complete(&mut *reader, &mut buf)?;
+			if len == 0 {
+				return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+			}
 
 			let mut parser = self.parser.lock();
 			parser.parse(&buf[..len]);
 
-			if len > 0 && len < buf.len() {
+			if len < buf.len() {
 				parser.flush();
 			}
 			return Ok(());

--- a/yazi-term/src/stream/stream.rs
+++ b/yazi-term/src/stream/stream.rs
@@ -31,6 +31,7 @@ impl EventStream {
 							break;
 						}
 					}
+					// try_poll() already handles Interrupted, this is defensive.
 					Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
 					Err(e) => {
 						tx.send(Err(e)).ok();

--- a/yazi-term/src/stream/stream.rs
+++ b/yazi-term/src/stream/stream.rs
@@ -31,7 +31,7 @@ impl EventStream {
 							break;
 						}
 					}
-					Err(e) if e.kind() == io::ErrorKind::Interrupted => break,
+					Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
 					Err(e) => {
 						tx.send(Err(e)).ok();
 						break;

--- a/yazi-tui/Cargo.toml
+++ b/yazi-tui/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 yazi-config   = { path = "../yazi-config", version = "26.5.6" }
 yazi-emulator = { path = "../yazi-emulator", version = "26.5.6" }
 yazi-macro    = { path = "../yazi-macro", version = "26.5.6" }
+yazi-proxy    = { path = "../yazi-proxy", version = "26.5.6" }
 yazi-shared   = { path = "../yazi-shared", version = "26.5.6" }
 yazi-shim     = { path = "../yazi-shim", version = "26.5.6" }
 yazi-term     = { path = "../yazi-term", version = "26.5.6" }

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -5,6 +5,7 @@ use ratatui_core::{buffer::Buffer, layout::Rect, terminal::{CompletedFrame, Fram
 use yazi_config::YAZI;
 use yazi_emulator::{Emulator, Mux, TMUX};
 use yazi_macro::writef;
+use yazi_proxy::AppProxy;
 use yazi_shim::cell::SyncCell;
 use yazi_term::{TERM, event::{Event, KeyEventKind}, stream::EventStream};
 use yazi_tty::{TTY, TtyWriter, sequence::{DisableBracketedPaste, DisableDrag, DisableDrop, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste, EnableDrag, EnableDrop, EnableFocusChange, EnableMouseCapture, EnterAlternateScreen, If, LeaveAlternateScreen, PopKeyboardFlags, PushKeyboardFlags, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKeyboardFlags, RestoreCursorStyle, SetTitle, ShowCursor}};
@@ -105,6 +106,7 @@ impl Raterm {
 					_ => yazi_shared::event::Event::Term(event).emit(),
 				}
 			}
+			AppProxy::quit(Default::default());
 		});
 	}
 


### PR DESCRIPTION
Fixes #4051