### PR TITLE
fix: split graceful vs passive stop in terminal stream

### DIFF
--- a/yazi-term/src/source/unix.rs
+++ b/yazi-term/src/source/unix.rs
@@ -49,7 +49,7 @@ impl<'a> EventSource<'a> {
 		// Stop waiting for events.
 		if wakeup_ready {
 			while read_complete(&*self.waker, &mut [0u8; 1024])? != 0 {}
-			return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+			return Err(io::Error::from(io::ErrorKind::ConnectionAborted));
 		}
 
 		// More input is ready.

--- a/yazi-term/src/source/windows.rs
+++ b/yazi-term/src/source/windows.rs
@@ -28,7 +28,7 @@ impl<'a> EventSource<'a> {
 			// More input is ready.
 			WAIT_OBJECT_0 => Ok(()),
 			// Stop waiting for events.
-			r if r == WAIT_OBJECT_0 + 1 => Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+			r if r == WAIT_OBJECT_0 + 1 => Err(io::Error::from(io::ErrorKind::ConnectionAborted)),
 			// Timeout expired.
 			WAIT_TIMEOUT => Err(io::Error::from(io::ErrorKind::TimedOut)),
 			// An error occurred.

--- a/yazi-term/src/stream/stream.rs
+++ b/yazi-term/src/stream/stream.rs
@@ -33,6 +33,7 @@ impl EventStream {
 					}
 					// try_poll() already handles Interrupted, this is defensive.
 					Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+					// event source was gracefully stopped, stop the stream as well.
 					Err(e) if e.kind() == io::ErrorKind::ConnectionAborted => break,
 					Err(e) => {
 						tx.send(Err(e)).ok();

--- a/yazi-term/src/stream/stream.rs
+++ b/yazi-term/src/stream/stream.rs
@@ -33,6 +33,7 @@ impl EventStream {
 					}
 					// try_poll() already handles Interrupted, this is defensive.
 					Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+					Err(e) if e.kind() == io::ErrorKind::ConnectionAborted => break,
 					Err(e) => {
 						tx.send(Err(e)).ok();
 						break;

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -109,7 +109,7 @@ impl Raterm {
 					Some(Err(_)) => {
 						AppProxy::quit(Default::default());
 						break;
-					},
+					}
 					None => break,
 				}
 			}

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -97,16 +97,22 @@ impl Raterm {
 		let mut rx = self.stream.take().unwrap();
 
 		tokio::spawn(async move {
-			while let Some(Ok(event)) = rx.recv().await {
-				match event {
-					Event::Key(key) if key.kind != KeyEventKind::Press => continue,
-					Event::Mouse(mouse) if !YAZI.mgr.mouse_events.get().contains(mouse.kind.into()) => {
-						continue;
-					}
-					_ => yazi_shared::event::Event::Term(event).emit(),
+			loop {
+				match rx.recv().await {
+					Some(Ok(event)) => match event {
+						Event::Key(key) if key.kind != KeyEventKind::Press => continue,
+						Event::Mouse(mouse) if !YAZI.mgr.mouse_events.get().contains(mouse.kind.into()) => {
+							continue;
+						}
+						_ => yazi_shared::event::Event::Term(event).emit(),
+					},
+					Some(Err(_)) => {
+						AppProxy::quit(Default::default());
+						break;
+					},
+					None => break,
 				}
 			}
-			AppProxy::quit(Default::default());
 		});
 	}
 


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4053 

## Rationale of this PR

PR #4052 introduced behavior on MacOS/Linux that caused any blocking child process (nvim, fzf, zoxide) to immediately quit yazi. When the `Process::block` calls `AppProxy::stop().await` ([process.rs:24](yazi-scheduler/src/process/process.rs#L24)), that signal flow eventually hits the wakeup path in `unix.rs` which returned `UnexpectedEof`; but, blocking child processes didn't have a way of being differentiated apart from real TTY closures. Introduced the `ConnectionAborted` error kind to distinguish child process wakes from unexpected TTY closures, preventing `AppProxy::quit()` from firing on deliberate stops.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)

## Notes

- I've tested this on MacOS and it fixes the "immediate quit" issue, ran the tests and they passed, but I haven't tried it out on Linux.
