### PR TITLE
fix: use WebP as `magick` preset preloader output format to keep image transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 ### Fixed
 
 - Keep package hashes indifferent to line endings when `ya pkg` pulls packages ([#4064])
+- Use WebP as `magick` preset preloader cache format to keep image transparency ([#4065])
 
 ### Improved
 
@@ -1751,3 +1752,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4031]: https://github.com/sxyazi/yazi/pull/4031
 [#4040]: https://github.com/sxyazi/yazi/pull/4040
 [#4064]: https://github.com/sxyazi/yazi/pull/4064
+[#4065]: https://github.com/sxyazi/yazi/pull/4065

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ### Fixed
 
-- Keep package hashes indifferent to line endings when `ya pkg` pulls packages
+- Keep package hashes indifferent to line endings when `ya pkg` pulls packages ([#4064])
 
 ### Improved
 
@@ -1750,3 +1750,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4022]: https://github.com/sxyazi/yazi/pull/4022
 [#4031]: https://github.com/sxyazi/yazi/pull/4031
 [#4040]: https://github.com/sxyazi/yazi/pull/4040
+[#4064]: https://github.com/sxyazi/yazi/pull/4064

--- a/yazi-plugin/preset/plugins/magick.lua
+++ b/yazi-plugin/preset/plugins/magick.lua
@@ -49,7 +49,7 @@ function M:preload(job)
 		cmd:arg { "-background", job.args.bg, "-alpha", "remove" }
 	end
 
-	local status, err = cmd:arg(string.format("JPG:%s", cache)):status()
+	local status, err = cmd:arg(string.format("WEBP:%s", cache)):status()
 	if not status then
 		return true, Err("Failed to start `magick`, error: %s", err)
 	elseif not status.success then


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/4054