### PR TITLE
fix: sort interactive `cd` candidates case-insensitively so short exact matches match first

### DIFF
--- a/yazi-actor/src/cmp/trigger.rs
+++ b/yazi-actor/src/cmp/trigger.rs
@@ -53,7 +53,7 @@ impl Actor for Trigger {
 
 			if !cache.is_empty() {
 				cache
-					.sort_unstable_by(|a, b| natsort(a.name.encoded_bytes(), b.name.encoded_bytes(), false));
+					.sort_unstable_by(|a, b| natsort(a.name.encoded_bytes(), b.name.encoded_bytes(), true));
 				CmpProxy::show(CmpOpt { cache, cache_name: parent, word, ticket });
 			}
 


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/4025