### PR TITLE
fix: use cleaned and normalized `$PWD` as startup CWD to avoid MSYS2/git-bash path quirks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Normalize `\\?\`-prefixed Verbatim paths when creating relative symlinks on Windows ([#4067])
 - Keep package hashes indifferent to line endings when `ya pkg` pulls packages ([#4064])
 - Use WebP as `magick` preset preloader cache format to keep image transparency ([#4065])
+- Use cleaned and normalized `$PWD` as startup CWD to avoid MSYS2/git-bash path quirks
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Normalize `\\?\`-prefixed Verbatim paths when creating relative symlinks on Windows ([#4067])
 - Keep package hashes indifferent to line endings when `ya pkg` pulls packages ([#4064])
 - Use WebP as `magick` preset preloader cache format to keep image transparency ([#4065])
-- Use cleaned and normalized `$PWD` as startup CWD to avoid MSYS2/git-bash path quirks
+- Use cleaned and normalized `$PWD` as startup CWD to avoid MSYS2/git-bash path quirks ([#4068])
 
 ### Improved
 
@@ -1756,3 +1756,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4064]: https://github.com/sxyazi/yazi/pull/4064
 [#4065]: https://github.com/sxyazi/yazi/pull/4065
 [#4067]: https://github.com/sxyazi/yazi/pull/4067
+[#4068]: https://github.com/sxyazi/yazi/pull/4068

--- a/yazi-fs/src/cwd.rs
+++ b/yazi-fs/src/cwd.rs
@@ -4,7 +4,7 @@ use arc_swap::ArcSwap;
 use yazi_shared::url::{AsUrl, Url, UrlBuf, UrlLike};
 use yazi_shim::cell::RoCell;
 
-use crate::{FsUrl, Xdg};
+use crate::{FsUrl, Xdg, path::clean_url};
 
 pub static CWD: RoCell<Cwd> = RoCell::new();
 
@@ -18,13 +18,14 @@ impl Deref for Cwd {
 
 impl Default for Cwd {
 	fn default() -> Self {
-		let p = std::env::var_os("PWD")
+		let u = std::env::var_os("PWD")
 			.map(PathBuf::from)
 			.filter(|p| p.is_absolute())
-			.or_else(|| current_dir().ok())
+			.map(clean_url)
+			.or_else(|| current_dir().ok().map(UrlBuf::from))
 			.expect("failed to get current working directory");
 
-		Self(ArcSwap::new(Arc::new(UrlBuf::from(p))))
+		Self(ArcSwap::new(Arc::new(u)))
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/discussions/4028