### PR TITLE
fix: filter keybindings by chord in command palette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -820,9 +820,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bb4a855e3b10f84c4e7e895a7de01db7f9a7b7eb7f73ed9773fd52ac686451"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -2669,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.12"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8675564771a62f69a0af716b03e89b917b963c7b173b5855575e84fd4f605ca0"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
  "crypto-bigint",
  "crypto-common",

--- a/yazi-core/src/help/help.rs
+++ b/yazi-core/src/help/help.rs
@@ -41,53 +41,37 @@ impl Help {
 			self.keyword.clear();
 			self.bindings = KEYMAP.chords(self.layer).iter().cloned().collect();
 		} else if self.keyword != kw {
-			let lowercased = kw.to_lowercase();
 			self.keyword = kw.to_owned();
-
-			let exact_prefix = |on: &str| on.starts_with(kw);
-			let icase_prefix = |on: &str| on.to_lowercase().starts_with(&lowercased);
-
-			let all = KEYMAP.chords(self.layer);
-			// Priority 1: exact case-sensitive prefix (`y` -> `y`; `<C-` -> `<C-u>`)
-			let mut bindings: Vec<ChordArc> =
-				all.iter().filter(|c| exact_prefix(&c.on())).cloned().collect();
-			// Priority 2: case-insensitive prefix not in group 1 (`y` -> `Y`; `<e` -> `<Escape`)
-			bindings.extend(
-				all
-					.iter()
-					.filter(|c| {
-						let on = c.on();
-						!exact_prefix(&on) && icase_prefix(&on)
-					})
-					.cloned(),
-			);
-			// Priority 3: on() substring match (`enter` -> `<Enter>`, `<S-Enter>`)
-			let on_contains = |on: &str| on.to_lowercase().contains(&lowercased);
-			bindings.extend(
-				all
-					.iter()
-					.filter(|c| {
-						let on = c.on();
-						!icase_prefix(&on) && on_contains(&on)
-					})
-					.cloned(),
-			);
-			// Priority 4: desc-only match (`enter` -> `l` "Enter the child directory")
-			bindings.extend(
-				all
-					.iter()
-					.filter(|c| {
-						let on = c.on();
-						!icase_prefix(&on)
-							&& !on_contains(&on)
-							&& c.desc_or_run().to_lowercase().contains(&lowercased)
-					})
-					.cloned(),
-			);
-			self.bindings = bindings;
+			self.bindings = Self::filter_chords(&KEYMAP.chords(self.layer), kw);
 		}
 
 		render!(self.scroll(0));
+	}
+
+	fn filter_chords(chords: &[ChordArc], kw: &str) -> Vec<ChordArc> {
+		let lowercased = kw.to_lowercase();
+		let mut exact = vec![];
+		let mut icase = vec![];
+		let mut contains = vec![];
+		let mut desc = vec![];
+
+		for c in chords {
+			let on = c.on();
+			if on.starts_with(kw) {
+				exact.push(c.clone());
+			} else if on.to_lowercase().starts_with(&lowercased) {
+				icase.push(c.clone());
+			} else if on.to_lowercase().contains(&lowercased) {
+				contains.push(c.clone());
+			} else if c.desc_or_run().to_lowercase().contains(&lowercased) {
+				desc.push(c.clone());
+			}
+		}
+
+		exact.extend(icase);
+		exact.extend(contains);
+		exact.extend(desc);
+		exact
 	}
 }
 

--- a/yazi-core/src/help/help.rs
+++ b/yazi-core/src/help/help.rs
@@ -43,12 +43,48 @@ impl Help {
 		} else if self.keyword != kw {
 			let lowercased = kw.to_lowercase();
 			self.keyword = kw.to_owned();
-			self.bindings = KEYMAP
-				.chords(self.layer)
-				.iter()
-				.filter(|&c| c.desc_or_run().to_lowercase().contains(&lowercased))
-				.cloned()
-				.collect();
+
+			let exact_prefix = |on: &str| on.starts_with(kw);
+			let icase_prefix = |on: &str| on.to_lowercase().starts_with(&lowercased);
+
+			let all = KEYMAP.chords(self.layer);
+			// Priority 1: exact case-sensitive prefix (`y` -> `y`; `<C-` -> `<C-u>`)
+			let mut bindings: Vec<ChordArc> =
+				all.iter().filter(|c| exact_prefix(&c.on())).cloned().collect();
+			// Priority 2: case-insensitive prefix not in group 1 (`y` -> `Y`; `<e` -> `<Escape`)
+			bindings.extend(
+				all
+					.iter()
+					.filter(|c| {
+						let on = c.on();
+						!exact_prefix(&on) && icase_prefix(&on)
+					})
+					.cloned(),
+			);
+			// Priority 3: on() substring match (`enter` -> `<Enter>`, `<S-Enter>`)
+			let on_contains = |on: &str| on.to_lowercase().contains(&lowercased);
+			bindings.extend(
+				all
+					.iter()
+					.filter(|c| {
+						let on = c.on();
+						!icase_prefix(&on) && on_contains(&on)
+					})
+					.cloned(),
+			);
+			// Priority 4: desc-only match (`enter` -> `l` "Enter the child directory")
+			bindings.extend(
+				all
+					.iter()
+					.filter(|c| {
+						let on = c.on();
+						!icase_prefix(&on)
+							&& !on_contains(&on)
+							&& c.desc_or_run().to_lowercase().contains(&lowercased)
+					})
+					.cloned(),
+			);
+			self.bindings = bindings;
 		}
 
 		render!(self.scroll(0));


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4077

## Rationale of this PR

Updated some of the `filter_apply()` logic to address keybindings not being searchable in the command palette.

Had to introduce the following priority system to keep results intuitive:

1. **Exact prefix** (case-sensitive):
   - `y` -> `y`
   - `<C-` -> `<C-u>`, `<C-d>`, ...
2. **Case-insensitive prefix**:
   - `y` -> `Y`
   - `<e` -> `<Escape>`
   - `<c-u` -> `<C-u>`
3. **Key-name substring**:
   - `enter` -> `<Enter>`, `<S-Enter>`, ...
   - `left` -> `<Left>`
   - `backspace` -> `<Backspace>`
4. **Description substring**:
   - `enter` -> `l` ("Enter the child directory"), etc.

This means a user typing `y` sees `y` first, then `Y` second — before any description noise from words like "directory".

A user typing `y` will see `y` first, then `Y`, then descriptions from soft-matches like "directory" or "copy". Hopefully that doesn't stray too far from pre-existing behavior, but I think it feels fairly intuitive.

<img width="1810" height="1189" alt="image" src="https://github.com/user-attachments/assets/fcebbbc9-cd1b-45b6-8e7e-0b0fc90056c4" />

(On a side note, it'd be cool to be able to search across `run` strings too, but I see how that could get noisy. Maybe something like a new `[mgr] help_search_run = true` option in `yazi.toml` could introduce that in a separate PR.)

(Also, still learning best contributing practices, so I kept some comments in `help.rs` to show ordering intent. I can avoid that in future PRs if you prefer.)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
