### PR TITLE
perf: switch memory allocator back to jemalloc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,16 @@
 [env]
-MACOSX_DEPLOYMENT_TARGET = "10.12"
+MACOSX_DEPLOYMENT_TARGET  = "10.12"
+JEMALLOC_SYS_WITH_LG_PAGE = "16"
+
+# environment variable for tikv-jemalloc-sys
+#
+# https://jemalloc.net/jemalloc.3.html#opt.narenas
+# narenas is the maximum number of arenas to use for automatic multiplexing
+# of threads and arenas. The default is four times the number of CPUs,
+# or one if there is a single CPU.
+#
+# Improve memory efficiency by reducing fragmentation and ensuring all threads allocate from the same pool
+JEMALLOC_SYS_WITH_MALLOC_CONF = "narenas:1"
 
 [target.aarch64-apple-darwin]
 rustflags = [ "-Ctarget-cpu=apple-m1" ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,15 +1897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,15 +2009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3828,6 +3810,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,12 +4980,12 @@ dependencies = [
  "better-panic",
  "fdlimit",
  "libc",
- "mimalloc",
  "mlua",
  "paste",
  "ratatui-core",
  "ratatui-widgets",
  "signal-hook-tokio",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -7,6 +7,7 @@
 
   installShellFiles,
   fetchFromGitHub,
+  rust-jemalloc-sys,
 
   imagemagick,
 }:
@@ -38,6 +39,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     installShellFiles
     imagemagick
+  ];
+
+  buildInputs = [
+    rust-jemalloc-sys
   ];
 
   postInstall = ''

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -59,7 +59,7 @@ libc              = { workspace = true }
 signal-hook-tokio = { version = "0.4.0", features = [ "futures-v0_3" ] }
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
-mimalloc = "0.1.52"
+tikv-jemallocator = "0.6.1"
 
 [[bin]]
 name = "yazi"

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -1,6 +1,6 @@
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 yazi_macro::mod_pub!(app cmp confirm help input mgr notify pick spot tasks which);
 


### PR DESCRIPTION
Tested against https://github.com/sxyazi/yazi/pull/4083 on my Linux VM and saw the build size drop by 0.2M, but startup memory usage went up by 32%.

mimalloc doesn't really seem to fit our needs, switching back to the old good jemalloc.