### PR TITLE
fix: input icon spacing/create --dir detection, and add show_icons/truncate_paths options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Make help menu a command palette ([#4074])
 - H/M/L Vim-like motion for moving cursor relative to viewport ([#3970])
 - Context-aware icons for inputs ([#4080])
+- New `show_icons` option under `[input]` to toggle icons on input popups ([#4100])
 - Show file icons in trash/delete/overwrite confirmations ([#4096])
 - Dynamic keymap Lua API ([#4031])
 - New `ui.Input` element ([#4040])
@@ -1768,3 +1769,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4074]: https://github.com/sxyazi/yazi/pull/4074
 [#4080]: https://github.com/sxyazi/yazi/pull/4080
 [#4096]: https://github.com/sxyazi/yazi/pull/4096
+[#4100]: https://github.com/sxyazi/yazi/pull/4100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - H/M/L Vim-like motion for moving cursor relative to viewport ([#3970])
 - Context-aware icons for inputs ([#4080])
 - New `show_icons` option under `[input]` to toggle icons on input popups ([#4100])
+- New `show_icons` and `truncate_paths` options under `[confirm]` to toggle icons and RTL-ellipsis-truncate long paths on trash/delete/overwrite confirmations ([#4100])
 - Show file icons in trash/delete/overwrite confirmations ([#4096])
 - Dynamic keymap Lua API ([#4031])
 - New `ui.Input` element ([#4040])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4882,6 +4882,7 @@ dependencies = [
  "serde_with",
  "toml",
  "tracing",
+ "unicode-width",
  "yazi-binding",
  "yazi-codegen",
  "yazi-fs",

--- a/yazi-config/Cargo.toml
+++ b/yazi-config/Cargo.toml
@@ -39,3 +39,4 @@ serde           = { workspace = true }
 serde_with      = { workspace = true }
 toml            = { workspace = true }
 tracing         = { workspace = true }
+unicode-width   = { workspace = true }

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -214,6 +214,9 @@ shell_origin = "top-center"
 shell_offset = [ 0, 2, 50, 3 ]
 
 [confirm]
+truncate_paths = false
+show_icons     = true
+
 # trash
 trash_title 	= "Trash {n} selected file{s}?"
 trash_origin	= "center"

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -176,6 +176,7 @@ previewers = [
 
 [input]
 cursor_blink = false
+show_icons   = true
 
 # cd
 cd_title  = "Change directory:"

--- a/yazi-config/src/popup/confirm.rs
+++ b/yazi-config/src/popup/confirm.rs
@@ -4,6 +4,9 @@ use yazi_codegen::{DeserializeOver, DeserializeOver2};
 
 #[derive(Deserialize, DeserializeOver, DeserializeOver2)]
 pub struct Confirm {
+	pub truncate_paths: bool,
+	pub show_icons:     bool,
+
 	// trash
 	pub trash_title:  String,
 	pub trash_origin: Origin,

--- a/yazi-config/src/popup/input.rs
+++ b/yazi-config/src/popup/input.rs
@@ -7,6 +7,7 @@ use yazi_widgets::input::InputOpt;
 #[derive(Deserialize, DeserializeOver, DeserializeOver2)]
 pub struct Input {
 	pub cursor_blink: bool,
+	pub show_icons:   bool,
 
 	// cd
 	pub cd_title:  String,

--- a/yazi-config/src/popup/input.rs
+++ b/yazi-config/src/popup/input.rs
@@ -58,7 +58,7 @@ impl Input {
 
 	pub fn create(&self, dir: bool) -> InputOpt {
 		InputOpt {
-			id: "create".to_owned(),
+			id: if dir { "create-dir" } else { "create" }.to_owned(),
 			title: self.create_title[dir as usize].clone(),
 			position: Position::new(self.create_origin, self.create_offset),
 			..Default::default()

--- a/yazi-config/src/popup/options.rs
+++ b/yazi-config/src/popup/options.rs
@@ -2,12 +2,18 @@ use std::slice;
 
 use ratatui_core::text::{Line, Span, Text};
 use ratatui_widgets::paragraph::{Paragraph, Wrap};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use yazi_binding::position::Position;
 use yazi_fs::file::File;
 use yazi_macro::impl_data_any;
 use yazi_shared::strand::ToStrand;
 
 use crate::{THEME, YAZI};
+
+// Mirrors the horizontal `Margin::new(2, 0)` the confirm list widget applies
+// around its content (yazi-fm/src/confirm/list.rs), so a path truncated here
+// to the popup's configured width doesn't still overflow once rendered.
+const LIST_MARGIN: u16 = 4;
 
 // --- PickCfg
 #[derive(Clone, Debug, Default)]
@@ -46,29 +52,32 @@ impl ConfirmCfg {
 	}
 
 	pub fn trash(files: &[File]) -> Self {
+		let position = YAZI.confirm.trash_position();
 		Self::new(
 			Self::replace_number(&YAZI.confirm.trash_title, files.len()),
-			YAZI.confirm.trash_position(),
+			position,
 			None,
-			Self::truncate_files(files, 100),
+			Self::truncate_files(files, 100, position.width),
 		)
 	}
 
 	pub fn delete(files: &[File]) -> Self {
+		let position = YAZI.confirm.delete_position();
 		Self::new(
 			Self::replace_number(&YAZI.confirm.delete_title, files.len()),
-			YAZI.confirm.delete_position(),
+			position,
 			None,
-			Self::truncate_files(files, 100),
+			Self::truncate_files(files, 100, position.width),
 		)
 	}
 
 	pub fn overwrite(file: &File) -> Self {
+		let position = YAZI.confirm.overwrite_position();
 		Self::new(
 			YAZI.confirm.overwrite_title.clone(),
-			YAZI.confirm.overwrite_position(),
+			position,
 			Some(Text::raw(&YAZI.confirm.overwrite_body)),
-			Self::truncate_files(slice::from_ref(file), 1),
+			Self::truncate_files(slice::from_ref(file), 1, position.width),
 		)
 	}
 
@@ -101,7 +110,9 @@ impl ConfirmCfg {
 		Some(Text::from_iter(lines))
 	}
 
-	fn truncate_files(files: &[File], max: usize) -> Option<Text<'static>> {
+	fn truncate_files(files: &[File], max: usize, width: u16) -> Option<Text<'static>> {
+		let budget = (width as usize).saturating_sub(LIST_MARGIN as usize);
+
 		let mut lines = Vec::with_capacity(files.len().min(max + 1));
 		for (i, f) in files.iter().enumerate() {
 			if i >= max {
@@ -110,12 +121,47 @@ impl ConfirmCfg {
 			}
 
 			lines.push(Line::default());
-			if let Some(icon) = THEME.icon.matches(f, false) {
+			let mut prefix = 0;
+			if YAZI.confirm.show_icons
+				&& let Some(icon) = THEME.icon.matches(f, false)
+			{
+				prefix = icon.text.width() + 1;
 				lines[i].push_span(Span::styled(icon.text, icon.style));
 				lines[i].push_span(" ");
 			}
-			lines[i].push_span(f.url.to_strand().into_string_lossy());
+
+			let path = f.url.to_strand().into_string_lossy();
+			let path = if YAZI.confirm.truncate_paths {
+				Self::truncate_rtl(&path, budget.saturating_sub(prefix))
+			} else {
+				path
+			};
+			lines[i].push_span(path);
 		}
 		Some(lines.into())
+	}
+
+	// Truncates `s` from the left with a leading `…`, keeping its tail, since
+	// the end of a path is usually more identifying than its start.
+	fn truncate_rtl(s: &str, max: usize) -> String {
+		if s.width() <= max {
+			return s.to_owned();
+		}
+		if max == 0 {
+			return String::new();
+		}
+
+		let mut adv = 0;
+		let mut idx = s.len();
+		for (i, c) in s.char_indices().rev() {
+			let w = c.width().unwrap_or(0);
+			if adv + w > max.saturating_sub(1) {
+				break;
+			}
+			adv += w;
+			idx = i;
+		}
+
+		format!("…{}", &s[idx..])
 	}
 }

--- a/yazi-fm/src/input/input.rs
+++ b/yazi-fm/src/input/input.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use ratatui_core::{buffer::Buffer, layout::{Margin, Rect}, text::Line, widgets::Widget};
 use ratatui_widgets::{block::Block, borders::BorderType};
-use yazi_config::{Icon, THEME};
+use yazi_config::{Icon, THEME, YAZI};
 use yazi_core::Core;
 use yazi_fs::{cha::{Cha, ChaKind}, file::File};
 use yazi_shim::path::CROSS_SEPARATOR;
@@ -15,6 +15,10 @@ impl<'a> Input<'a> {
 	pub(crate) fn new(core: &'a Core) -> Self { Self { core } }
 
 	fn icon(&self) -> Option<Icon> {
+		if !YAZI.input.show_icons {
+			return None;
+		}
+
 		let input = &self.core.input.main;
 
 		let is_dir = input.value().ends_with(CROSS_SEPARATOR);

--- a/yazi-fm/src/input/input.rs
+++ b/yazi-fm/src/input/input.rs
@@ -23,6 +23,7 @@ impl<'a> Input<'a> {
 		let (path, mode): (&str, u16) = match input.id.as_str() {
 			"cd" => (input.value(), if is_dir { 0o40755 } else { 0o100644 }),
 			"create" => (input.value(), if is_dir { 0o40755 } else { 0o100644 }),
+			"create-dir" => (input.value(), 0o40755),
 			"rename-file" => (input.value(), 0o100644),
 			"rename-dir" => (input.value(), 0o40755),
 			"shell" => ("icon.sh", 0o100644),
@@ -53,7 +54,7 @@ impl Widget for Input<'_> {
 			.title(Line::styled(&input.title, THEME.input.title.get()));
 
 		if let Some(i) = self.icon() {
-			block = block.title_bottom(Line::raw(format!("{} ", i.text)).style(i.style).right_aligned());
+			block = block.title_bottom(Line::raw(i.text).style(i.style).right_aligned());
 		}
 
 		block.render(outer, buf);


### PR DESCRIPTION
## Summary

Follow-ups to #4080 (context-aware icons for inputs) and #4096 (icons on trash/delete/overwrite confirmations):

- The icon rendered in the input popup's bottom title always had a trailing space baked into its text (`format!("{} ", i.text)`), which made it visually inconsistent with the title text above it, which has no trailing space. Removed it.

<img width="1381" height="212" alt="image" src="https://github.com/user-attachments/assets/d14b60fc-5b57-4e18-8a9a-092b6a325a20" />

- `create --dir` (the dedicated "create directory" action) always showed the file icon while typing. The icon lookup only distinguishes file vs. dir by checking whether the currently typed value ends with a path separator — a convention that only applies to the plain `create` action (file-or-dir depending on a trailing `/`). Since `create`'s `InputOpt` didn't carry the `dir` flag anywhere past choosing the title, the icon code had no way to know `--dir` was passed. Gave it its own `create-dir` id (mirroring the existing `rename-file`/`rename-dir` split) so it always resolves to the directory icon.
- Added a `show_icons` option under `[input]` (enabled by default) so the icon feature can be turned off for input popups specifically, without having to clear all `[icon]` rules and lose file-type icons everywhere else.
- Added `show_icons` (enabled by default) and `truncate_paths` (disabled by default) options under `[confirm]`:
  - `show_icons` independently toggles icons on the trash/delete/overwrite confirmation dialogs.
  - `truncate_paths` RTL-truncates each listed path (with a leading `…`) to fit the popup's own configured width instead of relying on the list's word-wrap — a path has no internal spaces to break on, so a long path previously wrapped onto its own line right after the icon whenever it didn't fit, which reads like a stray newline. Off by default to preserve current behavior.

Defaults:

<img width="1394" height="458" alt="image" src="https://github.com/user-attachments/assets/15a699a8-0345-433c-a432-7604dec2e601" />

With `confirm.show_icons = false`:

<img width="1411" height="469" alt="image" src="https://github.com/user-attachments/assets/07ed0dff-7092-4f77-b8c4-733bbac955c0" />

With `confirm.truncate_paths = true`:

<img width="1411" height="469" alt="image" src="https://github.com/user-attachments/assets/d142adaa-a6da-453c-a0fb-4ec6e505c45b" />

And with both the above flags set as said above: 

<img width="1411" height="469" alt="image" src="https://github.com/user-attachments/assets/d608b6c5-69cb-46ab-b63f-7bd5d1897661" />

## AI disclaimer

This PR was developed with AI assistance (Claude Code). I reviewed, tested, and am responsible for all of the changes.

## Test plan

- [x] `cargo check -p yazi-fm -p yazi-config` passes
- [x] `cargo fmt --check` shows no diff for the changed files
- [x] Manually verify: `create` (file/dir input, e.g. bound to `A`) still switches icon live based on a trailing `/`
- [x] Manually verify: `create --dir` (e.g. bound to `a`) shows the directory icon immediately, with no trailing space after any input icon
- [x] Manually verify: setting `show_icons = false` under `[input]` hides icons on all input popups (cd/create/rename/shell), and the default (`true`) preserves current behavior
- [x] Manually verify: setting `show_icons = false` under `[confirm]` hides icons on trash/delete/overwrite dialogs
- [x] Manually verify: setting `truncate_paths = true` under `[confirm]` shows a truncated `…`-prefixed path on one line for long paths instead of wrapping to a second line