### PR TITLE
Verify SFTP host keys

### DIFF
--- a/yazi-shared/src/url/buf.rs
+++ b/yazi-shared/src/url/buf.rs
@@ -167,8 +167,8 @@ impl UrlBuf {
 				Self::Archive { loc: loc.rebase(base), domain: domain.clone() }
 			}
 			Self::Sftp { loc, domain } => {
-				todo!();
-				// Self::Sftp { loc: loc.rebase(base), domain: domain.clone() }
+				let base = typed_path::UnixPath::new(base.as_os_str().as_encoded_bytes());
+				Self::Sftp { loc: loc.rebase(base), domain: domain.clone() }
 			}
 		}
 	}

--- a/yazi-vfs/src/provider/sftp/conn.rs
+++ b/yazi-vfs/src/provider/sftp/conn.rs
@@ -1,8 +1,8 @@
 use std::{io, sync::Arc, time::{Duration, SystemTime}};
 
 use chrono::DateTime;
-use russh::keys::{PrivateKeyWithHashAlg, agent::AgentIdentity};
-use yazi_fs::provider::local::Local;
+use russh::keys::{PrivateKeyWithHashAlg, agent::AgentIdentity, known_hosts};
+use yazi_fs::{provider::local::Local, Xdg};
 
 use crate::config::ServiceSftp;
 
@@ -23,9 +23,30 @@ impl russh::client::Handler for Conn {
 
 	async fn check_server_key(
 		&mut self,
-		_server_public_key: &russh::keys::PublicKey,
+		server_public_key: &russh::keys::PublicKey,
 	) -> Result<bool, Self::Error> {
-		Ok(true)
+		let path = Xdg::config_dir().join("known_hosts");
+
+		match known_hosts::check_known_hosts_path(&self.config.host, self.config.port, server_public_key, &path) {
+			Ok(true) => Ok(true),
+			Ok(false) => {
+				if let Err(e) = known_hosts::learn_known_hosts_path(&self.config.host, self.config.port, server_public_key, &path) {
+					tracing::warn!("Failed to record host key in known_hosts: {e}");
+				}
+				Ok(true)
+			}
+			Err(russh::keys::Error::KeyChanged { line }) => {
+				tracing::error!(
+					"Host key for `{}` has changed (known_hosts:{}). Possible MITM attack!",
+					self.config.host, line
+				);
+				Ok(false)
+			}
+			Err(e) => {
+				tracing::warn!("Could not verify host key for `{}`: {e}", self.config.host);
+				Ok(true)
+			}
+		}
 	}
 }
 

--- a/yazi-vfs/src/provider/sftp/conn.rs
+++ b/yazi-vfs/src/provider/sftp/conn.rs
@@ -2,7 +2,7 @@ use std::{io, sync::Arc, time::{Duration, SystemTime}};
 
 use chrono::DateTime;
 use russh::keys::{PrivateKeyWithHashAlg, agent::AgentIdentity, known_hosts};
-use yazi_fs::{provider::local::Local, Xdg};
+use yazi_fs::{Xdg, provider::local::Local};
 
 use crate::config::ServiceSftp;
 
@@ -27,10 +27,20 @@ impl russh::client::Handler for Conn {
 	) -> Result<bool, Self::Error> {
 		let path = Xdg::config_dir().join("known_hosts");
 
-		match known_hosts::check_known_hosts_path(&self.config.host, self.config.port, server_public_key, &path) {
+		match known_hosts::check_known_hosts_path(
+			&self.config.host,
+			self.config.port,
+			server_public_key,
+			&path,
+		) {
 			Ok(true) => Ok(true),
 			Ok(false) => {
-				if let Err(e) = known_hosts::learn_known_hosts_path(&self.config.host, self.config.port, server_public_key, &path) {
+				if let Err(e) = known_hosts::learn_known_hosts_path(
+					&self.config.host,
+					self.config.port,
+					server_public_key,
+					&path,
+				) {
 					tracing::warn!("Failed to record host key in known_hosts: {e}");
 				}
 				Ok(true)
@@ -38,7 +48,8 @@ impl russh::client::Handler for Conn {
 			Err(russh::keys::Error::KeyChanged { line }) => {
 				tracing::error!(
 					"Host key for `{}` has changed (known_hosts:{}). Possible MITM attack!",
-					self.config.host, line
+					self.config.host,
+					line
 				);
 				Ok(false)
 			}

--- a/yazi-vfs/src/provider/sftp/conn.rs
+++ b/yazi-vfs/src/provider/sftp/conn.rs
@@ -54,8 +54,8 @@ impl russh::client::Handler for Conn {
 				Ok(false)
 			}
 			Err(e) => {
-				tracing::warn!("Could not verify host key for `{}`: {e}", self.config.host);
-				Ok(true)
+				tracing::error!("Could not verify host key for `{}`: {e}", self.config.host);
+				Ok(false)
 			}
 		}
 	}


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4114

## Rationale of this PR

This PR implements SSH host key verification for SFTP connections.

Previously, the `check_server_key()` callback unconditionally accepted every server host key by returning `Ok(true)`. As a result, the client's connection did not verify the server's identity before establishing the SSH session.

To address this, this PR introduces a Trust On First Use (TOFU) verification mechanism.

The implementation:

* Stores the server's public key in a local `known_hosts` file on the first successful connection.
* Verifies the presented host key against the stored key on subsequent connections.
* Rejects the connection if the host key has changed.
* Logs an appropriate error to notify the user of the host key mismatch.

This approach aligns the SFTP provider with the expected security behavior of SSH clients while preserving a straightforward user experience.

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
* [x] I confirm this PR follows the [[AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)