### PR TITLE
ci: pin winget-releaser to a full commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish to Winget
-        uses: vedantmgoyal9/winget-releaser@main
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: sxyazi.yazi
           installers-regex: 'yazi-(x86_64|aarch64)-pc-windows-msvc\.zip$'


### PR DESCRIPTION
## What
Pin `vedantmgoyal9/winget-releaser` in `publish.yml` from `@main` to the **v2** release commit (`4ffc788`).

## Why
The `winget` job hands this action `token: ${{ secrets.WINGET_TOKEN }}` (a publishing credential) on every release. Because `@main` is a moving branch, the exact code that receives that token can change without any change here. Pinning to the v2 commit fixes it to a reviewed version; behaviour is unchanged.

I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself and take responsibility for it.