### PR TITLE
fix(mgr): restore hovered fallback for %s/%d shell-formatting when no…

### DIFF
--- a/yazi-core/src/mgr/snap.rs
+++ b/yazi-core/src/mgr/snap.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use yazi_fs::Splatable;
 use yazi_shared::url::{AsUrl, Url, UrlBuf};
 
@@ -24,11 +26,15 @@ impl Splatable for MgrSnap {
 
 	fn selected(&self, tab: usize, mut idx: Option<usize>) -> impl Iterator<Item = Url<'_>> {
 		idx = idx.and_then(|i| i.checked_sub(1));
-		tab
-			.checked_sub(1)
-			.and_then(|tab| self.tabs.get(tab))
-			.map_or_else(|| &[][..], |s| &s.selected)
-			.iter()
+		// Fall back to the hovered item when nothing is explicitly selected, same
+		// as `Tab::selected_or_hovered_urls()` used for file operations elsewhere.
+		let urls: Box<dyn Iterator<Item = &UrlBuf>> =
+			match tab.checked_sub(1).and_then(|tab| self.tabs.get(tab)) {
+				Some(s) if !s.selected.is_empty() => Box::new(s.selected.iter()),
+				Some(s) => Box::new(s.hovered.iter()),
+				None => Box::new(iter::empty()),
+			};
+		urls
 			.skip(idx.unwrap_or(0))
 			.take(if idx.is_some() { 1 } else { usize::MAX })
 			.map(AsUrl::as_url)
@@ -50,5 +56,45 @@ impl Splatable for MgrSnap {
 			.skip(idx.unwrap_or(0))
 			.take(if idx.is_some() { 1 } else { usize::MAX })
 			.map(AsUrl::as_url)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+
+	use super::*;
+
+	fn url(s: &str) -> UrlBuf { UrlBuf::from(PathBuf::from(s)) }
+
+	fn snap(selected: &[&str], hovered: Option<&str>) -> MgrSnap {
+		MgrSnap {
+			tab:    0,
+			tabs:   vec![TabSnap {
+				hovered:  hovered.map(url),
+				selected: selected.iter().map(|s| url(s)).collect(),
+			}],
+			yanked: vec![],
+		}
+	}
+
+	#[test]
+	fn selected_falls_back_to_hovered_when_nothing_selected() {
+		let s = snap(&[], Some("hovered/file"));
+		let urls: Vec<_> = s.selected(1, None).collect();
+		assert_eq!(urls, [url("hovered/file")]);
+	}
+
+	#[test]
+	fn selected_prefers_actual_selection_over_hovered() {
+		let s = snap(&["a", "b"], Some("hovered/file"));
+		let urls: Vec<_> = s.selected(1, None).collect();
+		assert_eq!(urls, [url("a"), url("b")]);
+	}
+
+	#[test]
+	fn selected_is_empty_when_nothing_selected_or_hovered() {
+		let s = snap(&[], None);
+		assert_eq!(s.selected(1, None).count(), 0);
 	}
 }


### PR DESCRIPTION
…thing is selected

The Splatable impl for Mgr used to fall back to the hovered item via Tab::selected_or_hovered_urls() when the selection was empty, the same convention used everywhere else (yank, copy, remove, open). PR #4108 rewrote this into MgrSnap/TabSnap but only ported the plain "selected" list, dropping the hovered fallback. This made %s and %d expand to nothing when hovering a file without an explicit selection.

Restore the fallback in MgrSnap::selected(), which both %s/%S and %d/%D read from.

Resolves #4132

## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
