### PR TITLE
fix(mgr): restore hovered fallback for %s/%d shell-formatting when nothing is selected

### DIFF
--- a/yazi-core/src/mgr/snap.rs
+++ b/yazi-core/src/mgr/snap.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use yazi_fs::Splatable;
 use yazi_shared::url::{AsUrl, Url, UrlBuf};
 
@@ -24,14 +26,15 @@ impl Splatable for MgrSnap {
 
 	fn selected(&self, tab: usize, mut idx: Option<usize>) -> impl Iterator<Item = Url<'_>> {
 		idx = idx.and_then(|i| i.checked_sub(1));
-		tab
-			.checked_sub(1)
-			.and_then(|tab| self.tabs.get(tab))
-			.map_or_else(|| &[][..], |s| &s.selected)
-			.iter()
-			.skip(idx.unwrap_or(0))
-			.take(if idx.is_some() { 1 } else { usize::MAX })
-			.map(AsUrl::as_url)
+		// Fall back to the hovered item when nothing is explicitly selected, same
+		// as `Tab::selected_or_hovered_urls()` used for file operations elsewhere.
+		let urls: Box<dyn Iterator<Item = &UrlBuf>> =
+			match tab.checked_sub(1).and_then(|tab| self.tabs.get(tab)) {
+				Some(s) if !s.selected.is_empty() => Box::new(s.selected.iter()),
+				Some(s) => Box::new(s.hovered.iter()),
+				None => Box::new(iter::empty()),
+			};
+		urls.skip(idx.unwrap_or(0)).take(if idx.is_some() { 1 } else { usize::MAX }).map(AsUrl::as_url)
 	}
 
 	fn hovered(&self, tab: usize) -> Option<Url<'_>> {
@@ -50,5 +53,45 @@ impl Splatable for MgrSnap {
 			.skip(idx.unwrap_or(0))
 			.take(if idx.is_some() { 1 } else { usize::MAX })
 			.map(AsUrl::as_url)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+
+	use super::*;
+
+	fn url(s: &str) -> UrlBuf { UrlBuf::from(PathBuf::from(s)) }
+
+	fn snap(selected: &[&str], hovered: Option<&str>) -> MgrSnap {
+		MgrSnap {
+			tab:    0,
+			tabs:   vec![TabSnap {
+				hovered:  hovered.map(url),
+				selected: selected.iter().map(|s| url(s)).collect(),
+			}],
+			yanked: vec![],
+		}
+	}
+
+	#[test]
+	fn selected_falls_back_to_hovered_when_nothing_selected() {
+		let s = snap(&[], Some("hovered/file"));
+		let urls: Vec<_> = s.selected(1, None).collect();
+		assert_eq!(urls, [url("hovered/file")]);
+	}
+
+	#[test]
+	fn selected_prefers_actual_selection_over_hovered() {
+		let s = snap(&["a", "b"], Some("hovered/file"));
+		let urls: Vec<_> = s.selected(1, None).collect();
+		assert_eq!(urls, [url("a"), url("b")]);
+	}
+
+	#[test]
+	fn selected_is_empty_when_nothing_selected_or_hovered() {
+		let s = snap(&[], None);
+		assert_eq!(s.selected(1, None).count(), 0);
 	}
 }


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4132

## Rationale of this PR

The `Splatable` implementation for `Mgr` used to fall back to the hovered item (via `Tab::selected_or_hovered_urls()`) when nothing was explicitly selected — the same convention used everywhere else in yazi for file operations (yank, copy, remove, open). PR #4108 rewrote this into the new `MgrSnap`/`TabSnap` structs but only ported the plain `selected` list, dropping the fallback to the hovered item.

As a result, `%s`/`%S` and `%d`/`%D` in shell-formatted commands (e.g. custom keymaps using `shell -- ...`) expand to nothing when a file is hovered but not explicitly selected, as reported in #4132.

This restores the fallback in `MgrSnap::selected()`, which both the `%s` and `%d` visitors read from in `yazi-fs`'s `Splatter`. Added unit tests covering: falling back to hovered when nothing is selected, preferring an explicit selection over the hovered item, and staying empty when neither is present.

**Verified:**
- Added regression tests fail against the pre-fix code and pass with the fix.
- `cargo test --workspace` passes.
- `cargo clippy -p yazi-core` reports no new warnings on the changed file.

## AI Policy disclosure

This PR was prepared with assistance from Claude Code (Anthropic, Claude model). Extent of AI assistance: identifying the root cause (diffing PR #4108 to find the dropped fallback), implementing the fix, and writing/running the regression tests described above. I (the PR author) reviewed, tested, and understood the change and how it fits into the rest of the codebase before submitting it. Anthropic/Claude does not assert copyright over this contribution.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)