### PR TITLE
fix: privilege hovered file when splatting commands in the `shell` action

### DIFF
--- a/yazi-core/src/mgr/snap.rs
+++ b/yazi-core/src/mgr/snap.rs
@@ -23,13 +23,13 @@ impl Splatable for MgrSnap {
 
 	fn selected(&self, tab: usize, mut idx: Option<usize>) -> impl Iterator<Item = &File> {
 		idx = idx.and_then(|i| i.checked_sub(1));
-		tab
-			.checked_sub(1)
-			.and_then(|tab| self.tabs.get(tab))
-			.map_or_else(|| &[][..], |s| &s.selected)
-			.iter()
-			.skip(idx.unwrap_or(0))
-			.take(if idx.is_some() { 1 } else { usize::MAX })
+
+		let files = match tab.checked_sub(1).and_then(|tab| self.tabs.get(tab)) {
+			Some(s) if !s.selected.is_empty() => &s.selected,
+			Some(s) => s.hovered.as_slice(),
+			None => &[],
+		};
+		files.iter().skip(idx.unwrap_or(0)).take(if idx.is_some() { 1 } else { usize::MAX })
 	}
 
 	fn hovered(&self, tab: usize) -> Option<&File> {


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4132

## Rationale of this PR

- Before: `%s`/`%d` used the selected list, and fell back to the hovered file when nothing was selected.
- After PR #4108: `MgrSnap`/`TabSnap` only carried the selected list, so the hovered fallback was missing.
- Impact: hovering a file without an explicit selection made `%s`/`%d` expand to empty.
- This fix: restore the fallback in `MgrSnap::selected()`.

The root cause was already correctly diagnosed by @nabsei in #4133 / #4135. Those PRs were withdrawn over AI-disclosure process friction, not because the fix was wrong.

## Verified

- `cargo test -p yazi-core --lib` — 19 passed, including 3 new tests for `MgrSnap::selected()`:
  - falls back to hovered when selection is empty
  - prefers explicit selection over hovered
  - stays empty when neither is present
- `cargo clippy -p yazi-core --lib` — no new warnings on the changed file

## AI Policy disclosure

Prepared with Claude Code assistance:
- Orchestration: Opus 4.8
- Implementation: Sonnet 5

AI helped with diagnosis, code, and tests. I reviewed the change, understand how it fits in the codebase, and verified the tests above myself before submitting. Anthropic/Claude does not assert copyright over this contribution.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)