### PR TITLE
docs: add a note about following the contribution guidelines in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,5 @@ If it has already been detailed in the associated issue, please skip this sectio
 
 - [ ] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
 - [ ] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
+
+<!-- If an AI agent opened this PR, verify only one PR was created and that the disclosure above is in the final body. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ If it has already been detailed in the associated issue, please skip this sectio
 - [ ] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
 - [ ] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
 
-<!-- If you used AI tooling while preparing this PR, write and post this description yourself, and double-check it's the only PR that got created. -->
+<!-- AI bots are not allowed to open PRs in this repository. All PRs must be made by humans and comply with the AI policy. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ If it has already been detailed in the associated issue, please skip this sectio
 - [ ] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
 - [ ] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
 
-<!-- If an AI agent opened this PR, verify only one PR was created and that the disclosure above is in the final body. -->
+<!-- If you used AI tooling while preparing this PR, write and post this description yourself, and double-check it's the only PR that got created. -->


### PR DESCRIPTION
## Which issue does this PR resolve?

Following up on [your comment on #4137](https://github.com/sxyazi/yazi/pull/4137#issuecomment-5027768339) suggesting a short note in the PR template rather than CONTRIBUTING.md — here's a small proposal.

## Rationale of this PR

Adds a one-line HTML comment (invisible once the PR is rendered, visible while editing) right after the AI Policy checkbox in `.github/pull_request_template.md`.

When I opened #4133/#4135 earlier, a single PR-creation invocation ended up producing two PRs, one of which was missing the disclosure text — which caused avoidable confusion. This note is a small reminder for anyone in the same situation to double check they ended up with exactly one PR containing the disclosure they intended, before it becomes a review-time surprise.

This is docs-only, no code touched.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

---
This PR was prepared with the assistance of Claude Code (Anthropic's CLI-based coding agent). The change and rationale above were reviewed and confirmed by me before submitting.