### PR TITLE
fix: `copy path` should always copy file paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@
 - Use Rust prefixes (`as_`, `to_`, `into_`, `try_`, `is_`, `has_`) according to their usual semantics; prefer descriptive names.
 - Name variables, modules, methods, and other symbols simply, elegantly, and expressively. Be creative while keeping names clear, consistent with established terminology, and idiomatic.
 - When passing arguments, use the parameter's conversion traits directly (such as `Into<_>` or `AsRef<_>`); avoid eager conversions like `.to_string()`, `.to_owned()`, and `.as_ref()` unless ownership, type inference, or semantics require them.
+- Prefer methods provided by `UrlLike`, `PathLike`, or `StrandLike` directly on the original value (for example, `buf.parent()` over `buf.as_url().parent()`), rather than converting it first with `as_url()`, `dyn_path()`, or `to_strand()`.
+- Prefer `&*value` for dereferencing over `AsRef` when both are suitable.
 - Prefer general-purpose traits and conversion APIs already provided by the codebase or its dependencies over manual construction or adapter closures; for example, use `into_lua()` where applicable.
 
 ## Code Changes
@@ -26,7 +28,8 @@
 - Put reusable code in the lowest suitable shared layer; avoid unnecessary dependencies and allocations. Prefer borrowed values and existing wrappers.
 - Use stable Rust APIs; nightly is formatting-only. Use only `pub`, `pub(super)`, and `pub(crate)`—never `pub(in ...)`.
 - Keep async I/O non-blocking, preserve platform/fork behavior, and follow existing error boundaries with `?`.
-- For renames or refactors, update all related variables, functions, parameters, modules, methods, types, derived types, exports, tests, configuration keys, documentation, and Lua bindings.
+- For renames or refactors, update all related variables, functions, parameters, modules, methods, types, derived types, exports, tests, configuration keys, documentation, Lua bindings, and, when a type and file share a name, the file as well.
+- When adding a changelog entry, leave the PR number blank for a human to fill in.
 - Do not add or modify tests unless requested.
 
 ## Validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ### Deprecated
 
-- Deprecate `copy dirname` in favor of `copy dirpath`
+- Deprecate `copy dirname` in favor of `copy dirpath` ([#4169])
 - Deprecate `backward --far` and `forward --far` in favor of `backward wide` and `forward wide`, respectively ([#4012])
 - Deprecate `tab::Mode.is_visual` in favor of the new `tab::Mode.is_normal` ([#4101])
 - Deprecate `Url.is_regular`, `Url.is_search`, and `Url.domain` in favor of `Url.spec.is_regular`, `Url.spec.is_search`, and `Url.spec.domain`, respectively ([#4118])
@@ -1785,3 +1785,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4118]: https://github.com/sxyazi/yazi/pull/4118
 [#4120]: https://github.com/sxyazi/yazi/pull/4120
 [#4144]: https://github.com/sxyazi/yazi/pull/4144
+[#4169]: https://github.com/sxyazi/yazi/pull/4169

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ### Deprecated
 
+- Deprecate `copy dirname` in favor of `copy dirpath`
 - Deprecate `backward --far` and `forward --far` in favor of `backward wide` and `forward wide`, respectively ([#4012])
 - Deprecate `tab::Mode.is_visual` in favor of the new `tab::Mode.is_normal` ([#4101])
 - Deprecate `Url.is_regular`, `Url.is_search`, and `Url.domain` in favor of `Url.spec.is_regular`, `Url.spec.is_search`, and `Url.spec.domain`, respectively ([#4118])

--- a/yazi-actor/src/mgr/copy.rs
+++ b/yazi-actor/src/mgr/copy.rs
@@ -15,31 +15,41 @@ impl Actor for Copy {
 
 	fn act(cx: &mut Ctx, form: Self::Form) -> Result<Data> {
 		act!(mgr:escape_visual, cx)?;
+		if form.r#type == "dirname" {
+			yazi_proxy::deprecate!("`copy dirname` is deprecated, use `copy dirpath` instead");
+		}
 
 		let mut s = Vec::<u8>::new();
 		let mut it = if form.hovered {
-			Box::new(cx.hovered_url().into_iter())
+			Box::new(cx.hovered().into_iter())
 		} else {
-			cx.tab().selected_or_hovered_urls()
+			cx.tab().selected_or_hovered_files()
 		}
 		.peekable();
 
-		while let Some(u) = it.next() {
+		while let Some(f) = it.next() {
 			match form.r#type.as_ref() {
-				// TODO: rename to "url"
 				"path" => {
-					s.extend_from_slice(&form.separator.transform(&u.to_strand()));
+					s.extend_from_slice(&form.separator.transform(&f.content_path()));
 				}
-				"dirname" => {
-					if let Some(p) = u.parent() {
+				"url" => {
+					s.extend_from_slice(&form.separator.transform(&f.url.to_strand()));
+				}
+				"dirpath" | "dirname" => {
+					if let Some(p) = f.content_path().parent() {
+						s.extend_from_slice(&form.separator.transform(&p));
+					}
+				}
+				"dirurl" => {
+					if let Some(p) = f.url.parent() {
 						s.extend_from_slice(&form.separator.transform(&p.to_strand()));
 					}
 				}
 				"filename" => {
-					s.extend_from_slice(&form.separator.transform(&u.name().unwrap_or_default()));
+					s.extend_from_slice(&form.separator.transform(&f.name().unwrap_or_default()));
 				}
 				"name_without_ext" => {
-					s.extend_from_slice(&form.separator.transform(&u.stem().unwrap_or_default()));
+					s.extend_from_slice(&form.separator.transform(&f.stem().unwrap_or_default()));
 				}
 				_ => bail!("Unknown copy type: {}", form.r#type),
 			};
@@ -49,7 +59,9 @@ impl Actor for Copy {
 		}
 
 		// Copy the CWD path regardless even if the directory is empty
-		if s.is_empty() && form.r#type == "dirname" {
+		if s.is_empty() && matches!(&*form.r#type, "dirpath" | "dirname") {
+			s.extend_from_slice(&form.separator.transform(&cx.current().content_path()));
+		} else if s.is_empty() && form.r#type == "dirurl" {
 			s.extend_from_slice(&form.separator.transform(&cx.cwd().to_strand()));
 		}
 

--- a/yazi-config/preset/keymap-default.toml
+++ b/yazi-config/preset/keymap-default.toml
@@ -97,8 +97,10 @@ keymap = [
 	{ on = [ "m", "n" ], run = "linemode none",        desc = "Linemode: none" },
 
 	# Copy
-	{ on = [ "c", "c" ], run = "copy path",             desc = "Copy file URL" },
-	{ on = [ "c", "d" ], run = "copy dirname",          desc = "Copy directory URL" },
+	{ on = [ "c", "c" ], run = "copy path",             desc = "Copy file path" },
+	{ on = [ "c", "C" ], run = "copy url",              desc = "Copy file URL" },
+	{ on = [ "c", "d" ], run = "copy dirpath",          desc = "Copy directory path" },
+	{ on = [ "c", "D" ], run = "copy dirurl",           desc = "Copy directory URL" },
 	{ on = [ "c", "f" ], run = "copy filename",         desc = "Copy filename" },
 	{ on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy filename without extension" },
 

--- a/yazi-proxy/src/macros.rs
+++ b/yazi-proxy/src/macros.rs
@@ -3,8 +3,8 @@ macro_rules! deprecate {
 	($content:expr) => {{
 		static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 		if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
-			$crate::emit!(Call(
-				yazi_shared::event::Action::new("app:deprecate").with("content", format!($tt, id))
+			yazi_macro::emit!(Call(
+				yazi_shared::event::Action::new_relay("app:deprecate").with("content", $content)
 			));
 		}
 	}};

--- a/yazi-shared/src/strand/conversion.rs
+++ b/yazi-shared/src/strand/conversion.rs
@@ -67,6 +67,10 @@ impl AsStrand for Cow<'_, OsStr> {
 	fn as_strand(&self) -> Strand<'_> { Strand::Os(self) }
 }
 
+impl AsStrand for Cow<'_, std::path::Path> {
+	fn as_strand(&self) -> Strand<'_> { Strand::Os(self.as_os_str()) }
+}
+
 impl AsStrand for PathDyn<'_> {
 	fn as_strand(&self) -> Strand<'_> {
 		match self {


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/4167

Previously, `copy path` behaved differently: it copied the local path for local files, but the URL for virtual filesystems. This PR makes it always copy the path for consistent behavior and to match what "path" means.

It also adds two new options: 

- `copy url` - always copy the file URL
- `copy dirurl` - always copy the directory URL

## Deprecation

`copy dirname` has been renamed to `copy dirpath` to pair with the new `copy dirurl`. 

The old `copy dirname` command still works with a deprecation warning.