### PR TITLE
fix: archive previewer may show a wrong tree view

### DIFF
--- a/yazi-plugin/preset/plugins/archive.lua
+++ b/yazi-plugin/preset/plugins/archive.lua
@@ -250,7 +250,7 @@ end
 ---@return table items
 ---@return Error? err
 function M.parse_7z_slt(child, skip, limit)
-	local items, tops, parents, err = { M.make_item() }, {}, {}, nil
+	local items, err = { M.make_item() }, nil
 	local key, value, empty, stderr = "", "", Path.os(""), {}
 	repeat
 		local next, event = child:read_line()
@@ -266,8 +266,8 @@ function M.parse_7z_slt(child, skip, limit)
 
 		if next == "\n" or next == "\r\n" then
 			if items[#items].path ~= empty then
-				M.treelize(items, tops, parents)
-				M.pop_dup_dir(items, parents, false)
+				items[#items].is_dir = items[#items].folder == "+"
+					or items[#items].attr:sub(1, 1) == "D"
 				items[#items + 1] = M.make_item()
 			end
 			goto continue
@@ -292,13 +292,11 @@ function M.parse_7z_slt(child, skip, limit)
 	if items[#items].path == empty then
 		items[#items] = nil
 	else
-		M.treelize(items, tops, parents)
+		items[#items].is_dir = items[#items].folder == "+"
+			or items[#items].attr:sub(1, 1) == "D"
 	end
 
-	M.pop_dup_dir(items, parents, #items <= skip + limit)
-	if #items > skip + limit then
-		items[#items] = nil
-	end
+	items = M.treelize(items)
 
 	if #stderr ~= 0 then
 		err = Err("7-zip errored out while listing items, stderr: %s", table.concat(stderr, "\n"))
@@ -308,51 +306,58 @@ end
 
 ---Convert a flat list of items into a tree structure
 ---@param items table
----@param tops Path[]
----@param parents table<string, boolean>
-function M.treelize(items, tops, parents)
-	local f = table.remove(items)
-	while #tops > 0 and not f.path:starts_with(tops[#tops]) do
-		tops[#tops] = nil
+---@return table tree
+function M.treelize(items)
+	if #items == 0 then
+		return items
 	end
 
-	local buf, it = {}, f.path.parent
-	while it and #it ~= 0 and it ~= tops[#tops] do
-		buf[#buf + 1], it = it, it.parent
-	end
-	for i = #buf, 1, -1 do
-		items[#items + 1] = M.make_item { path = buf[i], depth = #tops, is_dir = true }
-		tops[#tops + 1] = buf[i]
-		M.pop_dup_dir(items, parents, false)
+	local root = { children = {} }
+
+	for _, item in ipairs(items) do
+		local chain = {}
+		local p = item.path
+		while p and #p ~= 0 do
+			chain[#chain + 1] = p
+			p = p.parent
+		end
+
+		local node = root
+		for i = #chain, 1, -1 do
+			local key = tostring(chain[i])
+			-- synthesize intermediate directories if missing
+			if not node.children[key] then
+				node.children[key] = { path = chain[i], children = {} }
+			end
+			node = node.children[key]
+		end
+		node.item = item
 	end
 
-	f.depth = #tops
-	f.is_dir = f.folder == "+" or f.attr:sub(1, 1) == "D"
+    -- DFS preorder traversal
+	local result = {}
+	local function dfs(node, depth)
+		local sorted = {}
+		for _, child in pairs(node.children) do
+			sorted[#sorted + 1] = child
+		end
+		table.sort(sorted, function(a, b)
+			return tostring(a.path) < tostring(b.path)
+		end)
+		for _, child in ipairs(sorted) do
+			local has_children = next(child.children) ~= nil
+			local item = child.item or M.make_item { path = child.path }
+			item.depth = depth
+			item.is_dir = item.is_dir or has_children
+			result[#result + 1] = item
 
-	if not f.is_dir then
-		items[#items + 1] = f
-	elseif f.path ~= tops[#tops] then
-		items[#items + 1], tops[#tops + 1] = f, f.path
+			if has_children then
+				dfs(child, depth + 1)
+			end
+		end
 	end
+	dfs(root, 0)
+
+	return result
 end
-
----@param items table
----@param parents table<string, boolean>
----@param eof boolean
-function M.pop_dup_dir(items, parents, eof)
-	local n, i = #items, eof and #items or #items - 1
-	if not items[i] or not items[i].is_dir then
-		return
-	end
-
-	local p = tostring(items[i].path)
-	if not parents[p] then
-		parents[p] = true
-	elseif eof then
-		items[n] = nil
-	elseif not items[n].path:starts_with(items[i].path) then
-		items[i], items[n] = items[n], nil
-	end
-end
-
 return M


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4162

## Rationale of this PR

This is discussed quite a lot in the issue above. I'll omit all of them here.

This PR changes the original archive tree-view flat-to-tree algorithm to a typical trie-based algorithm.

### Benchmarks

| Archive | Entries | 7z l | Old (orig) | New (orig) | Old (shuf) | New (shuf) |
|---|---:|---:|---:|---:|---:|---:|
| 10.7z | 21 | 11.1 ms | 1.1 ms | 1.1 ms | 1.2 ms | 1.1 ms |
| 100.7z | 111 | 14.0 ms | 1.9 ms | 2.4 ms | 2.4 ms | 2.4 ms |
| 1000.7z | 1059 | 15.0 ms | 11.5 ms | 15.8 ms | 22.0 ms | 15.8 ms |
| 10000.7z | 11223 | 43.7 ms | 174.3 ms | 250.9 ms | 616.7 ms | 263.5 ms |
| 50000.7z | 54120 | 161.3 ms | 973.9 ms | 1.548 s | 3.940 s | 1.611 s |
| 10.rar | 21 | 12.6 ms | 1.3 ms | 1.3 ms | 1.3 ms | 1.2 ms |
| 100.rar | 111 | 13.7 ms | 2.5 ms | 2.9 ms | 3.0 ms | 3.0 ms |
| 1000.rar | 1059 | 44.2 ms | 16.8 ms | 21.0 ms | 27.3 ms | 20.9 ms |
| 10000.rar | 11223 | 319.6 ms | 225.3 ms | 306.3 ms | 663.6 ms | 313.1 ms |
| 50000.rar | 54120 | 1.173 s | 1.204 s | 1.780 s | 4.370 s | 1.896 s |
| 10.zip | 21 | 13.5 ms | 1.2 ms | 1.2 ms | 1.3 ms | 1.2 ms |
| 100.zip | 111 | 16.0 ms | 2.3 ms | 2.8 ms | 2.7 ms | 2.7 ms |
| 1000.zip | 1059 | 19.3 ms | 14.4 ms | 18.8 ms | 26.3 ms | 19.0 ms |
| 10000.zip | 11223 | 53.4 ms | 195.8 ms | 283.1 ms | 645.2 ms | 290.5 ms |
| 50000.zip | 54120 | 203.7 ms | 1.085 s | 1.707 s | 4.234 s | 1.821 s |

I use files from my `$HOME` directory i.e. `fd --size=-1MiB -t f -t d > list.txt` then `cat list.txt | head -n $num | tar -cvf out.tar -T -` then derive all the `zip`s, `rar`s, `7z`s from the tar. `fd` by default outputs in a dfs order (marked as `orig` above) so the original algorithm processes it well.

For the benchmarks, I've extracted the related code and made them two standalone luas which receive inputs in `7z -ba -slt` format and output the tree. First, bench the `7z l` performance using `hyperfine '7z l -ba -slt -sccUTF-8 '$f' > /dev/null' -p 'echo 1 | sudo tee /proc/sys/vm/drop_caches'`, then bench the processing performance using `7z l -ba -slt -sccUTF-8 $f > /tmp/orig.txt; hyperfine 'cat /tmp/orig.txt | lua treelize.lua`. Note I have another 7z-shuf script to shuffle the `7z -ba -slt` output, marked as `shuf` in the benchmark table above.

If the item count < 1000, 7z listing is the bottleneck. When it gets >1000 (except rar), flat-to-tree processing is the bottleneck. The fact also applies to the old algorithm. Besides, note the new algorithm is much stable. For the old algorithm, when the input is shuffled, it has a significant performance degradation.

The old algorithm is trying to do an "incremental previewing" but I suppose it's useless due to the fact `7z l` doesn't do streamed listing.

**raw hyperfine output**
[7z-l.txt](https://github.com/user-attachments/files/30407484/7z-l.txt)
[treelize.txt](https://github.com/user-attachments/files/30407485/treelize.txt)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
