### PR TITLE
fix: allow root to use cache dir owned by another user

### DIFF
--- a/yazi-fs/src/fns.rs
+++ b/yazi-fs/src/fns.rs
@@ -102,9 +102,9 @@ pub fn create_owned_dir_blocking(p: &Path) -> io::Result<()> {
 			return Err(io::Error::last_os_error());
 		}
 
-		// Reject directories not owned by the current user.
+		// Reject directories not owned by the current user, unless running as root.
 		let uid = USERS_CACHE.get_current_uid();
-		if stat.st_uid != uid {
+		if uid != 0 && stat.st_uid != uid {
 			return Err(io::Error::new(
 				io::ErrorKind::PermissionDenied,
 				format!("directory {:?} is owned by uid {} but current uid is {}", p, stat.st_uid, uid),


### PR DESCRIPTION
Fixes #4166. When `cache_dir` is set and the directory exists (owned by the original user), running yazi with `sudo -E -s` fails because `create_owned_dir_blocking` requires the directory owner to match the current uid. Root (uid 0) can access any directory, so skip the check when running as root.

AI disclosure: This PR was created with the assistance of an AI coding tool. The fix was reviewed and verified by a human.

## Verification

- `cargo build --package yazi-fs --package yazi-config` succeeds
- `cargo test --package yazi-fs --package yazi-config` passes (7/7)