### PR TITLE
fix: return `NotFound` when top-level item is missing in Windows Recycle Bin

### DIFF
--- a/yazi-fs/src/trash/windows/shell_item.rs
+++ b/yazi-fs/src/trash/windows/shell_item.rs
@@ -24,7 +24,7 @@ impl ShellItem {
 			.children()?
 			.into_iter()
 			.find(|item| item.display_name(SIGDN_DESKTOPABSOLUTEPARSING).is_ok_and(|s| s == name))
-			.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "item is not in the recycle bin"))
+			.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "item is not in the recycle bin"))
 	}
 
 	pub(super) fn children(&self) -> io::Result<Vec<Self>> {


### PR DESCRIPTION
Resolves #4185  
## Rationale of this PR  Return `NotFound` instead of `InvalidInput` when a Windows trash item disappears during shell item processing, preventing successful file deletion from being reported as a failure during cleanup.  
## Checklist  
- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)  
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)