### PR TITLE
perf: make terminal capability probing async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 ### Improved
 
 - Eliminate hacks in image and UI conflict resolution ([#4022])
+- Make terminal capability probing async ([#4194])
 - Enable SSO (small string optimization) for custom schemes and custom styles ([#4164])
 
 ## [v26.5.6]
@@ -1792,3 +1793,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4174]: https://github.com/sxyazi/yazi/pull/4174
 [#4177]: https://github.com/sxyazi/yazi/pull/4177
 [#4184]: https://github.com/sxyazi/yazi/pull/4184
+[#4194]: https://github.com/sxyazi/yazi/pull/4194

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "ctutils",
  "subtle",
@@ -4026,13 +4026,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4061,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -4463,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4864,6 +4864,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "yazi-adapter",
  "yazi-binding",
  "yazi-boot",
  "yazi-config",
@@ -4909,6 +4910,7 @@ dependencies = [
  "yazi-macro",
  "yazi-shared",
  "yazi-shim",
+ "yazi-term",
  "yazi-tty",
  "yazi-widgets",
 ]
@@ -5101,9 +5103,7 @@ name = "yazi-emulator"
 version = "26.5.6"
 dependencies = [
  "anyhow",
- "either",
- "ratatui-core",
- "scopeguard",
+ "arc-swap",
  "tokio",
  "tracing",
  "yazi-macro",
@@ -5151,6 +5151,7 @@ dependencies = [
  "yazi-config",
  "yazi-core",
  "yazi-dds",
+ "yazi-emulator",
  "yazi-fs",
  "yazi-macro",
  "yazi-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ thiserror             = "2.0.19"
 tokio                 = { version = "1.53.1", features = [ "full" ] }
 tokio-stream          = "0.1.19"
 tokio-util            = "0.7.19"
-toml                  = { version = "1.1.3" }
+toml                  = { version = "1.1.4" }
 tracing               = { version = "0.1.44", features = [ "max_level_debug", "release_max_level_debug" ] }
 twox-hash             = { version = "2.1.3", default-features = false, features = [ "std", "random", "xxhash3_128" ] }
 typed-path            = "0.12.3"

--- a/yazi-actor/Cargo.toml
+++ b/yazi-actor/Cargo.toml
@@ -17,6 +17,7 @@ default      = [ "vendored-lua" ]
 vendored-lua = [ "mlua/vendored" ]
 
 [dependencies]
+yazi-adapter   = { path = "../yazi-adapter", version = "26.5.6" }
 yazi-binding   = { path = "../yazi-binding", version = "26.5.6" }
 yazi-boot      = { path = "../yazi-boot", version = "26.5.6" }
 yazi-config    = { path = "../yazi-config", version = "26.5.6" }

--- a/yazi-actor/src/app/mod.rs
+++ b/yazi-actor/src/app/mod.rs
@@ -6,10 +6,12 @@ yazi_macro::mod_flat!(
 	focus
 	lua
 	mouse
+	passthrough
 	plugin
 	plugin_do
 	quit
 	reflow
+	report
 	resize
 	resume
 	stop

--- a/yazi-actor/src/app/passthrough.rs
+++ b/yazi-actor/src/app/passthrough.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use tracing::error;
+use yazi_emulator::EMULATOR;
+use yazi_macro::succ;
+use yazi_parser::app::PassthroughForm;
+use yazi_shared::data::Data;
+
+use crate::{Actor, Ctx};
+
+pub struct Passthrough;
+
+impl Actor for Passthrough {
+	type Form = PassthroughForm;
+
+	const NAME: &str = "passthrough";
+
+	fn act(cx: &mut Ctx, PassthroughForm { id }: Self::Form) -> Result<Data> {
+		let Some(term) = cx.term.as_mut() else { succ!() };
+
+		if term.probe.id != id || !term.probe.needs_passthrough() {
+			succ!();
+		}
+
+		if let Err(e) = term.probe.restart() {
+			error!("Failed to request terminal capabilities through tmux: {e}");
+		}
+
+		EMULATOR.store(Arc::new(term.probe.emulator.clone()));
+		succ!();
+	}
+}

--- a/yazi-actor/src/app/report.rs
+++ b/yazi-actor/src/app/report.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use yazi_adapter::ADAPTOR;
+use yazi_emulator::{EMULATOR, Mux};
+use yazi_macro::{act, succ};
+use yazi_proxy::AppProxy;
+use yazi_shared::data::Data;
+use yazi_term::event::Report as TermReport;
+
+use crate::{Actor, Ctx};
+
+pub struct Report;
+
+impl Actor for Report {
+	type Form = TermReport;
+
+	const NAME: &str = "report";
+
+	fn act(cx: &mut Ctx, report: Self::Form) -> Result<Data> {
+		let Some(term) = cx.term.as_mut() else { succ!() };
+
+		term.probe.emulator.apply(&report);
+		EMULATOR.store(Arc::new(term.probe.emulator.clone()));
+
+		if !matches!(report, TermReport::Da1(_)) {
+			succ!();
+		} else if !term.probe.needs_passthrough() {
+			ADAPTOR.resolve(&term.probe.emulator);
+			return act!(app:theme, cx);
+		}
+
+		let id = term.probe.id;
+		tokio::spawn(async move {
+			Mux::tmux_passthrough().await;
+			AppProxy::passthrough(id);
+		});
+
+		succ!();
+	}
+}

--- a/yazi-actor/src/app/stop.rs
+++ b/yazi-actor/src/app/stop.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use yazi_macro::succ;
-use yazi_parser::VoidForm;
+use yazi_parser::app::StopForm;
 use yazi_shared::data::Data;
 
 use crate::{Actor, Ctx};
@@ -8,14 +8,18 @@ use crate::{Actor, Ctx};
 pub struct Stop;
 
 impl Actor for Stop {
-	type Form = VoidForm;
+	type Form = StopForm;
 
 	const NAME: &str = "stop";
 
-	fn act(cx: &mut Ctx, _: Self::Form) -> Result<Data> {
+	fn act(cx: &mut Ctx, Self::Form { replier }: Self::Form) -> Result<Data> {
 		cx.active_mut().preview.reset_image();
 
 		*cx.term = None;
+
+		if let Some(replier) = replier {
+			replier.send(Ok(Data::Nil)).ok();
+		}
 
 		succ!();
 	}

--- a/yazi-actor/src/app/theme.rs
+++ b/yazi-actor/src/app/theme.rs
@@ -4,6 +4,7 @@ use yazi_config::{THEME, build_flavor};
 use yazi_emulator::EMULATOR;
 use yazi_macro::{render, succ};
 use yazi_parser::VoidForm;
+use yazi_scheduler::NotifyProxy;
 use yazi_shared::data::Data;
 use yazi_shim::serde::Overlay;
 
@@ -17,8 +18,10 @@ impl Actor for Theme {
 	const NAME: &str = "theme";
 
 	fn act(_cx: &mut Ctx, _: Self::Form) -> Result<Data> {
-		let light = EMULATOR.load().light;
-		THEME.overlay(build_flavor(light, true)?);
+		match build_flavor(EMULATOR.load().light) {
+			Ok(theme) => THEME.overlay(theme),
+			Err(e) => succ!(NotifyProxy::push_error("Theme load failed", format!("{e:#}"))),
+		};
 
 		yazi_plugin::theme::reset()?;
 		succ!(render!());

--- a/yazi-actor/src/app/theme.rs
+++ b/yazi-actor/src/app/theme.rs
@@ -17,9 +17,10 @@ impl Actor for Theme {
 	const NAME: &str = "theme";
 
 	fn act(_cx: &mut Ctx, _: Self::Form) -> Result<Data> {
-		THEME.overlay(build_flavor(EMULATOR.light, true)?);
-		yazi_plugin::theme::reset()?;
+		let light = EMULATOR.load().light;
+		THEME.overlay(build_flavor(light, true)?);
 
+		yazi_plugin::theme::reset()?;
 		succ!(render!());
 	}
 }

--- a/yazi-actor/src/mgr/quit.rs
+++ b/yazi-actor/src/mgr/quit.rs
@@ -18,7 +18,7 @@ impl Actor for Quit {
 
 	const NAME: &str = "quit";
 
-	fn act(cx: &mut Ctx, Self::Form { opt }: Self::Form) -> Result<Data> {
+	fn act(cx: &mut Ctx, Self::Form { opt, .. }: Self::Form) -> Result<Data> {
 		let ongoing = cx.tasks.scheduler.ongoing.clone();
 		let (left, left_titles) = {
 			let ongoing = ongoing.lock();

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -19,6 +19,7 @@ yazi-fs       = { path = "../yazi-fs", version = "26.5.6" }
 yazi-macro    = { path = "../yazi-macro", version = "26.5.6" }
 yazi-shared   = { path = "../yazi-shared", version = "26.5.6" }
 yazi-shim     = { path = "../yazi-shim", version = "26.5.6" }
+yazi-term     = { path = "../yazi-term", version = "26.5.6" }
 yazi-tty      = { path = "../yazi-tty", version = "26.5.9" }
 yazi-widgets  = { path = "../yazi-widgets", version = "26.5.6" }
 

--- a/yazi-adapter/src/adapter.rs
+++ b/yazi-adapter/src/adapter.rs
@@ -1,43 +1,60 @@
-use std::{fmt::{self, Debug}, ops::Deref};
+use std::{fmt::{self, Debug}, path::PathBuf};
 
 use anyhow::Result;
 use ratatui_core::layout::Rect;
-use yazi_emulator::EMULATOR;
+use tokio::time::{Duration, timeout};
+use yazi_emulator::{EMULATOR, Emulator};
+use yazi_shared::CompletionCell;
 use yazi_shim::cell::SyncCell;
 use yazi_widgets::clear::ClearInventory;
 
 use crate::{ADAPTOR, drivers::{Driver, Drivers}};
 
+#[derive(Default)]
 pub struct Adapter {
-	driver:        Driver,
+	driver:        CompletionCell<Driver>,
 	shown:         SyncCell<Option<Rect>>,
 	pub collision: SyncCell<bool>,
 }
 
-impl Deref for Adapter {
-	type Target = Driver;
-
-	fn deref(&self) -> &Self::Target { &self.driver }
-}
-
 impl Debug for Adapter {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.driver.fmt(f) }
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self.driver.get() {
+			Some(driver) => driver.fmt(f),
+			None => f.write_str("Pending"),
+		}
+	}
 }
 
 impl Adapter {
-	pub(super) fn new() -> Self {
-		Self {
-			driver:    Drivers::matches(&EMULATOR),
-			shown:     SyncCell::new(None),
-			collision: SyncCell::new(false),
-		}
+	pub async fn image_show<P>(&self, path: P, max: Rect) -> Result<Rect>
+	where
+		P: Into<PathBuf>,
+	{
+		let driver = match timeout(Duration::from_secs(10), self.driver.wait()).await {
+			Ok(driver) => *driver,
+			Err(_) => self.resolve(&EMULATOR.load()),
+		};
+		driver.image_show(path, max).await
 	}
 
 	pub fn image_hide(&self) -> Result<()> {
-		if let Some(area) = self.shown.replace(None) { self.driver.image_erase(area) } else { Ok(()) }
+		let Some(area) = self.shown.replace(None) else { return Ok(()) };
+		match self.driver.get() {
+			Some(driver) => driver.image_erase(area),
+			None => Ok(()),
+		}
 	}
 
 	pub(super) fn shown_store(&self, area: Rect) { self.shown.set(Some(area)); }
+
+	pub fn resolve(&self, emulator: &Emulator) -> Driver {
+		*self.driver.get_or_init(|| {
+			let driver = Drivers::matches(emulator);
+			driver.start();
+			driver
+		})
+	}
 }
 
 inventory::submit! {
@@ -48,7 +65,7 @@ inventory::submit! {
 				return None;
 			}
 
-			ADAPTOR.driver.image_erase(overlap).ok();
+			ADAPTOR.driver.get()?.image_erase(overlap).ok();
 			ADAPTOR.collision.set(true);
 			Some(overlap)
 		},

--- a/yazi-adapter/src/drivers/drivers.rs
+++ b/yazi-adapter/src/drivers/drivers.rs
@@ -1,12 +1,12 @@
 use std::{env, ops::{Deref, DerefMut}};
 
 use tracing::warn;
-use yazi_emulator::{Emulator, TMUX};
+use yazi_emulator::{Brand, Emulator};
 use yazi_shared::env_exists;
 
 use crate::drivers::{Driver as D, Ueberzug};
 
-pub(crate) struct Drivers(Vec<D>);
+pub struct Drivers(Vec<D>);
 
 impl Deref for Drivers {
 	type Target = Vec<D>;
@@ -19,7 +19,17 @@ impl DerefMut for Drivers {
 }
 
 impl From<&yazi_emulator::Emulator> for Drivers {
-	fn from(value: &yazi_emulator::Emulator) -> Self { value.kind.either_into() }
+	fn from(value: &yazi_emulator::Emulator) -> Self {
+		match value.brand {
+			Brand::Unknown => Self(match (value.kgp, value.sixel) {
+				(true, true) => vec![D::Sixel, D::KgpOld],
+				(true, false) => vec![D::KgpOld],
+				(false, true) => vec![D::Sixel],
+				(false, false) => vec![],
+			}),
+			brand => brand.into(),
+		}
+	}
 }
 
 impl From<yazi_emulator::Brand> for Drivers {
@@ -27,6 +37,7 @@ impl From<yazi_emulator::Brand> for Drivers {
 		use yazi_emulator::Brand as B;
 
 		Self(match value {
+			B::Unknown => vec![],
 			B::Kitty => vec![D::Kgp],
 			B::Konsole => vec![D::KgpOld],
 			B::Iterm2 => vec![D::Iip, D::Sixel],
@@ -50,27 +61,16 @@ impl From<yazi_emulator::Brand> for Drivers {
 	}
 }
 
-impl From<yazi_emulator::Unknown> for Drivers {
-	fn from(value: yazi_emulator::Unknown) -> Self {
-		Self(match (value.kgp, value.sixel) {
-			(true, true) => vec![D::Sixel, D::KgpOld],
-			(true, false) => vec![D::KgpOld],
-			(false, true) => vec![D::Sixel],
-			(false, false) => vec![],
-		})
-	}
-}
-
 impl Drivers {
 	pub fn matches(emulator: &Emulator) -> D {
-		let mut adapters: Self = emulator.into();
+		let mut drivers: Self = emulator.into();
 		if env_exists("ZELLIJ_SESSION_NAME") {
-			adapters.retain(|p| *p == D::Sixel);
-		} else if TMUX.get() {
-			adapters.retain(|p| *p != D::KgpOld);
+			drivers.retain(|p| *p == D::Sixel);
+		} else if emulator.tmux {
+			drivers.retain(|p| *p != D::KgpOld);
 		}
-		if let Some(p) = adapters.first() {
-			return *p;
+		if let Some(d) = drivers.first() {
+			return *d;
 		}
 
 		let supported_compositor = Ueberzug::supported_compositor();
@@ -78,7 +78,7 @@ impl Drivers {
 			"x11" => return D::X11,
 			"wayland" if supported_compositor => return D::Wayland,
 			"wayland" if !supported_compositor => return D::Chafa,
-			_ => warn!("[Adapter] Could not identify XDG_SESSION_TYPE"),
+			_ => warn!("[Drivers] Could not identify XDG_SESSION_TYPE"),
 		}
 		if env_exists("WAYLAND_DISPLAY") {
 			return if supported_compositor { D::Wayland } else { D::Chafa };
@@ -88,7 +88,7 @@ impl Drivers {
 			_ => {}
 		}
 
-		warn!("[Adapter] Falling back to chafa");
+		warn!("[Drivers] Falling back to chafa");
 		D::Chafa
 	}
 }

--- a/yazi-adapter/src/lib.rs
+++ b/yazi-adapter/src/lib.rs
@@ -2,36 +2,12 @@ yazi_macro::mod_pub!(drivers);
 
 yazi_macro::mod_flat!(adapter icc image);
 
-use yazi_emulator::{Brand, CLOSE, EMULATOR, ESCAPE, Emulator, Mux, START, TMUX};
-use yazi_shared::in_wsl;
 use yazi_shim::cell::{RoCell, SyncCell};
 
 pub static ADAPTOR: RoCell<Adapter> = RoCell::new();
-
-// WSL support
 pub static WSL: SyncCell<bool> = SyncCell::new(false);
 
-pub fn init() -> anyhow::Result<()> {
-	// WSL support
-	WSL.set(in_wsl());
-
-	// Emulator detection
-	let mut emulator = Emulator::detect().unwrap_or_default();
-	TMUX.set(emulator.kind.left() == Some(Brand::Tmux));
-
-	// Tmux support
-	if TMUX.get() {
-		ESCAPE.set("\x1b\x1b");
-		START.set("\x1bPtmux;\x1b\x1b");
-		CLOSE.set("\x1b\\");
-		Mux::tmux_passthrough();
-		emulator = Emulator::detect().unwrap_or_default();
-	}
-
-	EMULATOR.init(emulator);
-	yazi_config::init_flavor(EMULATOR.light)?;
-
-	ADAPTOR.init(Adapter::new());
-	ADAPTOR.start();
-	Ok(())
+pub fn init() {
+	ADAPTOR.with(Adapter::default);
+	WSL.set(yazi_shared::in_wsl());
 }

--- a/yazi-cli/src/env/env.rs
+++ b/yazi-cli/src/env/env.rs
@@ -1,8 +1,10 @@
 use std::{env, ffi::OsStr, fmt::Write, path::Path, process::Command};
 
+use anyhow::Result;
 use regex::Regex;
+use yazi_adapter::drivers::Drivers;
 use yazi_config::{THEME, YAZI};
-use yazi_emulator::Mux;
+use yazi_emulator::{Brand, Emulator, Mux};
 use yazi_fs::Xdg;
 use yazi_shared::timestamp_us;
 use yazi_shim::OptionExt;
@@ -11,8 +13,10 @@ use yazi_term::TERM;
 use crate::env::Env;
 
 impl Env {
-	pub(crate) fn print() -> Result<String, std::fmt::Error> {
+	pub(crate) async fn print() -> Result<String> {
 		let mut s = String::new();
+		let emulator = Emulator::probe().await?;
+
 		writeln!(s, "Yazi\n{}", Self::yazi_version())?;
 		writeln!(s, "    Backtrace: {:?}", env::var_os("RUST_BACKTRACE"))?;
 
@@ -31,12 +35,12 @@ impl Env {
 		writeln!(s, "    TERM                : {:?}", env::var_os("TERM"))?;
 		writeln!(s, "    TERM_PROGRAM        : {:?}", env::var_os("TERM_PROGRAM"))?;
 		writeln!(s, "    TERM_PROGRAM_VERSION: {:?}", env::var_os("TERM_PROGRAM_VERSION"))?;
-		writeln!(s, "    Brand.from_env      : {:?}", yazi_emulator::Brand::from_env())?;
-		writeln!(s, "    Emulator.detect     : {:?}", *yazi_emulator::EMULATOR)?;
+		writeln!(s, "    Brand.from_env      : {:?}", Brand::from_env())?;
+		writeln!(s, "    Emulator.detect     : {emulator:?}")?;
 
 		writeln!(s, "\nAdapter")?;
-		writeln!(s, "    Adapter.matches    : {:?}", *yazi_adapter::ADAPTOR)?;
-		writeln!(s, "    Dimension.available: {:?}", TERM.dimension())?;
+		writeln!(s, "    Drivers.matches: {:?}", Drivers::matches(&emulator))?;
+		writeln!(s, "    TERM.dimension : {:?}", TERM.dimension())?;
 
 		writeln!(s, "\nDesktop")?;
 		writeln!(s, "    XDG_SESSION_TYPE           : {:?}", env::var_os("XDG_SESSION_TYPE"))?;
@@ -52,7 +56,7 @@ impl Env {
 		writeln!(s, "    shared.in_ssh_connection: {}", yazi_shared::in_ssh_connection())?;
 
 		writeln!(s, "\nWSL")?;
-		writeln!(s, "    WSL: {:?}", yazi_adapter::WSL)?;
+		writeln!(s, "    WSL: {:?}", yazi_shared::in_wsl())?;
 
 		writeln!(s, "\nVariables")?;
 		writeln!(s, "    SHELL              : {:?}", env::var_os("SHELL"))?;
@@ -83,7 +87,6 @@ impl Env {
 		)?;
 
 		writeln!(s, "\nMultiplexers")?;
-		writeln!(s, "    TMUX               : {}", yazi_emulator::TMUX)?;
 		writeln!(s, "    tmux version       : {}", Self::dep_version("tmux", "-V"))?;
 		writeln!(s, "    tmux build flags   : enable-sixel={}", Mux::tmux_sixel_flag())?;
 		writeln!(s, "    ZELLIJ_SESSION_NAME: {:?}", env::var_os("ZELLIJ_SESSION_NAME"))?;

--- a/yazi-cli/src/env/env.rs
+++ b/yazi-cli/src/env/env.rs
@@ -3,7 +3,7 @@ use std::{env, ffi::OsStr, fmt::Write, path::Path, process::Command};
 use anyhow::Result;
 use regex::Regex;
 use yazi_adapter::drivers::Drivers;
-use yazi_config::{THEME, YAZI};
+use yazi_config::{YAZI, build_flavor};
 use yazi_emulator::{Brand, Emulator, Mux};
 use yazi_fs::Xdg;
 use yazi_shared::timestamp_us;
@@ -16,6 +16,7 @@ impl Env {
 	pub(crate) async fn print() -> Result<String> {
 		let mut s = String::new();
 		let emulator = Emulator::probe().await?;
+		let theme = build_flavor(emulator.light)?;
 
 		writeln!(s, "Yazi\n{}", Self::yazi_version())?;
 		writeln!(s, "    Backtrace: {:?}", env::var_os("RUST_BACKTRACE"))?;
@@ -29,7 +30,7 @@ impl Env {
 		writeln!(s, "    Theme            : {}", Self::config_state("theme.toml"))?;
 		writeln!(s, "    VFS              : {}", Self::config_state("vfs.toml"))?;
 		writeln!(s, "    Package          : {}", Self::config_state("package.toml"))?;
-		writeln!(s, "    Dark/light flavor: {:?} / {:?}", THEME.flavor.dark, THEME.flavor.light)?;
+		writeln!(s, "    Dark/light flavor: {:?} / {:?}", theme.flavor.dark, theme.flavor.light)?;
 
 		writeln!(s, "\nEmulator")?;
 		writeln!(s, "    TERM                : {:?}", env::var_os("TERM"))?;

--- a/yazi-cli/src/main.rs
+++ b/yazi-cli/src/main.rs
@@ -121,8 +121,7 @@ async fn run() -> anyhow::Result<()> {
 			yazi_tty::init();
 			yazi_term::init()?;
 			yazi_config::init()?;
-			yazi_adapter::init()?;
-			outln!("{}", env::Env::print()?)?;
+			outln!("{}", env::Env::print().await?)?;
 		}
 	}
 

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -49,26 +49,18 @@ fn try_init(merge: bool) -> anyhow::Result<()> {
 	Ok(())
 }
 
-pub fn build_flavor(light: bool, merge: bool) -> anyhow::Result<Theme> {
+pub fn build_flavor(light: bool) -> anyhow::Result<Theme> {
 	let mut preset = Preset::theme(light)?;
+	let theme_str = Theme::read()?;
+	let theme = parse("theme.toml", toml::de::DeTable::parse(&theme_str))?;
 
-	if merge {
-		let theme_str = Theme::read()?;
-		let theme = parse("theme.toml", toml::de::DeTable::parse(&theme_str))?;
+	let flavor_str = parse("theme.toml", Flavor::from_theme(&theme, &theme_str))?.read(light)?;
 
-		let flavor_str = parse("theme.toml", Flavor::from_theme(&theme, &theme_str))?.read(light)?;
-
-		preset = preset.deserialize_over(&flavor_str)?;
-		preset = parse(
-			"theme.toml",
-			error_with_input(
-				preset.deserialize_over_with(toml::de::Deserializer::from(theme)),
-				&theme_str,
-			),
-		)?;
-	} else {
-		preset = preset.deserialize_over("")?;
-	}
+	preset = preset.deserialize_over(&flavor_str)?;
+	preset = parse(
+		"theme.toml",
+		error_with_input(preset.deserialize_over_with(toml::de::Deserializer::from(theme)), &theme_str),
+	)?;
 
 	preset.reshape(light)
 }

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -23,6 +23,8 @@ pub fn init() -> anyhow::Result<()> {
 		wait_for_key(e)?;
 		try_init(false)?;
 	}
+
+	THEME.init(Preset::theme(false)?.reshape(false)?);
 	Ok(())
 }
 
@@ -44,19 +46,6 @@ fn try_init(merge: bool) -> anyhow::Result<()> {
 	YAZI.init(yazi);
 	KEYMAP.init(keymap);
 	VFS.init(vfs);
-	Ok(())
-}
-
-pub fn init_flavor(light: bool) -> anyhow::Result<()> {
-	if let Err(e) = try_init_flavor(light, true) {
-		wait_for_key(e)?;
-		try_init_flavor(light, false)?;
-	}
-	Ok(())
-}
-
-fn try_init_flavor(light: bool, merge: bool) -> anyhow::Result<()> {
-	THEME.init(build_flavor(light, merge)?);
 	Ok(())
 }
 

--- a/yazi-emulator/Cargo.toml
+++ b/yazi-emulator/Cargo.toml
@@ -21,8 +21,6 @@ yazi-tty    = { path = "../yazi-tty", version = "26.5.9" }
 
 # External dependencies
 anyhow       = { workspace = true }
-either       = { workspace = true }
-ratatui-core = { workspace = true }
-scopeguard   = { workspace = true }
+arc-swap     = { workspace = true }
 tokio        = { workspace = true }
 tracing      = { workspace = true }

--- a/yazi-emulator/src/brand.rs
+++ b/yazi-emulator/src/brand.rs
@@ -1,10 +1,12 @@
+use std::env;
+
 use tracing::debug;
 use yazi_shared::env_exists;
 
-use crate::Mux;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Brand {
+	#[default]
+	Unknown,
 	Kitty,
 	Konsole,
 	Iterm2,
@@ -45,7 +47,6 @@ impl Brand {
 	}
 
 	pub fn from_env() -> Option<Self> {
-		let (term, program) = Self::env();
 		let vars = [
 			("KITTY_WINDOW_ID", Self::Kitty),
 			("KONSOLE_VERSION", Self::Konsole),
@@ -58,7 +59,7 @@ impl Brand {
 			("TABBY_CONFIG_DIRECTORY", Self::Tabby),
 		];
 
-		match term.as_str() {
+		match &*env::var("TERM").unwrap_or_default() {
 			"xterm-kitty" => return Some(Self::Kitty),
 			"foot" => return Some(Self::Foot),
 			"foot-extra" => return Some(Self::Foot),
@@ -67,7 +68,8 @@ impl Brand {
 			"rxvt-unicode-256color" => return Some(Self::Urxvt),
 			_ => {}
 		}
-		match program.as_str() {
+
+		match &*env::var("TERM_PROGRAM").unwrap_or_default() {
 			"iTerm.app" => return Some(Self::Iterm2),
 			"WezTerm" => return Some(Self::WezTerm),
 			"ghostty" => return Some(Self::Ghostty),
@@ -81,19 +83,12 @@ impl Brand {
 			"Apple_Terminal" => return Some(Self::Apple),
 			_ => {}
 		}
+
 		if let Some((var, brand)) = vars.into_iter().find(|&(s, _)| env_exists(s)) {
 			debug!("Detected special environment variable: {var}");
 			return Some(brand);
 		}
 
 		None
-	}
-
-	fn env() -> (String, String) {
-		let (term, program) = Mux::term_program();
-		(
-			term.unwrap_or(std::env::var("TERM").unwrap_or_default()),
-			program.unwrap_or(std::env::var("TERM_PROGRAM").unwrap_or_default()),
-		)
 	}
 }

--- a/yazi-emulator/src/dimension.rs
+++ b/yazi-emulator/src/dimension.rs
@@ -7,7 +7,7 @@ pub struct Dimension;
 
 impl Dimension {
 	pub fn cell_size() -> Option<(f64, f64)> {
-		let emu = &*EMULATOR;
+		let emu = EMULATOR.load();
 		Some(if emu.force_16t {
 			(emu.csi_16t.0 as f64, emu.csi_16t.1 as f64)
 		} else if let Some(r) = TERM.dimension().ratio() {

--- a/yazi-emulator/src/emulator.rs
+++ b/yazi-emulator/src/emulator.rs
@@ -1,77 +1,61 @@
-use std::{io::{self, BufWriter, Write}, time::Duration};
+use std::io::{BufWriter, Write};
 
 use anyhow::Result;
-use either::Either;
-use ratatui_core::style::Color;
-use scopeguard::defer;
-use tokio::time::sleep;
-use tracing::{debug, error, warn};
+use arc_swap::ArcSwap;
+use tracing::debug;
 use yazi_macro::writef;
 use yazi_shim::cell::RoCell;
-use yazi_term::TERM;
-use yazi_tty::{Handle, TTY, sequence::{HideCursor, If, KittyGraphicsQuery, MoveTo, RequestBgColor, RequestCellPixelSize, RequestDA1, RequestXtVersion, RestoreCursorPos, SaveCursorPos, SetFg, SetSgr, ShowCursor}};
+use yazi_term::{TERM, event::Report};
+use yazi_tty::{Handle, TTY, sequence::{HideCursor, MoveTo, RestoreCursorPos, SaveCursorPos, ShowCursor}};
 
-use crate::{Brand, Mux, TMUX, Unknown};
+use crate::Brand;
 
-pub static EMULATOR: RoCell<Emulator> = RoCell::new();
+pub static EMULATOR: RoCell<ArcSwap<Emulator>> = RoCell::new();
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Emulator {
-	pub kind:      Either<Brand, Unknown>,
-	pub version:   String,
-	pub light:     bool,
-	pub csi_16t:   (u16, u16),
-	pub force_16t: bool,
-}
-
-impl Default for Emulator {
-	fn default() -> Self {
-		Self {
-			kind:      Either::Right(Unknown::default()),
-			version:   String::new(),
-			light:     false,
-			csi_16t:   (0, 0),
-			force_16t: false,
-		}
-	}
+	pub brand:        Brand,
+	pub version:      String,
+	pub kgp:          bool,
+	pub sixel:        bool,
+	pub light:        bool,
+	pub csi_16t:      (u16, u16),
+	pub force_16t:    bool,
+	pub cursor_blink: bool,
+	pub cursor_shape: Option<u8>,
+	pub tmux:         bool,
 }
 
 impl Emulator {
-	pub fn detect() -> Result<Self> {
-		defer! { TERM.enter_cooked_mode().ok(); }
-		TERM.enter_raw_mode()?;
+	pub(super) fn from_env() -> Self {
+		Self { brand: Brand::from_env().unwrap_or(Brand::Unknown), ..Default::default() }
+	}
 
-		let resort = Brand::from_env();
-		writef!(
-			TTY.writer(),
-			"{SaveCursorPos}{}{}{}{}{}{RestoreCursorPos}",
-			If(resort.is_none(), Mux::wrap(KittyGraphicsQuery)),
-			Mux::wrap(RequestXtVersion),
-			RequestCellPixelSize,
-			RequestBgColor,
-			Mux::wrap(RequestDA1),
-		)?;
-
-		let resp = Self::read_until_da1();
-		Mux::tmux_drain()?;
-
-		let kind = if let Some(b) = Brand::from_csi(&resp).or(resort) {
-			Either::Left(b)
-		} else {
-			Either::Right(Unknown {
-				kgp:   resp.contains("\x1b_Gi=31;OK"),
-				sixel: ["?4;", "?4c", ";4;", ";4c"].iter().any(|s| resp.contains(s)),
-			})
-		};
-
-		let csi_16t = Self::csi_16t(&resp).unwrap_or_default();
-		Ok(Self {
-			kind,
-			version: Self::csi_gt_q(&resp).unwrap_or_default(),
-			light: Self::light_bg(&resp).unwrap_or_default(),
-			csi_16t,
-			force_16t: Self::force_16t(csi_16t),
-		})
+	pub fn apply(&mut self, report: &Report) {
+		match report {
+			Report::CursorBlink(blink) => self.cursor_blink = *blink,
+			Report::CursorShape(shape) => self.cursor_shape = Some(*shape),
+			Report::Da1(attrs) => self.sixel = attrs.contains(&4),
+			Report::XtVersion(version) => {
+				self.version = version.to_string();
+				if let Some(brand) = Brand::from_csi(version) {
+					self.brand = brand;
+				}
+			}
+			Report::CellPixelSize { width, height } => {
+				self.csi_16t = (*width, *height);
+				self.force_16t = Self::force_16t(self.csi_16t);
+			}
+			Report::BackgroundColor([r, g, b]) => {
+				let luma = *r as f32 * 0.2627 / 65535.0
+					+ *g as f32 * 0.6780 / 65535.0
+					+ *b as f32 * 0.0593 / 65535.0;
+				debug!("Detected background color: {r:04x}/{g:04x}/{b:04x} (luma = {luma:.2})");
+				self.light = luma > 0.6;
+			}
+			Report::KittyGraphics { id: 31, ok } => self.kgp = *ok,
+			_ => {}
+		}
 	}
 
 	pub fn move_lock<F, T>((x, y): (u16, u16), cb: F) -> Result<T>
@@ -81,10 +65,11 @@ impl Emulator {
 		use std::{thread, time::Duration};
 
 		let mut w = TTY.lockout();
+		let tmux = EMULATOR.load().tmux;
 
 		// I really don't want to add this,
 		// But tmux and ConPTY sometimes cause the cursor position to get out of sync.
-		if TMUX.get() || cfg!(windows) {
+		if tmux || cfg!(windows) {
 			writef!(w, "{SaveCursorPos}{}{ShowCursor}", MoveTo(x, y))?;
 			writef!(w, "{}{ShowCursor}", MoveTo(x, y))?;
 			writef!(w, "{}{ShowCursor}", MoveTo(x, y))?;
@@ -94,7 +79,7 @@ impl Emulator {
 		}
 
 		let result = cb(&mut w);
-		if TMUX.get() || cfg!(windows) {
+		if tmux || cfg!(windows) {
 			write!(w, "{HideCursor}{RestoreCursorPos}")?;
 		} else {
 			write!(w, "{RestoreCursorPos}")?;
@@ -102,88 +87,6 @@ impl Emulator {
 
 		w.flush()?;
 		result
-	}
-
-	pub fn read_until_da1() -> String {
-		let now = std::time::Instant::now();
-		let h = tokio::spawn(Self::error_to_user());
-
-		let (buf, result) = TTY.read_until(Duration::from_millis(1000), |b, buf| {
-			b == b'c'
-				&& buf.contains(&0x1b)
-				&& buf.rsplitn(2, |&b| b == 0x1b).next().is_some_and(|s| s.starts_with(b"[?"))
-		});
-
-		h.abort();
-		match result {
-			Ok(()) => debug!("Terminal responded to DA1 in {:?}: {buf:?}", now.elapsed()),
-			Err(e) => {
-				error!("Terminal failed to respond to DA1 in {:?}: {buf:?}, error: {e:?}", now.elapsed())
-			}
-		}
-
-		String::from_utf8_lossy(&buf).into_owned()
-	}
-
-	pub fn read_until_dsr() -> String {
-		let now = std::time::Instant::now();
-		let (buf, result) = TTY.read_until(Duration::from_millis(200), |b, buf| {
-			b == b'n' && (buf.ends_with(b"\x1b[0n") || buf.ends_with(b"\x1b[3n"))
-		});
-
-		match result {
-			Ok(()) => debug!("Terminal responded to DSR in {:?}: {buf:?}", now.elapsed()),
-			Err(e) => {
-				error!("Terminal failed to respond to DSR in {:?}: {buf:?}, error: {e:?}", now.elapsed())
-			}
-		}
-		String::from_utf8_lossy(&buf).into_owned()
-	}
-
-	async fn error_to_user() {
-		sleep(Duration::from_millis(400)).await;
-		_ = writef!(
-			io::stderr(),
-			"{}{}\r\nTerminal response timeout: {}The request sent by Yazi didn't receive a correct response.\r\nPlease check your terminal environment as per: https://yazi-rs.github.io/docs/faq#trt\r\n",
-			SetFg(Color::Red),
-			SetSgr::Bold,
-			SetSgr::Reset,
-		);
-	}
-
-	fn csi_16t(resp: &str) -> Option<(u16, u16)> {
-		let b = resp.split_once("\x1b[6;")?.1.as_bytes();
-
-		let h: Vec<_> = b.iter().copied().take_while(|&c| c.is_ascii_digit()).collect();
-		b.get(h.len()).filter(|&&c| c == b';')?;
-
-		let w: Vec<_> = b[h.len() + 1..].iter().copied().take_while(|&c| c.is_ascii_digit()).collect();
-		b.get(h.len() + 1 + w.len()).filter(|&&c| c == b't')?;
-
-		let (w, h) = unsafe { (String::from_utf8_unchecked(w), String::from_utf8_unchecked(h)) };
-		Some((w.parse().ok()?, h.parse().ok()?))
-	}
-
-	fn csi_gt_q(resp: &str) -> Option<String> {
-		let (_, s) = resp.split_once("\x1bP>|")?;
-		Some(s[..s.find("\x1b\\")?].to_owned())
-	}
-
-	fn light_bg(resp: &str) -> Result<bool> {
-		match resp.split_once("]11;rgb:") {
-			Some((_, s)) if s.len() >= 14 => {
-				let r = u8::from_str_radix(&s[0..2], 16)? as f32;
-				let g = u8::from_str_radix(&s[5..7], 16)? as f32;
-				let b = u8::from_str_radix(&s[10..12], 16)? as f32;
-				let luma = r * 0.2627 / 256.0 + g * 0.6780 / 256.0 + b * 0.0593 / 256.0;
-				debug!("Detected background color: {} (luma = {luma:.2})", &s[..14]);
-				Ok(luma > 0.6)
-			}
-			_ => {
-				warn!("Failed to detect background color: {resp:?}");
-				Ok(false)
-			}
-		}
 	}
 
 	fn force_16t((w, h): (u16, u16)) -> bool {

--- a/yazi-emulator/src/lib.rs
+++ b/yazi-emulator/src/lib.rs
@@ -1,1 +1,3 @@
-yazi_macro::mod_flat!(brand dimension emulator mux unknown);
+yazi_macro::mod_flat!(brand dimension emulator mux probe);
+
+pub fn init() { EMULATOR.init(arc_swap::ArcSwap::from_pointee(Emulator::from_env())); }

--- a/yazi-emulator/src/mux.rs
+++ b/yazi-emulator/src/mux.rs
@@ -1,74 +1,38 @@
-use std::fmt::{self, Display};
+use std::{fmt::{self, Display}, process::Stdio};
 
-use anyhow::Result;
+use tokio::{process::Command, time::{Duration, timeout}};
 use tracing::error;
-use yazi_macro::{time, writef};
-use yazi_shim::cell::SyncCell;
-use yazi_tty::{TTY, sequence::RequestDeviceStatus};
 
-use crate::Emulator;
+use crate::EMULATOR;
 
-pub static TMUX: SyncCell<bool> = SyncCell::new(false);
-pub static ESCAPE: SyncCell<&'static str> = SyncCell::new("\x1b");
-pub static START: SyncCell<&'static str> = SyncCell::new("\x1b");
-pub static CLOSE: SyncCell<&'static str> = SyncCell::new("");
+pub const ESCAPE: MuxSequence = MuxSequence("\x1b", "\x1b\x1b");
+pub const START: MuxSequence = MuxSequence("\x1b", "\x1bPtmux;\x1b\x1b");
+pub const CLOSE: MuxSequence = MuxSequence("", "\x1b\\");
 
 pub struct Mux;
 
 impl Mux {
-	pub fn wrap<T: Display>(s: T) -> impl Display {
-		struct Wrapper<T>(T);
+	pub async fn tmux_passthrough() {
+		let output = Command::new("tmux")
+			.args(["set", "-p", "allow-passthrough", "on"])
+			.kill_on_drop(true)
+			.stdin(Stdio::null())
+			.stdout(Stdio::null())
+			.stderr(Stdio::piped())
+			.output();
 
-		impl<T: Display> Display for Wrapper<T> {
-			fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-				if !TMUX.get() {
-					return self.0.fmt(f);
-				}
-
-				write!(
-					f,
-					"{START}{}{CLOSE}",
-					self.0.to_string().trim_start_matches('\x1b').replace('\x1b', ESCAPE.get())
-				)
-			}
-		}
-
-		Wrapper(s)
-	}
-
-	pub fn tmux_passthrough() {
-		let output = time!(
-			"Running `tmux set -p allow-passthrough on`",
-			std::process::Command::new("tmux")
-				.args(["set", "-p", "allow-passthrough", "on"])
-				.stdin(std::process::Stdio::null())
-				.stdout(std::process::Stdio::null())
-				.stderr(std::process::Stdio::piped())
-				.spawn()
-				.and_then(|c| c.wait_with_output())
-		);
-
-		match output {
-			Ok(o) if o.status.success() => {}
-			Ok(o) => {
+		match timeout(Duration::from_secs(5), output).await {
+			Ok(Ok(o)) if o.status.success() => {}
+			Ok(Ok(o)) => {
 				error!(
 					"Running `tmux set -p allow-passthrough on` failed: {:?}, {}",
 					o.status,
 					String::from_utf8_lossy(&o.stderr)
 				);
 			}
-			Err(e) => {
-				error!("Failed to spawn `tmux set -p allow-passthrough on`: {e}");
-			}
+			Ok(Err(e)) => error!("Failed to spawn `tmux set -p allow-passthrough on`: {e}"),
+			Err(_) => error!("Running `tmux set -p allow-passthrough on` timed out"),
 		}
-	}
-
-	pub fn tmux_drain() -> Result<()> {
-		if TMUX.get() {
-			writef!(TTY.writer(), "{}", Self::wrap(RequestDeviceStatus))?;
-			_ = Emulator::read_until_dsr();
-		}
-		Ok(())
 	}
 
 	pub fn tmux_sixel_flag() -> &'static str {
@@ -85,32 +49,13 @@ impl Mux {
 			_ => "Unknown",
 		}
 	}
+}
 
-	pub(super) fn term_program() -> (Option<String>, Option<String>) {
-		let (mut term, mut program) = (None, None);
-		if !TMUX.get() {
-			return (term, program);
-		}
+// --- MuxSequence
+pub struct MuxSequence(&'static str, &'static str);
 
-		let Ok(output) = time!(
-			"Running `tmux show-environment`",
-			std::process::Command::new("tmux").arg("show-environment").output()
-		) else {
-			return (term, program);
-		};
-
-		for line in String::from_utf8_lossy(&output.stdout).lines() {
-			if let Some((k, v)) = line.trim().split_once('=') {
-				match k {
-					"TERM" => term = Some(v.to_owned()),
-					"TERM_PROGRAM" => program = Some(v.to_owned()),
-					_ => continue,
-				}
-			}
-			if term.is_some() && program.is_some() {
-				break;
-			}
-		}
-		(term, program)
+impl Display for MuxSequence {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str(if EMULATOR.load().tmux { self.1 } else { self.0 })
 	}
 }

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -1,0 +1,96 @@
+use std::{fmt::Display, time::Duration};
+
+use anyhow::{Result, bail};
+use tokio::time;
+use tracing::error;
+use yazi_macro::writef;
+use yazi_shared::id::{Id, Ids};
+use yazi_term::{TERM, event::{Event, Report}, stream::EventStream};
+use yazi_tty::{TTY, sequence::{If, KittyGraphicsQuery, RequestBgColor, RequestCellPixelSize, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestXtVersion, RestoreCursorPos, SaveCursorPos, TmuxPassthrough}};
+
+use crate::{Brand, Emulator, Mux};
+
+static IDS: Ids = Ids::new();
+
+pub struct Probe {
+	pub id:       Id,
+	pub emulator: Emulator,
+}
+
+impl Probe {
+	pub fn start() -> Result<Self> {
+		let probe = Self { id: IDS.next(), emulator: Emulator::from_env() };
+		probe.request()?;
+		Ok(probe)
+	}
+
+	pub fn restart(&mut self) -> Result<()> {
+		self.id = IDS.next();
+		self.emulator = Emulator { tmux: true, ..Default::default() };
+		self.request()
+	}
+
+	pub fn needs_passthrough(&self) -> bool {
+		self.emulator.brand == Brand::Tmux && !self.emulator.tmux
+	}
+
+	fn request(&self) -> Result<()> {
+		let w = |t: &'static dyn Display| TmuxPassthrough(t, self.emulator.tmux);
+
+		writef!(
+			TTY.writer(),
+			"{SaveCursorPos}{}{}{RequestCursorStyle}{RequestCursorBlink}{RequestCellPixelSize}{RequestBgColor}{}{RestoreCursorPos}",
+			w(&RequestXtVersion),
+			If(self.emulator.brand == Brand::Unknown, w(&KittyGraphicsQuery)),
+			w(&RequestDA1),
+		)?;
+
+		Ok(())
+	}
+}
+
+impl Emulator {
+	pub async fn probe() -> Result<Self> {
+		TERM.enter_raw_mode()?;
+		let mut stream = EventStream::from(&*TERM);
+		let mut rx = stream.take().unwrap();
+
+		let result = async {
+			let mut probe = Probe::start()?;
+			loop {
+				let wait_da1 = async {
+					while let Some(event) = rx.recv().await {
+						let Event::Report(report) = event? else { continue };
+
+						probe.emulator.apply(&report);
+						if matches!(report, Report::Da1(_)) {
+							return Ok(());
+						}
+					}
+					bail!("Terminal event stream closed during emulator detection");
+				};
+
+				match time::timeout(Duration::from_secs(3), wait_da1).await {
+					Ok(result) => result?,
+					Err(_) => return Ok(probe.emulator),
+				}
+
+				if !probe.needs_passthrough() {
+					return Ok(probe.emulator);
+				}
+
+				Mux::tmux_passthrough().await;
+				if let Err(e) = probe.restart() {
+					error!("Failed to request terminal capabilities through tmux: {e}");
+					return Ok(probe.emulator);
+				}
+			}
+		}
+		.await;
+
+		drop(rx);
+		drop(stream);
+		TERM.enter_cooked_mode()?;
+		result
+	}
+}

--- a/yazi-emulator/src/unknown.rs
+++ b/yazi-emulator/src/unknown.rs
@@ -1,5 +1,0 @@
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Unknown {
-	pub kgp:   bool,
-	pub sixel: bool,
-}

--- a/yazi-fm/Cargo.toml
+++ b/yazi-fm/Cargo.toml
@@ -24,6 +24,7 @@ yazi-boot      = { path = "../yazi-boot", version = "26.5.6" }
 yazi-config    = { path = "../yazi-config", version = "26.5.6" }
 yazi-core      = { path = "../yazi-core", version = "26.5.6" }
 yazi-dds       = { path = "../yazi-dds", version = "26.5.6" }
+yazi-emulator  = { path = "../yazi-emulator", version = "26.5.6" }
 yazi-fs        = { path = "../yazi-fs", version = "26.5.6" }
 yazi-macro     = { path = "../yazi-macro", version = "26.5.6" }
 yazi-parser    = { path = "../yazi-parser", version = "26.5.6" }

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use tokio::{select, sync::mpsc, time::sleep};
 use yazi_actor::Ctx;
 use yazi_core::Core;
-use yazi_macro::act;
+use yazi_macro::{act, render, succ};
 use yazi_shared::{data::Data, event::{Event, NEED_RENDER}};
 use yazi_tui::Raterm;
 
@@ -59,8 +59,7 @@ impl App {
 	fn bootstrap(&mut self) -> Result<Data> {
 		let cx = &mut Ctx::active(&mut self.core, &mut self.term);
 		act!(app:bootstrap, cx)?;
-
-		self.render(false)
+		succ!(render!())
 	}
 
 	async fn drain(&mut self, rx: &mut mpsc::UnboundedReceiver<Event>) -> Result<bool> {

--- a/yazi-fm/src/dispatcher.rs
+++ b/yazi-fm/src/dispatcher.rs
@@ -29,6 +29,7 @@ impl<'a> Dispatcher<'a> {
 			Event::Term(TermEvent::FocusOut) => Ok(()),
 			Event::Term(TermEvent::Paste(str)) => self.dispatch_paste(str),
 			Event::Term(TermEvent::Dnd(dnd)) => self.dispatch_dnd(dnd),
+			Event::Term(TermEvent::Report(report)) => self.dispatch_report(report),
 		};
 
 		if let Err(e) = &result {
@@ -44,7 +45,7 @@ impl<'a> Dispatcher<'a> {
 			warn!("Call dispatch error: {e:?}");
 		}
 		if let Some(tx) = tx {
-			tx.send(result).ok();
+			tx.reply_if_unclaimed(result);
 		}
 	}
 
@@ -100,5 +101,10 @@ impl<'a> Dispatcher<'a> {
 	fn dispatch_dnd(&mut self, dnd: DndEvent) -> Result<()> {
 		let cx = &mut Ctx::active(&mut self.app.core, &mut self.app.term);
 		act!(app:dnd, cx, dnd).map(|_| ())
+	}
+
+	fn dispatch_report(&mut self, report: yazi_term::event::Report) -> Result<()> {
+		let cx = &mut Ctx::active(&mut self.app.core, &mut self.app.term);
+		act!(app:report, cx, report).map(|_| ())
 	}
 }

--- a/yazi-fm/src/executor.rs
+++ b/yazi-fm/src/executor.rs
@@ -50,6 +50,7 @@ impl<'a> Executor<'a> {
 		on!(update_progress);
 		on!(lua);
 		on!(deprecate);
+		on!(passthrough);
 		on!(theme);
 		on!(stop);
 		on!(quit);

--- a/yazi-fm/src/main.rs
+++ b/yazi-fm/src/main.rs
@@ -28,7 +28,9 @@ async fn main() -> anyhow::Result<()> {
 
 	yazi_term::init()?;
 
-	yazi_adapter::init()?;
+	yazi_emulator::init();
+
+	yazi_adapter::init();
 
 	yazi_dds::init();
 

--- a/yazi-fs/src/engine/local/casefold.rs
+++ b/yazi-fs/src/engine/local/casefold.rs
@@ -96,7 +96,7 @@ fn casefold_impl(path: PathBuf) -> io::Result<PathBuf> {
 		// Case-insensitive match
 		Ok(parent.join(&names[i]))
 	} else {
-		Err(io::Error::from(io::ErrorKind::NotFound))
+		Err(io::ErrorKind::NotFound.into())
 	}
 }
 
@@ -153,7 +153,7 @@ fn casefold_impl(path: PathBuf) -> io::Result<PathBuf> {
 		// Case-insensitive match
 		Ok(parent.join(&names[i]))
 	} else {
-		Err(io::Error::from(io::ErrorKind::NotFound))
+		Err(io::ErrorKind::NotFound.into())
 	}
 }
 

--- a/yazi-parser/src/app/mod.rs
+++ b/yazi-parser/src/app/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(deprecate dnd lua mouse plugin quit reflow title update_progress);
+yazi_macro::mod_flat!(deprecate dnd lua mouse passthrough plugin quit reflow stop title update_progress);

--- a/yazi-parser/src/app/passthrough.rs
+++ b/yazi-parser/src/app/passthrough.rs
@@ -1,0 +1,22 @@
+use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use serde::Deserialize;
+use yazi_shared::{event::ActionCow, id::Id};
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub struct PassthroughForm {
+	pub id: Id,
+}
+
+impl TryFrom<ActionCow> for PassthroughForm {
+	type Error = anyhow::Error;
+
+	fn try_from(a: ActionCow) -> Result<Self, Self::Error> { Ok(a.deserialize()?) }
+}
+
+impl FromLua for PassthroughForm {
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
+}
+
+impl IntoLua for PassthroughForm {
+	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+}

--- a/yazi-parser/src/app/stop.rs
+++ b/yazi-parser/src/app/stop.rs
@@ -1,0 +1,23 @@
+use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use yazi_shared::event::{ActionCow, Replier};
+
+#[derive(Clone, Debug, Default)]
+pub struct StopForm {
+	pub replier: Option<Replier>,
+}
+
+impl TryFrom<ActionCow> for StopForm {
+	type Error = anyhow::Error;
+
+	fn try_from(mut a: ActionCow) -> Result<Self, Self::Error> {
+		Ok(Self { replier: a.take_replier() })
+	}
+}
+
+impl FromLua for StopForm {
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
+}
+
+impl IntoLua for StopForm {
+	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+}

--- a/yazi-parser/src/spark/spark.rs
+++ b/yazi-parser/src/spark/spark.rs
@@ -17,11 +17,13 @@ pub enum Spark<'a> {
 	AppMouse(crate::app::MouseForm),
 	AppPlugin(crate::app::PluginForm),
 	AppPluginDo(crate::app::PluginForm),
+	AppPassthrough(crate::app::PassthroughForm),
 	AppQuit(crate::app::QuitForm),
+	AppReport(yazi_term::event::Report),
 	AppReflow(crate::app::ReflowForm),
 	AppResize(crate::app::ReflowForm),
 	AppResume(crate::app::ReflowForm),
-	AppStop(crate::VoidForm),
+	AppStop(crate::app::StopForm),
 	AppTheme(crate::VoidForm),
 	AppTitle(crate::app::TitleForm),
 	AppUpdateProgress(crate::app::UpdateProgressForm),
@@ -212,7 +214,9 @@ impl<'a> IntoLua for Spark<'a> {
 			Self::AppMouse(b) => b.into_lua(lua),
 			Self::AppPlugin(b) => b.into_lua(lua),
 			Self::AppPluginDo(b) => b.into_lua(lua),
+			Self::AppPassthrough(b) => b.into_lua(lua),
 			Self::AppQuit(b) => b.into_lua(lua),
+			Self::AppReport(b) => b.into_lua(lua),
 			Self::AppReflow(b) => b.into_lua(lua),
 			Self::AppResize(b) => b.into_lua(lua),
 			Self::AppResume(b) => b.into_lua(lua),
@@ -362,7 +366,6 @@ try_from_spark!(
 	crate::VoidForm,
 	app:bootstrap,
 	app:focus,
-	app:stop,
 	app:theme,
 	mgr:back,
 	mgr:bulk_rename,
@@ -391,8 +394,11 @@ try_from_spark!(crate::app::DndForm, app:dnd);
 try_from_spark!(crate::app::LuaForm, app:lua);
 try_from_spark!(crate::app::MouseForm, app:mouse);
 try_from_spark!(crate::app::PluginForm, app:plugin, app:plugin_do);
+try_from_spark!(crate::app::PassthroughForm, app:passthrough);
 try_from_spark!(crate::app::QuitForm, app:quit, mgr:quit);
+try_from_spark!(yazi_term::event::Report, app:report);
 try_from_spark!(crate::app::ReflowForm, app:reflow, app:resize, app:resume);
+try_from_spark!(crate::app::StopForm, app:stop);
 try_from_spark!(crate::app::TitleForm, app:title);
 try_from_spark!(crate::app::UpdateProgressForm, app:update_progress);
 try_from_spark!(crate::cmp::CloseForm, cmp:close);

--- a/yazi-plugin/src/runtime/term.rs
+++ b/yazi-plugin/src/runtime/term.rs
@@ -5,7 +5,7 @@ use yazi_emulator::{Dimension, EMULATOR};
 pub(super) fn term() -> Composer<ComposerGet, ComposerSet> {
 	fn get(lua: &Lua, key: &[u8]) -> mlua::Result<Value> {
 		match key {
-			b"light" => EMULATOR.light.into_lua(lua),
+			b"light" => EMULATOR.load().light.into_lua(lua),
 			b"cell_size" => cell_size(lua)?.into_lua(lua),
 			_ => Ok(Value::Nil),
 		}

--- a/yazi-proxy/src/app.rs
+++ b/yazi-proxy/src/app.rs
@@ -1,14 +1,23 @@
 use yazi_core::app::{PluginOpt, QuitOpt};
 use yazi_macro::{emit, relay};
+use yazi_shared::id::Id;
 
 pub struct AppProxy;
 
 impl AppProxy {
-	pub fn quit(opt: QuitOpt) {
-		emit!(Call(relay!(app:quit).with_any("opt", opt)));
+	pub fn passthrough(id: Id) {
+		emit!(Call(relay!(app:passthrough).with("id", id)));
 	}
 
 	pub fn plugin_do(opt: PluginOpt) {
 		emit!(Call(relay!(app:plugin_do).with_any("opt", opt)));
+	}
+
+	pub fn quit(opt: QuitOpt) {
+		emit!(Call(relay!(app:quit).with_any("opt", opt)));
+	}
+
+	pub fn theme() {
+		emit!(Call(relay!(app:theme)));
 	}
 }

--- a/yazi-scheduler/src/proxy.rs
+++ b/yazi-scheduler/src/proxy.rs
@@ -1,21 +1,29 @@
 use tokio::sync::mpsc;
 use yazi_macro::{emit, relay};
-use yazi_shared::{id::Id, url::UrlBuf};
+use yazi_shared::{event::Replier, id::Id, url::UrlBuf};
 use yazi_shim::SStr;
 
 pub struct AppProxy;
 
 impl AppProxy {
+	pub async fn resume() {
+		let (tx, mut rx) = mpsc::unbounded_channel();
+		emit!(Call(relay!(app:resume).with_replier(tx)));
+		rx.recv().await;
+	}
+
 	pub async fn stop() {
 		let (tx, mut rx) = mpsc::unbounded_channel();
 		emit!(Call(relay!(app:stop).with_replier(tx)));
 		rx.recv().await;
 	}
 
-	pub async fn resume() {
-		let (tx, mut rx) = mpsc::unbounded_channel();
-		emit!(Call(relay!(app:resume).with_replier(tx)));
-		rx.recv().await;
+	pub fn stop_with(replier: Option<Replier>) {
+		let mut action = relay!(app:stop);
+		if let Some(replier) = replier {
+			action = action.with_replier(replier);
+		}
+		emit!(Call(action));
 	}
 }
 

--- a/yazi-sftp/src/session.rs
+++ b/yazi-sftp/src/session.rs
@@ -37,11 +37,7 @@ impl Session {
 		}
 
 		async fn write(writer: &mut WriteHalf<ChannelStream<Msg>>, buf: Vec<u8>) -> io::Result<()> {
-			if buf.is_empty() {
-				Err(io::Error::from(ErrorKind::BrokenPipe))
-			} else {
-				writer.write_all(&buf).await
-			}
+			if buf.is_empty() { Err(ErrorKind::BrokenPipe.into()) } else { writer.write_all(&buf).await }
 		}
 
 		let me_ = me.clone();

--- a/yazi-shared/src/completion_cell.rs
+++ b/yazi-shared/src/completion_cell.rs
@@ -1,0 +1,51 @@
+use std::sync::OnceLock;
+
+use tokio::sync::Notify;
+
+#[derive(Debug)]
+pub struct CompletionCell<T> {
+	value: OnceLock<T>,
+	ready: Notify,
+}
+
+impl<T> Default for CompletionCell<T> {
+	fn default() -> Self { Self { value: OnceLock::new(), ready: Notify::new() } }
+}
+
+impl<T> CompletionCell<T> {
+	pub fn get(&self) -> Option<&T> { self.value.get() }
+
+	pub fn get_or_init<F>(&self, f: F) -> &T
+	where
+		F: FnOnce() -> T,
+	{
+		if let Some(value) = self.value.get() {
+			return value;
+		}
+
+		let value = self.value.get_or_init(f);
+		self.ready.notify_waiters();
+		value
+	}
+
+	pub fn set(&self, value: T) -> Result<(), T> {
+		self.value.set(value)?;
+		self.ready.notify_waiters();
+		Ok(())
+	}
+
+	pub async fn wait(&self) -> &T {
+		loop {
+			if let Some(value) = self.value.get() {
+				return value;
+			}
+
+			let ready = self.ready.notified();
+			if let Some(value) = self.value.get() {
+				return value;
+			}
+
+			ready.await;
+		}
+	}
+}

--- a/yazi-shared/src/event/action.rs
+++ b/yazi-shared/src/event/action.rs
@@ -107,8 +107,8 @@ impl Action {
 		self
 	}
 
-	pub fn with_replier(mut self, tx: Replier) -> Self {
-		self.args.insert("replier".into(), Data::Any(Box::new(tx)));
+	pub fn with_replier(mut self, tx: impl Into<Replier>) -> Self {
+		self.args.insert("replier".into(), Data::Any(Box::new(tx.into())));
 		self
 	}
 
@@ -226,7 +226,11 @@ impl Action {
 		(0..self.len()).filter_map(|i| self.args.remove(&DataKey::from(i))?.into_any())
 	}
 
-	pub fn take_replier(&mut self) -> Option<Replier> { self.take_any("replier") }
+	pub fn take_replier(&mut self) -> Option<Replier> {
+		let replier: Replier = self.take_any("replier")?;
+		replier.claim();
+		Some(replier)
+	}
 }
 
 impl Display for Action {

--- a/yazi-shared/src/event/mod.rs
+++ b/yazi-shared/src/event/mod.rs
@@ -1,5 +1,3 @@
-yazi_macro::mod_flat!(action action_cow actions cmd de de_owned event);
-
-pub type Replier = tokio::sync::mpsc::UnboundedSender<anyhow::Result<crate::data::Data>>;
+yazi_macro::mod_flat!(action action_cow actions cmd de de_owned event replier);
 
 pub static NEED_RENDER: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);

--- a/yazi-shared/src/event/replier.rs
+++ b/yazi-shared/src/event/replier.rs
@@ -1,0 +1,38 @@
+use std::sync::{Arc, atomic::{AtomicU8, Ordering}};
+
+use tokio::sync::mpsc;
+use yazi_macro::impl_data_any;
+
+use crate::data::Data;
+
+type Reply = anyhow::Result<Data>;
+
+#[derive(Clone, Debug)]
+pub struct Replier {
+	tx:    mpsc::UnboundedSender<Reply>,
+	state: Arc<AtomicU8>,
+}
+
+impl_data_any!(Replier);
+
+impl From<mpsc::UnboundedSender<Reply>> for Replier {
+	fn from(tx: mpsc::UnboundedSender<Reply>) -> Self {
+		Self { tx, state: Arc::new(AtomicU8::new(0)) }
+	}
+}
+
+impl Replier {
+	pub(super) fn claim(&self) {
+		_ = self.state.compare_exchange(0, 1, Ordering::Relaxed, Ordering::Relaxed);
+	}
+
+	pub fn send(&self, result: Reply) -> Result<(), mpsc::error::SendError<Reply>> {
+		let state = self.state.swap(2, Ordering::Relaxed);
+		if state == 2 { Err(mpsc::error::SendError(result)) } else { self.tx.send(result) }
+	}
+
+	pub fn reply_if_unclaimed(&self, result: Reply) -> bool {
+		self.state.compare_exchange(0, 2, Ordering::Relaxed, Ordering::Relaxed).is_ok()
+			&& self.tx.send(result).is_ok()
+	}
+}

--- a/yazi-shared/src/lib.rs
+++ b/yazi-shared/src/lib.rs
@@ -2,7 +2,7 @@ extern crate self as yazi_shared;
 
 yazi_macro::mod_pub!(any_data auth data spec event id loc path pool shell strand translit url);
 
-yazi_macro::mod_flat!(bytes chars completion_token condition debounce env kebab_cased_key last_value layer localset natsort non_empty_string os predictor snake_cased_key source tests throttle time);
+yazi_macro::mod_flat!(bytes chars completion_cell completion_token condition debounce env kebab_cased_key last_value layer localset natsort non_empty_string os predictor snake_cased_key source tests throttle time);
 
 pub fn init() {
 	LOCAL_SET.with(tokio::task::LocalSet::new);

--- a/yazi-term/src/event/event.rs
+++ b/yazi-term/src/event/event.rs
@@ -1,4 +1,4 @@
-use crate::{Dimension, event::{DndEvent, KeyEvent, MouseEvent}};
+use crate::{Dimension, event::{DndEvent, KeyEvent, MouseEvent, Report}};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Event {
@@ -9,4 +9,5 @@ pub enum Event {
 	FocusOut,
 	Paste(String),
 	Dnd(DndEvent),
+	Report(Report),
 }

--- a/yazi-term/src/event/mod.rs
+++ b/yazi-term/src/event/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(dnd event keyboard lua modifiers mouse);
+yazi_macro::mod_flat!(dnd event keyboard lua modifiers mouse report);

--- a/yazi-term/src/event/report.rs
+++ b/yazi-term/src/event/report.rs
@@ -1,0 +1,17 @@
+use compact_str::CompactString;
+use mlua::{ExternalError, IntoLua, Lua, Value};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Report {
+	CursorBlink(bool),
+	CursorShape(u8),
+	Da1(Vec<u16>),
+	XtVersion(CompactString),
+	CellPixelSize { width: u16, height: u16 },
+	BackgroundColor([u16; 3]),
+	KittyGraphics { id: u32, ok: bool },
+}
+
+impl IntoLua for Report {
+	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+}

--- a/yazi-term/src/parser/csi.rs
+++ b/yazi-term/src/parser/csi.rs
@@ -44,7 +44,8 @@ impl Parser {
 			b'Q' => Event::Key(KeyCode::Fn(2).into()),
 			b'S' => Event::Key(KeyCode::Fn(4).into()),
 			b'?' => match last {
-				b'u' | b'c' | b'n' | b'y' => return Err(ParseError::Ignored),
+				b'c' | b'y' => return self.parse_csi_report(),
+				b'u' | b'n' => return Err(ParseError::Ignored),
 				_ => bail!(),
 			},
 			b'>' => match seq[seq.len() - 2..] {
@@ -54,8 +55,9 @@ impl Parser {
 			b'0'..=b'9' if !(64..=126).contains(&last) => return Err(ParseError::Incomplete),
 			b'0'..=b'9' => match last {
 				b'M' => return self.parse_csi_rxvt_mouse(),
-				b'~' => return self.parse_csi_special_key(),
 				b'u' => return self.parse_csi_u_key(),
+				b'~' => return self.parse_csi_special_key(),
+				b'n' | b't' => return self.parse_csi_report(),
 				b'R' => return Err(ParseError::Ignored),
 				_ if self.seq.contains(&b';') => return self.parse_csi_modifier_key(),
 				_ => return self.parse_csi_modifier_legacy_key(),

--- a/yazi-term/src/parser/mod.rs
+++ b/yazi-term/src/parser/mod.rs
@@ -1,4 +1,4 @@
-yazi_macro::mod_flat!(csi ground osc parser state);
+yazi_macro::mod_flat!(csi ground osc parser report state);
 
 #[cfg(windows)]
 yazi_macro::mod_flat!(windows);

--- a/yazi-term/src/parser/parser.rs
+++ b/yazi-term/src/parser/parser.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, mem, num::NonZeroU8, str};
+use std::{collections::VecDeque, mem, num::NonZeroU8, str, time::{Duration, Instant}};
 
 use yazi_shim::utf8_char_width;
 
@@ -10,14 +10,18 @@ pub struct Parser {
 	pub(super) state:  State,
 	pub(super) seq:    Vec<u8>,
 	pub(crate) events: VecDeque<Event>,
+	discard:           bool,
+	touched:           Instant,
 }
 
 impl Default for Parser {
 	fn default() -> Self {
 		Self {
-			state:  State::Ground,
-			seq:    Vec::with_capacity(64),
-			events: VecDeque::with_capacity(32),
+			state:   State::Ground,
+			seq:     Vec::with_capacity(64),
+			events:  VecDeque::with_capacity(32),
+			discard: false,
+			touched: Instant::now(),
 		}
 	}
 }
@@ -29,7 +33,14 @@ impl Parser {
 		}
 	}
 
-	fn step(&mut self, b: u8) {
+	pub fn step(&mut self, b: u8) {
+		// If the sequence is too long, mark it for discard.
+		if self.seq.len() >= self.state.limit() {
+			self.seq.clear();
+			self.discard = true;
+		}
+
+		self.touched = Instant::now();
 		match &self.state {
 			State::Ground => self.on_ground(b),
 			State::Esc => self.on_esc(b),
@@ -40,30 +51,34 @@ impl Parser {
 			State::Osc | State::OscSt => self.on_osc(b),
 			State::Osc72(_) => self.on_osc72(b),
 			State::Dcs | State::DcsSt => self.on_dcs(b),
+			State::Apc | State::ApcSt => self.on_apc(b),
 			State::Utf8(n) => self.on_utf8(b, *n),
 			State::AltUtf8(n) => self.on_alt_utf8(b, *n),
 		}
 	}
 
-	/// Resolve any pending ambiguous state.
-	///
-	/// Call this when no more input bytes are immediately available. If the
-	/// parser is waiting in the [`State::Esc`] state (a lone `\x1B` has
-	/// been seen but no follow-up bytes arrived), this emits a bare
-	/// [`KeyCode::Escape`] event and resets to [`State::Ground`].
-	pub fn flush(&mut self) {
-		match &self.state {
-			State::Esc => self.emit_key(KeyCode::Escape),
-			State::Osc72(s) if s.has_more => return,
-			_ => {}
-		}
-
-		self.reset();
-	}
-
 	fn reset(&mut self) {
 		self.state = State::Ground;
 		self.seq.clear();
+		self.discard = false;
+	}
+
+	pub(crate) fn drain(&mut self) {
+		self.reset();
+		self.events.clear();
+	}
+
+	pub(crate) fn leftover(&self) -> Option<Duration> {
+		self.state.timeout().map(|d| d.saturating_sub(self.touched.elapsed()))
+	}
+
+	pub(crate) fn expire(&mut self) {
+		if self.leftover().is_none_or(|d| !d.is_zero()) {
+			return;
+		} else if matches!(&self.state, State::Esc) {
+			self.emit_key(KeyCode::Escape);
+		}
+		self.reset();
 	}
 
 	pub(crate) fn emit(&mut self, event: impl Into<Event>) { self.events.push_back(event.into()); }
@@ -97,6 +112,7 @@ impl Parser {
 			b'[' => self.state = State::Csi,
 			b']' => self.state = State::Osc,
 			b'P' => self.state = State::Dcs,
+			b'_' => self.state = State::Apc,
 			b'O' => self.state = State::EscO,
 			// ESC ESC: emit Escape for the first byte, the second is consumed.
 			b'\x1B' => {
@@ -128,10 +144,7 @@ impl Parser {
 			b'F' => Event::Key(KeyCode::End.into()),
 			b'H' => Event::Key(KeyCode::Home.into()),
 			v @ b'P'..=b'S' => Event::Key(KeyCode::Fn(1 + v - b'P').into()),
-			_ => {
-				self.reset();
-				return;
-			}
+			_ => return self.reset(),
 		};
 		self.emit(event);
 		self.reset();
@@ -149,6 +162,11 @@ impl Parser {
 		// technically in the final-byte range but must not trigger early dispatch.
 		if b == b'[' && self.seq.len() == 3 {
 			return;
+		}
+
+		// If the sequence is marked for discard, reset and ignore it.
+		if self.discard {
+			return self.reset();
 		}
 
 		// `\x1B[M` (no params) = X10 normal-mouse encoding; 3 raw bytes follow.
@@ -186,26 +204,30 @@ impl Parser {
 	fn on_bracketed_paste(&mut self, b: u8) {
 		self.seq.push(b);
 
-		if self.seq.ends_with(b"\x1b[201~") {
-			// seq = b"\x1B[200~" + paste_content + b"\x1B[201~"
-			let paste = String::from_utf8_lossy(&self.seq[6..self.seq.len() - 6]).into_owned();
-			self.emit(Event::Paste(paste));
-			self.reset();
+		if !self.seq.ends_with(b"\x1b[201~") {
+			return;
+		} else if self.discard {
+			return self.reset();
 		}
+
+		// seq = b"\x1B[200~" + paste_content + b"\x1B[201~"
+		let paste = String::from_utf8_lossy(&self.seq[6..self.seq.len() - 6]).into_owned();
+		self.emit(Event::Paste(paste));
+		self.reset();
 	}
 
 	fn on_osc(&mut self, b: u8) {
 		self.seq.push(b);
 
 		match (&self.state, b) {
-			(State::Osc, b'\x07') => self.reset(), // BEL — OSC complete (discard)
+			(State::Osc, b'\x07') => self.finish_report(Self::parse_osc_report),
 			(State::Osc, _) if self.seq.starts_with(b"\x1b]72;") => {
 				self.state = State::Osc72(Default::default());
 			}
 			(State::Osc, b'\x1B') => self.state = State::OscSt,
-			(State::Osc, _) => {}                         // keep accumulating
-			(State::OscSt, b'\\') => self.reset(),        // ST (`\x1B\\`) — OSC complete (discard)
-			(State::OscSt, b'\x1B') => {}                 // another ESC — stay in OscSt
+			(State::Osc, _) => {} // keep accumulating
+			(State::OscSt, b'\\') => self.finish_report(Self::parse_osc_report),
+			(State::OscSt, b'\x1B') => {} // another ESC — stay in OscSt
 			(State::OscSt, _) => self.state = State::Osc, // not ST — resume OSC
 			_ => unreachable!(),
 		}
@@ -216,6 +238,8 @@ impl Parser {
 
 		if !self.seq.ends_with(b"\x1b\\") {
 			return;
+		} else if self.discard {
+			return self.reset();
 		} else if self.parse_osc72().is_err() {
 			return self.reset();
 		}
@@ -241,9 +265,22 @@ impl Parser {
 		match (&self.state, b) {
 			(State::Dcs, b'\x1B') => self.state = State::DcsSt,
 			(State::Dcs, _) => {}
-			(State::DcsSt, b'\\') => self.reset(), // ST — DCS complete (discard)
-			(State::DcsSt, b'\x1B') => {}          // another ESC — stay in DcsSt
+			(State::DcsSt, b'\\') => self.finish_report(Self::parse_dcs_report),
+			(State::DcsSt, b'\x1B') => {} // another ESC — stay in DcsSt
 			(State::DcsSt, _) => self.state = State::Dcs, // not ST — resume DCS
+			_ => unreachable!(),
+		}
+	}
+
+	fn on_apc(&mut self, b: u8) {
+		self.seq.push(b);
+
+		match (&self.state, b) {
+			(State::Apc, b'\x1B') => self.state = State::ApcSt,
+			(State::Apc, _) => {}
+			(State::ApcSt, b'\\') => self.finish_report(Self::parse_apc_report),
+			(State::ApcSt, b'\x1B') => {}
+			(State::ApcSt, _) => self.state = State::Apc,
 			_ => unreachable!(),
 		}
 	}
@@ -285,6 +322,15 @@ impl Parser {
 			&& let Some(c) = s.chars().next()
 		{
 			self.emit_key(KeyEvent::new(KeyCode::Char(c), Modifiers::ALT | Modifiers::for_char(c)));
+		}
+		self.reset();
+	}
+
+	fn finish_report(&mut self, parse: fn(&Self) -> crate::Result<Event>) {
+		if !self.discard
+			&& let Ok(event) = parse(self)
+		{
+			self.emit(event);
 		}
 		self.reset();
 	}

--- a/yazi-term/src/parser/report.rs
+++ b/yazi-term/src/parser/report.rs
@@ -1,0 +1,119 @@
+use std::str;
+
+use compact_str::CompactString;
+
+use crate::{ParseError, Result, bail, event::{Event, Report}, parser::Parser};
+
+impl Parser {
+	pub(super) fn parse_csi_report(&self) -> Result<Event> {
+		let seq = &self.seq;
+		debug_assert!(seq.starts_with(b"\x1b["));
+
+		Ok(Event::Report(match (seq.get(2), seq.last()) {
+			// `CSI ? Ps ; ... c` (`\x1b[?...c`) - DA1 (Primary Device Attributes) response.
+			(Some(b'?'), Some(b'c')) => Report::Da1(
+				str::from_utf8(&seq[3..seq.len() - 1])?
+					.split(';')
+					.filter(|s| !s.is_empty())
+					.map(str::parse)
+					.collect::<Result<_, _>>()?,
+			),
+
+			// `CSI ? 12 ; Ps $ y` (`\x1b[?12;...$y`) - DECRPM response for DEC mode 12.
+			(Some(b'?'), Some(b'y')) => {
+				let status: u8 = str::from_utf8(&seq[3..seq.len() - 1])?
+					.strip_prefix("12;")
+					.and_then(|s| s.strip_suffix('$'))
+					.ok_or(ParseError::Invalid)?
+					.parse()?;
+
+				Report::CursorBlink(match status {
+					1 | 3 => true,
+					2 | 4 => false,
+					_ => bail!(),
+				})
+			}
+
+			// `CSI 6 ; Ph ; Pw t` (`\x1b[6;...;...t`) - XTWINOPS character-cell size report.
+			(Some(b'6'), Some(b't')) => {
+				let (h, w) = str::from_utf8(&seq[3..seq.len() - 1])?
+					.strip_prefix(';')
+					.and_then(|s| s.split_once(';'))
+					.ok_or(ParseError::Invalid)?;
+				Report::CellPixelSize { width: w.parse()?, height: h.parse()? }
+			}
+
+			_ => bail!(),
+		}))
+	}
+
+	pub(super) fn parse_dcs_report(&self) -> Result<Event> {
+		let seq = self.seq.strip_suffix(b"\x1b\\").ok_or(ParseError::Invalid)?;
+
+		// DECRQSS response for DECSCUSR:
+		//   `DCS 1 $ r Ps SP q ST` (`\x1bP1$r... q\x1b\\`)
+		if let Some(body) = seq.strip_prefix(b"\x1bP1$r") {
+			return Ok(Event::Report(match body {
+				[shape @ b'0'..=b'6', b' ', b'q'] => Report::CursorShape(shape - b'0'),
+				_ => bail!(),
+			}));
+		}
+
+		// `DCS > | Pt ST` (`\x1bP>|...\x1b\\`) - XTVERSION response.
+		if let Some(body) = seq.strip_prefix(b"\x1bP>|") {
+			return Ok(Event::Report(Report::XtVersion(CompactString::from_utf8_lossy(body))));
+		}
+
+		bail!()
+	}
+
+	pub(super) fn parse_osc_report(&self) -> Result<Event> {
+		let seq = self
+			.seq
+			.strip_suffix(b"\x07")
+			.or_else(|| self.seq.strip_suffix(b"\x1b\\"))
+			.ok_or(ParseError::Invalid)?;
+
+		// Dynamic background-color report:
+		//   `OSC 11 ; rgb:Pr/Pg/Pb ST|BEL` (`\x1b]11;rgb:...`)
+		if let Some(body) = seq.strip_prefix(b"\x1b]11;rgb:") {
+			return Ok(Event::Report(Report::BackgroundColor(parse_bg_rgb(body)?)));
+		}
+
+		bail!()
+	}
+
+	pub(super) fn parse_apc_report(&self) -> Result<Event> {
+		let seq = self.seq.strip_suffix(b"\x1b\\").ok_or(ParseError::Invalid)?;
+
+		// Kitty graphics response:
+		//   `APC G i=Pi,...;OK|ERROR ST` (`\x1b_Gi=...;...\x1b\\`)
+		if let Some(body) = seq.strip_prefix(b"\x1b_G") {
+			let (meta, status) = str::from_utf8(body)?.split_once(';').ok_or(ParseError::Invalid)?;
+			let id =
+				meta.split(',').find_map(|s| s.strip_prefix("i=")).ok_or(ParseError::Invalid)?.parse()?;
+			return Ok(Event::Report(Report::KittyGraphics { id, ok: status == "OK" }));
+		}
+
+		bail!()
+	}
+}
+
+fn parse_bg_rgb(body: &[u8]) -> Result<[u16; 3]> {
+	let mut it = str::from_utf8(body)?.split('/');
+	let mut rgb = [0; 3];
+
+	for value in &mut rgb {
+		let s = it.next().ok_or(ParseError::Invalid)?;
+		let n = u16::from_str_radix(s, 16)?;
+		*value = match s.len() {
+			1 => n * 0x1111,          // A    -> AAAA
+			2 => n * 0x0101,          // AB   -> ABAB
+			3 => (n << 4) | (n >> 8), // ABC  -> ABCA
+			4 => n,                   // ABCD -> ABCD
+			_ => bail!(),
+		};
+	}
+
+	if it.next().is_some() { bail!() } else { Ok(rgb) }
+}

--- a/yazi-term/src/parser/state.rs
+++ b/yazi-term/src/parser/state.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU8;
+use std::{num::NonZeroU8, time::Duration};
 
 #[derive(Debug, Default, PartialEq)]
 pub(crate) enum State {
@@ -25,12 +25,42 @@ pub(crate) enum State {
 	Dcs,
 	/// Inside DCS, just saw `\x1B` (potential start of ST).
 	DcsSt,
+	/// Inside an APC sequence (`\x1B_` … ST).
+	Apc,
+	/// Inside APC, just saw `\x1B` (potential start of ST).
+	ApcSt,
 	/// Mid-UTF-8 character in ground: `n` continuation bytes still needed.
 	Utf8(NonZeroU8),
 	/// `\x1B` + mid-UTF-8 character: `n` continuation bytes still needed.
 	AltUtf8(NonZeroU8),
 }
 
+impl State {
+	pub(super) const fn limit(&self) -> usize {
+		match self {
+			Self::Csi => 4096,
+			Self::BracketedPaste => 16 << 20,
+			Self::Osc
+			| Self::Osc72(_)
+			| Self::OscSt
+			| Self::Dcs
+			| Self::DcsSt
+			| Self::Apc
+			| Self::ApcSt => 1 << 20,
+			_ => usize::MAX,
+		}
+	}
+
+	pub(super) const fn timeout(&self) -> Option<Duration> {
+		match self {
+			Self::Ground => None,
+			Self::Esc => Some(Duration::from_millis(10)),
+			_ => Some(Duration::from_secs(1)),
+		}
+	}
+}
+
+// --- StateOsc72
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct StateOsc72 {
 	pub(crate) r#type:   Option<u8>,

--- a/yazi-term/src/parser/state.rs
+++ b/yazi-term/src/parser/state.rs
@@ -53,7 +53,7 @@ impl State {
 
 	pub(super) const fn timeout(&self) -> Option<Duration> {
 		match self {
-			Self::Ground => None,
+			Self::Ground | Self::BracketedPaste => None,
 			Self::Esc => Some(Duration::from_millis(10)),
 			_ => Some(Duration::from_secs(1)),
 		}

--- a/yazi-term/src/parser/windows.rs
+++ b/yazi-term/src/parser/windows.rs
@@ -11,7 +11,7 @@ impl Parser {
 					let ch = unsafe { event.uChar.AsciiChar } as u8;
 
 					if event.bKeyDown != 0 && ch != 0 {
-						self.parse(&[ch]);
+						self.step(ch);
 					}
 				}
 				Console::WINDOW_BUFFER_SIZE_EVENT => {
@@ -30,7 +30,5 @@ impl Parser {
 				_ => {}
 			}
 		}
-
-		self.flush();
 	}
 }

--- a/yazi-term/src/source/common.rs
+++ b/yazi-term/src/source/common.rs
@@ -3,6 +3,8 @@ use std::{io, time::Duration};
 use crate::{Timeout, event::Event, source::EventSource};
 
 impl<'a> EventSource<'a> {
+	pub fn wake(&self) -> io::Result<()> { self.waker.wake() }
+
 	pub fn try_poll<F>(&self, timeout: Option<Duration>, mut filter: F) -> io::Result<Event>
 	where
 		F: FnMut(&Event) -> bool,
@@ -16,15 +18,25 @@ impl<'a> EventSource<'a> {
 			}
 
 			drop(parser);
+			if timeout.elapsed() {
+				return Err(io::ErrorKind::TimedOut.into());
+			}
+
 			match self.try_fill(timeout) {
 				Ok(()) => {}
 				Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
 				Err(e) => return Err(e),
 			}
-
-			if timeout.elapsed() {
-				return Err(io::Error::from(io::ErrorKind::TimedOut));
-			}
 		}
 	}
+
+	pub(crate) fn drain(&self) -> io::Result<()> {
+		let result = self.waker.drain();
+		self.parser.lock().drain();
+		result
+	}
+}
+
+pub(super) fn min_timeout(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
+	a.into_iter().chain(b).min()
 }

--- a/yazi-term/src/source/unix.rs
+++ b/yazi-term/src/source/unix.rs
@@ -5,14 +5,14 @@ use rustix::{event::Timespec, termios};
 use signal_hook::consts::SIGWINCH;
 use yazi_tty::{TtyReader, TtyWriter};
 
-use crate::{Timeout, event::Event, parser::Parser, waker::Waker};
+use crate::{Timeout, event::Event, parser::Parser, source::min_timeout, waker::Waker};
 
 #[derive(Debug)]
 pub struct EventSource<'a> {
 	pub(super) parser: Mutex<Parser>,
 	reader:            TtyReader<'a>,
 	writer:            TtyWriter<'a>,
-	waker:             Waker,
+	pub(super) waker:  Waker,
 
 	sigwinch_id:   signal_hook::SigId,
 	sigwinch_read: UnixStream,
@@ -39,17 +39,16 @@ impl<'a> EventSource<'a> {
 		})
 	}
 
-	pub fn wake(&self) -> io::Result<()> { self.waker.wake() }
-
 	pub(crate) fn try_fill(&self, timeout: Timeout) -> io::Result<()> {
 		let mut reader = self.reader.lock();
+		let timeout = min_timeout(timeout.leftover(), self.parser.lock().leftover());
 		let [read_ready, sigwinch_ready, wakeup_ready] =
-			poll([reader.as_fd(), self.sigwinch_read.as_fd(), self.waker.as_fd()], timeout.leftover())?;
+			poll([reader.as_fd(), self.sigwinch_read.as_fd(), self.waker.as_fd()], timeout)?;
 
 		// Stop waiting for events.
 		if wakeup_ready {
-			while read_complete(&*self.waker, &mut [0u8; 1024])? != 0 {}
-			return Err(io::Error::from(io::ErrorKind::ConnectionAborted));
+			self.waker.drain()?;
+			return Err(io::ErrorKind::ConnectionAborted.into());
 		}
 
 		// More input is ready.
@@ -58,15 +57,11 @@ impl<'a> EventSource<'a> {
 
 			let len = read_complete(&mut *reader, &mut buf)?;
 			if len == 0 {
-				return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+				return Err(io::ErrorKind::UnexpectedEof.into());
 			}
 
 			let mut parser = self.parser.lock();
 			parser.parse(&buf[..len]);
-
-			if len < buf.len() {
-				parser.flush();
-			}
 			return Ok(());
 		}
 
@@ -76,6 +71,7 @@ impl<'a> EventSource<'a> {
 			self.parser.lock().emit(Event::Resize(termios::tcgetwinsize(self.writer)?.into()));
 		}
 
+		self.parser.lock().expire();
 		Ok(())
 	}
 }

--- a/yazi-term/src/source/windows.rs
+++ b/yazi-term/src/source/windows.rs
@@ -4,12 +4,12 @@ use parking_lot::Mutex;
 use windows_sys::Win32::{Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT}, System::{Console::{INPUT_RECORD, ReadConsoleInputA}, Threading::{INFINITE, WaitForMultipleObjects}}};
 use yazi_tty::TtyReader;
 
-use crate::{Timeout, parser::Parser, waker::Waker};
+use crate::{Timeout, parser::Parser, source::min_timeout, waker::Waker};
 
 pub struct EventSource<'a> {
 	pub(super) parser: Mutex<Parser>,
 	reader:            TtyReader<'a>,
-	waker:             Waker,
+	pub(super) waker:  Waker,
 }
 
 impl<'a> EventSource<'a> {
@@ -17,25 +17,29 @@ impl<'a> EventSource<'a> {
 		Ok(Self { reader, parser: Mutex::new(Parser::default()), waker: Waker::new()? })
 	}
 
-	pub fn wake(&self) -> io::Result<()> { self.waker.wake() }
-
 	pub(crate) fn try_fill(&self, timeout: Timeout) -> io::Result<()> {
 		let reader = self.reader.lock();
-		let millis = timeout.leftover().map(|dur| dur.as_millis() as u32).unwrap_or(INFINITE);
+		let duration = min_timeout(timeout.leftover(), self.parser.lock().leftover());
+		let millis = duration
+			.map(|dur| dur.as_nanos().div_ceil(1_000_000).min(u32::MAX as u128) as u32)
+			.unwrap_or(INFINITE);
 
-		let mut handles = [reader.as_raw_handle(), self.waker.as_raw_handle()];
-		match unsafe { WaitForMultipleObjects(handles.len() as u32, handles.as_mut_ptr(), 0, millis) } {
+		let handles = [reader.as_raw_handle(), self.waker.as_raw_handle()];
+		match unsafe { WaitForMultipleObjects(handles.len() as u32, handles.as_ptr(), 0, millis) } {
 			// More input is ready.
-			WAIT_OBJECT_0 => Ok(()),
+			WAIT_OBJECT_0 => {}
 			// Stop waiting for events.
-			r if r == WAIT_OBJECT_0 + 1 => Err(io::Error::from(io::ErrorKind::ConnectionAborted)),
-			// Timeout expired.
-			WAIT_TIMEOUT => Err(io::Error::from(io::ErrorKind::TimedOut)),
+			r if r == WAIT_OBJECT_0 + 1 => return Err(io::ErrorKind::ConnectionAborted.into()),
+			// Parser or caller timeout expired.
+			WAIT_TIMEOUT => {
+				self.parser.lock().expire();
+				return Ok(());
+			}
 			// An error occurred.
-			WAIT_FAILED => Err(io::Error::last_os_error()),
+			WAIT_FAILED => return Err(io::Error::last_os_error()),
 			// Unexpected return value.
-			_ => Err(io::Error::other("WaitForMultipleObjects returned unexpected value")),
-		}?;
+			_ => return Err(io::Error::other("WaitForMultipleObjects returned unexpected value")),
+		}
 
 		let (buf, len) = read_console(reader.as_raw_handle())?;
 		self.parser.lock().parse_input_records(&buf[..len]);

--- a/yazi-term/src/stream/stream.rs
+++ b/yazi-term/src/stream/stream.rs
@@ -6,7 +6,19 @@ use tokio::sync::mpsc;
 use crate::{event::Event, source::EventSource, terminal::Terminal};
 
 pub struct EventStream {
-	rx: Option<mpsc::UnboundedReceiver<io::Result<Event>>>,
+	rx:     Option<mpsc::UnboundedReceiver<io::Result<Event>>>,
+	source: Arc<EventSource<'static>>,
+	worker: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for EventStream {
+	fn drop(&mut self) {
+		self.source.wake().ok();
+		if let Some(worker) = self.worker.take() {
+			worker.join().ok();
+		}
+		self.source.drain().ok();
+	}
 }
 
 impl From<&'static Terminal<'_>> for EventStream {
@@ -18,11 +30,12 @@ impl EventStream {
 	where
 		F: Fn(&Event) -> bool + Send + 'static,
 	{
+		let source_ = source.clone();
 		let (tx, rx) = mpsc::unbounded_channel();
 
-		thread::spawn(move || {
+		let worker = thread::spawn(move || {
 			loop {
-				match source.try_poll(None, |_| true) {
+				match source_.try_poll(None, |_| true) {
 					Ok(event) => {
 						if !(filter)(&event) {
 							continue;
@@ -43,7 +56,7 @@ impl EventStream {
 			}
 		});
 
-		Self { rx: Some(rx) }
+		Self { rx: Some(rx), source, worker: Some(worker) }
 	}
 
 	pub fn take(&mut self) -> Option<mpsc::UnboundedReceiver<io::Result<Event>>> { self.rx.take() }

--- a/yazi-term/src/waker/unix.rs
+++ b/yazi-term/src/waker/unix.rs
@@ -1,4 +1,4 @@
-use std::{io::{self, Write}, ops::Deref, os::unix::net::UnixStream};
+use std::{io::{self, Read, Write}, ops::Deref, os::unix::net::UnixStream};
 
 #[derive(Debug)]
 pub(crate) struct Waker {
@@ -22,4 +22,16 @@ impl Waker {
 	}
 
 	pub fn wake(&self) -> io::Result<()> { Write::write_all(&mut &self.writer, &[0]) }
+
+	pub(crate) fn drain(&self) -> io::Result<()> {
+		loop {
+			match Read::read(&mut &self.reader, &mut [0; 1024]) {
+				Ok(0) => return Ok(()),
+				Ok(_) => {}
+				Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+				Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+				Err(e) => return Err(e),
+			}
+		}
+	}
 }

--- a/yazi-term/src/waker/windows.rs
+++ b/yazi-term/src/waker/windows.rs
@@ -30,4 +30,12 @@ impl Waker {
 			Ok(())
 		}
 	}
+
+	pub(crate) fn drain(&self) -> io::Result<()> {
+		if unsafe { Threading::ResetEvent(self.handle.as_raw_handle()) } == 0 {
+			Err(io::Error::last_os_error())
+		} else {
+			Ok(())
+		}
+	}
 }

--- a/yazi-tty/src/sequence/cursor.rs
+++ b/yazi-tty/src/sequence/cursor.rs
@@ -63,15 +63,15 @@ impl Display for SetCursorStyle {
 
 /// Restore cursor shape and blink state
 pub struct RestoreCursorStyle {
-	pub shape: u8,
 	pub blink: bool,
+	pub shape: Option<u8>,
 }
 
 impl Display for RestoreCursorStyle {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let (shape, shape_blink) = match self.shape {
-			u8::MAX => (0, None),
-			n => (n.max(1).div_ceil(2), Some(n.max(1) & 1 == 1)),
+			None => (0, None),
+			Some(n) => (n.max(1).div_ceil(2), Some(n.max(1) & 1 == 1)),
 		};
 
 		let blink = shape_blink.unwrap_or(self.blink);

--- a/yazi-tty/src/sequence/mod.rs
+++ b/yazi-tty/src/sequence/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(clipboard csi_u cursor dnd erase mode query r#if style sync traits);
+yazi_macro::mod_flat!(clipboard csi_u cursor dnd erase mode passthrough query r#if style sync traits);

--- a/yazi-tty/src/sequence/passthrough.rs
+++ b/yazi-tty/src/sequence/passthrough.rs
@@ -1,0 +1,17 @@
+use std::fmt::{self, Display};
+
+pub struct TmuxPassthrough<T>(pub T, pub bool);
+
+impl<T: Display> Display for TmuxPassthrough<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		if !self.1 {
+			return self.0.fmt(f);
+		}
+
+		write!(
+			f,
+			"\x1bPtmux;\x1b\x1b{}\x1b\\",
+			self.0.to_string().trim_start_matches('\x1b').replace('\x1b', "\x1b\x1b")
+		)
+	}
+}

--- a/yazi-tty/src/sequence/query.rs
+++ b/yazi-tty/src/sequence/query.rs
@@ -50,10 +50,3 @@ pub struct RequestCursorBlink;
 impl Display for RequestCursorBlink {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("\x1b[?12$p") }
 }
-
-/// Device Status Report (DSR)
-pub struct RequestDeviceStatus;
-
-impl Display for RequestDeviceStatus {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("\x1b[5n") }
-}

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -2,13 +2,14 @@ use std::{io, ops::Deref};
 
 use anyhow::Result;
 use ratatui_core::{buffer::Buffer, layout::Rect, terminal::{CompletedFrame, Frame, Terminal}};
+use tokio::task::JoinHandle;
 use yazi_config::YAZI;
-use yazi_emulator::{Emulator, Mux, TMUX};
+use yazi_emulator::{EMULATOR, Probe};
 use yazi_macro::writef;
 use yazi_proxy::AppProxy;
 use yazi_shim::cell::SyncCell;
 use yazi_term::{TERM, event::{Event, KeyEventKind}, stream::EventStream};
-use yazi_tty::{TTY, TtyWriter, sequence::{DisableBracketedPaste, DisableDrag, DisableDrop, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste, EnableDrag, EnableDrop, EnableFocusChange, EnableMouseCapture, EnterAlternateScreen, If, LeaveAlternateScreen, PopKeyboardFlags, PushKeyboardFlags, RequestCursorBlink, RequestCursorStyle, RequestDA1, RestoreCursorStyle, SetTitle, ShowCursor}};
+use yazi_tty::{TTY, TtyWriter, sequence::{DisableBracketedPaste, DisableDrag, DisableDrop, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste, EnableDrag, EnableDrop, EnableFocusChange, EnableMouseCapture, EnterAlternateScreen, If, LeaveAlternateScreen, PopKeyboardFlags, PushKeyboardFlags, RestoreCursorStyle, SetTitle, ShowCursor}};
 
 use crate::{RatermBackend, RatermOption, RatermState};
 
@@ -16,7 +17,9 @@ pub static STATE: SyncCell<RatermState> = SyncCell::new(RatermState::default());
 
 pub struct Raterm {
 	inner:       Terminal<RatermBackend<TtyWriter<'static>>>,
-	stream:      EventStream,
+	_stream:     EventStream,
+	pub probe:   Probe,
+	forwarder:   JoinHandle<()>,
 	last_area:   Rect,
 	last_buffer: Buffer,
 }
@@ -28,24 +31,24 @@ impl Deref for Raterm {
 }
 
 impl Drop for Raterm {
-	fn drop(&mut self) { Self::stop(); }
+	fn drop(&mut self) {
+		self.forwarder.abort();
+		Self::stop();
+	}
 }
 
 impl Raterm {
 	pub fn start() -> Result<Self> {
 		TERM.setup()?;
 		TERM.enter_raw_mode()?;
-		static FIRST: SyncCell<bool> = SyncCell::new(false);
-		if FIRST.replace(true) && yazi_emulator::TMUX.get() {
-			yazi_emulator::Mux::tmux_passthrough();
-		}
 
 		let opt = RatermOption::default();
+		STATE.set(RatermState::new(&opt));
+
+		let mut stream = EventStream::from(&*TERM);
 		writef!(
 			TTY.writer(),
-			"{}{RequestCursorStyle}{RequestCursorBlink}{RequestDA1}{}{EnableBracketedPaste}{EnableFocusChange}{}{}{}{}",
-			If(!TMUX.get(), EnterAlternateScreen),
-			If(TMUX.get(), EnterAlternateScreen),
+			"{EnterAlternateScreen}{EnableBracketedPaste}{EnableFocusChange}{}{}{}{}",
 			PushKeyboardFlags::DISAMBIGUATE_ESCAPE_CODES
 				| PushKeyboardFlags::REPORT_ALTERNATE_KEYS
 				| PushKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
@@ -55,32 +58,30 @@ impl Raterm {
 			If(opt.mouse, EnableMouseCapture),
 		)?;
 
-		let resp = Emulator::read_until_da1();
-		Mux::tmux_drain()?;
+		let mut inner = Terminal::new(RatermBackend::new(TTY.writer()))?;
+		inner.hide_cursor()?;
+		inner.clear()?;
+		inner.flush()?;
 
-		STATE.set(RatermState::new(&resp, &opt));
-		let mut term = Self {
-			inner:       Terminal::new(RatermBackend::new(TTY.writer()))?,
-			stream:      EventStream::from(&*TERM),
-			last_area:   Default::default(),
+		Ok(Self {
+			inner,
+			forwarder: Self::spawn(&mut stream),
+			_stream: stream,
+			probe: Probe::start()?,
+			last_area: Default::default(),
 			last_buffer: Default::default(),
-		};
-
-		term.inner.hide_cursor()?;
-		term.inner.clear()?;
-		term.inner.flush()?;
-		term.spawn();
-		Ok(term)
+		})
 	}
 
 	pub fn stop() {
+		let emu = EMULATOR.load();
 		let state = STATE.get();
 
 		_ = writef!(
 			TTY.writer(),
 			"{}{PopKeyboardFlags}{DisableDrop}{DisableDrag}{}{}{DisableFocusChange}{DisableBracketedPaste}{LeaveAlternateScreen}{ShowCursor}",
 			If(state.mouse, DisableMouseCapture),
-			RestoreCursorStyle { shape: state.cursor_shape, blink: state.cursor_blink },
+			RestoreCursorStyle { blink: emu.cursor_blink, shape: emu.cursor_shape },
 			If(state.title, SetTitle("")),
 		);
 
@@ -88,9 +89,8 @@ impl Raterm {
 		TERM.restorer.restore(&TTY);
 	}
 
-	fn spawn(&mut self) {
-		let mut rx = self.stream.take().unwrap();
-
+	fn spawn(stream: &mut EventStream) -> JoinHandle<()> {
+		let mut rx = stream.take().unwrap();
 		tokio::spawn(async move {
 			loop {
 				match rx.recv().await {
@@ -108,7 +108,7 @@ impl Raterm {
 					None => break,
 				}
 			}
-		});
+		})
 	}
 
 	pub fn draw(&mut self, f: impl FnOnce(&mut Frame)) -> io::Result<CompletedFrame<'_>> {

--- a/yazi-tui/src/state.rs
+++ b/yazi-tui/src/state.rs
@@ -2,26 +2,12 @@ use crate::RatermOption;
 
 #[derive(Clone, Copy)]
 pub struct RatermState {
-	pub mouse:        bool,
-	pub title:        bool,
-	pub cursor_shape: u8,
-	pub cursor_blink: bool,
+	pub mouse: bool,
+	pub title: bool,
 }
 
 impl RatermState {
-	pub(super) const fn default() -> Self {
-		Self { mouse: false, title: false, cursor_shape: 0, cursor_blink: false }
-	}
+	pub(super) const fn default() -> Self { Self { mouse: false, title: false } }
 
-	pub(super) fn new(resp: &str, opt: &RatermOption) -> Self {
-		let cursor_shape = resp
-			.split_once("\x1bP1$r")
-			.and_then(|(_, s)| s.bytes().next())
-			.filter(|&b| matches!(b, b'0'..=b'6'))
-			.map_or(u8::MAX, |b| b - b'0');
-
-		let cursor_blink = resp.contains("\x1b[?12;1$y");
-
-		Self { mouse: opt.mouse, title: false, cursor_shape, cursor_blink }
-	}
+	pub(super) fn new(opt: &RatermOption) -> Self { Self { mouse: opt.mouse, ..Self::default() } }
 }

--- a/yazi-vfs/src/engine/engine.rs
+++ b/yazi-vfs/src/engine/engine.rs
@@ -129,7 +129,7 @@ where
 	if original.auth().same_service(link.auth()) {
 		Engines::new(original).await?.hard_link(link.loc()).await
 	} else {
-		Err(io::Error::from(io::ErrorKind::CrossesDevices))
+		Err(io::ErrorKind::CrossesDevices.into())
 	}
 }
 
@@ -222,7 +222,7 @@ where
 	if from.auth().same_service(to.auth()) {
 		Engines::new(from).await?.rename(to.loc()).await
 	} else {
-		Err(io::Error::from(io::ErrorKind::CrossesDevices))
+		Err(io::ErrorKind::CrossesDevices.into())
 	}
 }
 

--- a/yazi-vfs/src/engine/sftp/demand.rs
+++ b/yazi-vfs/src/engine/sftp/demand.rs
@@ -73,7 +73,7 @@ impl FileBuilder for Demand {
 			&& status.is_failure()
 			&& conn.lstat(engine.path).await.is_ok()
 		{
-			return Err(io::Error::from(io::ErrorKind::AlreadyExists));
+			return Err(io::ErrorKind::AlreadyExists.into());
 		}
 
 		Ok(result?)

--- a/yazi-vfs/src/engine/sftp/sftp.rs
+++ b/yazi-vfs/src/engine/sftp/sftp.rs
@@ -71,14 +71,11 @@ impl<'a> Engine for Sftp<'a> {
 			} else if similar.is_none() {
 				similar = Some(s.into_owned());
 			} else {
-				return Err(io::Error::from(io::ErrorKind::NotFound));
+				return Err(io::ErrorKind::NotFound.into());
 			}
 		}
 
-		similar
-			.map(|n| parent.try_join(n))
-			.transpose()?
-			.ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))
+		similar.map(|n| parent.try_join(n)).transpose()?.ok_or(io::ErrorKind::NotFound.into())
 	}
 
 	async fn copy<P>(&self, to: P, attrs: yazi_fs::engine::Attrs) -> io::Result<u64>
@@ -130,7 +127,7 @@ impl<'a> Engine for Sftp<'a> {
 			&& status.is_failure()
 			&& op.lstat(self.path).await.is_ok()
 		{
-			return Err(io::Error::from(io::ErrorKind::AlreadyExists));
+			return Err(io::ErrorKind::AlreadyExists.into());
 		}
 
 		Ok(result?)


### PR DESCRIPTION
Previously, Yazi blocked on requesting and waiting for terminal responses on startup to probe terminal capabilities.

With this PR, this process becomes async, so it no longer blocks and instead runs concurrently with the process initialization.