### PR TITLE
fix: work around image previews broken by a `tmux` 3.7b redraw bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@
 
 - Search and reuse first. For new features, extend existing infrastructure or data structures with general, reusable capabilities when that keeps the final code concise.
 - For refactors, inspect the whole target module and its callers first. Look for duplicated work, redundant I/O, underpowered return values, one-use wrappers, and reusable cross-platform abstractions; implement high-confidence, behavior-preserving simplifications while preserving error, fallback, and platform semantics.
-- Keep diffs minimal and avoid unrelated refactors. Prefer clear code over custom patterns or comments; comment only behavior the code cannot explain.
-- Keep responsibility boundaries clear and cohesive. Put reusable code in the lowest suitable shared layer; avoid unnecessary dependencies and allocations. Prefer borrowed values and existing wrappers.
+- Keep diffs minimal and avoid unrelated refactors. Prefer clear, flat control flow and positive predicates; use standard combinators, early returns, ordered branches, and match guards to express cases directly and avoid nested conditionals or compound negation. Comment only behavior the code cannot explain.
+- Keep responsibility boundaries clear and cohesive. Prefer pure functions and explicit invariants; favor convention over configuration when invariants can eliminate state or coordination. Put reusable code in the lowest suitable shared layer; avoid unnecessary dependencies and allocations. Prefer borrowed values and existing wrappers.
 - Use stable Rust APIs; nightly is formatting-only. Use only `pub`, `pub(super)`, and `pub(crate)`—never `pub(in ...)`.
 - Keep async I/O non-blocking, preserve platform/fork behavior, and follow existing error boundaries with `?`.
 - For renames or refactors, update all related variables, functions, parameters, modules, methods, types, derived types, exports, tests, configuration keys, documentation, Lua bindings, and, when a type and file share a name, the file as well.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 ### Fixed
 
 - Refresh file list after deleting a file from search view ([#4174])
+- Work around image previews broken by a `tmux` 3.7b redraw bug ([#4195])
 - Normalize `\\?\`-prefixed Verbatim paths when creating relative symlinks on Windows ([#4067])
 - Keep package hashes indifferent to line endings when `ya pkg` pulls packages ([#4064])
 - Use WebP as `magick` preset preloader cache format to keep image transparency ([#4065])
@@ -1794,3 +1795,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4177]: https://github.com/sxyazi/yazi/pull/4177
 [#4184]: https://github.com/sxyazi/yazi/pull/4184
 [#4194]: https://github.com/sxyazi/yazi/pull/4194
+[#4195]: https://github.com/sxyazi/yazi/pull/4195

--- a/yazi-actor/src/app/report.rs
+++ b/yazi-actor/src/app/report.rs
@@ -32,7 +32,7 @@ impl Actor for Report {
 
 		let id = term.probe.id;
 		tokio::spawn(async move {
-			Mux::tmux_passthrough().await;
+			Mux::tmux_setup().await;
 			AppProxy::passthrough(id);
 		});
 

--- a/yazi-adapter/src/drivers/drivers.rs
+++ b/yazi-adapter/src/drivers/drivers.rs
@@ -62,11 +62,13 @@ impl From<yazi_emulator::Brand> for Drivers {
 }
 
 impl Drivers {
-	pub fn matches(emulator: &Emulator) -> D {
-		let mut drivers: Self = emulator.into();
+	pub fn matches(emu: &Emulator) -> D {
+		let mut drivers: Self = emu.into();
 		if env_exists("ZELLIJ_SESSION_NAME") {
 			drivers.retain(|p| *p == D::Sixel);
-		} else if emulator.tmux {
+		} else if emu.sixel && emu.mux.is_some_and(|mux| mux.sixel) {
+			return D::Sixel;
+		} else if emu.mux.is_some() {
 			drivers.retain(|p| *p != D::KgpOld);
 		}
 		if let Some(d) = drivers.first() {

--- a/yazi-cli/src/env/env.rs
+++ b/yazi-cli/src/env/env.rs
@@ -37,7 +37,7 @@ impl Env {
 		writeln!(s, "    TERM_PROGRAM        : {:?}", env::var_os("TERM_PROGRAM"))?;
 		writeln!(s, "    TERM_PROGRAM_VERSION: {:?}", env::var_os("TERM_PROGRAM_VERSION"))?;
 		writeln!(s, "    Brand.from_env      : {:?}", Brand::from_env())?;
-		writeln!(s, "    Emulator.detect     : {emulator:?}")?;
+		writeln!(s, "    Emulator.probe      : {emulator:?}")?;
 
 		writeln!(s, "\nAdapter")?;
 		writeln!(s, "    Drivers.matches: {:?}", Drivers::matches(&emulator))?;

--- a/yazi-emulator/src/emulator.rs
+++ b/yazi-emulator/src/emulator.rs
@@ -8,7 +8,7 @@ use yazi_shim::cell::RoCell;
 use yazi_term::{TERM, event::Report};
 use yazi_tty::{Handle, TTY, sequence::{HideCursor, MoveTo, RestoreCursorPos, SaveCursorPos, ShowCursor}};
 
-use crate::Brand;
+use crate::{Brand, Mux};
 
 pub static EMULATOR: RoCell<ArcSwap<Emulator>> = RoCell::new();
 
@@ -23,7 +23,7 @@ pub struct Emulator {
 	pub force_16t:    bool,
 	pub cursor_blink: bool,
 	pub cursor_shape: Option<u8>,
-	pub tmux:         bool,
+	pub mux:          Option<Mux>,
 }
 
 impl Emulator {
@@ -65,7 +65,7 @@ impl Emulator {
 		use std::{thread, time::Duration};
 
 		let mut w = TTY.lockout();
-		let tmux = EMULATOR.load().tmux;
+		let tmux = EMULATOR.load().mux.is_some();
 
 		// I really don't want to add this,
 		// But tmux and ConPTY sometimes cause the cursor position to get out of sync.

--- a/yazi-emulator/src/mux.rs
+++ b/yazi-emulator/src/mux.rs
@@ -9,12 +9,25 @@ pub const ESCAPE: MuxSequence = MuxSequence("\x1b", "\x1b\x1b");
 pub const START: MuxSequence = MuxSequence("\x1b", "\x1bPtmux;\x1b\x1b");
 pub const CLOSE: MuxSequence = MuxSequence("", "\x1b\\");
 
-pub struct Mux;
+#[derive(Clone, Copy, Debug)]
+pub struct Mux {
+	pub sixel: bool,
+}
 
 impl Mux {
-	pub async fn tmux_passthrough() {
+	pub async fn tmux_setup() {
 		let output = Command::new("tmux")
-			.args(["set", "-p", "allow-passthrough", "on"])
+			.args([
+				"set",
+				"-p",
+				"allow-passthrough",
+				"on",
+				";",
+				"set",
+				"-s",
+				"input-buffer-size",
+				"104857600",
+			])
 			.kill_on_drop(true)
 			.stdin(Stdio::null())
 			.stdout(Stdio::null())
@@ -25,13 +38,17 @@ impl Mux {
 			Ok(Ok(o)) if o.status.success() => {}
 			Ok(Ok(o)) => {
 				error!(
-					"Running `tmux set -p allow-passthrough on` failed: {:?}, {}",
+					"Failed to configure tmux passthrough and input buffer: status {:?}, stderr: {}",
 					o.status,
 					String::from_utf8_lossy(&o.stderr)
 				);
 			}
-			Ok(Err(e)) => error!("Failed to spawn `tmux set -p allow-passthrough on`: {e}"),
-			Err(_) => error!("Running `tmux set -p allow-passthrough on` timed out"),
+			Ok(Err(e)) => {
+				error!("Failed to start tmux while configuring passthrough and input buffer: {e}")
+			}
+			Err(_) => {
+				error!("Timed out after 5 seconds while configuring tmux passthrough and input buffer")
+			}
 		}
 	}
 
@@ -56,6 +73,7 @@ pub struct MuxSequence(&'static str, &'static str);
 
 impl Display for MuxSequence {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.write_str(if EMULATOR.load().tmux { self.1 } else { self.0 })
+		let emu = EMULATOR.load();
+		f.write_str(if emu.mux.is_none_or(|mux| mux.sixel && emu.sixel) { self.0 } else { self.1 })
 	}
 }

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -26,16 +26,17 @@ impl Probe {
 
 	pub fn restart(&mut self) -> Result<()> {
 		self.id = IDS.next();
-		self.emulator = Emulator { tmux: true, ..Default::default() };
+		self.emulator =
+			Emulator { mux: Some(Mux { sixel: self.emulator.sixel }), ..Default::default() };
 		self.request()
 	}
 
 	pub fn needs_passthrough(&self) -> bool {
-		self.emulator.brand == Brand::Tmux && !self.emulator.tmux
+		self.emulator.brand == Brand::Tmux && self.emulator.mux.is_none()
 	}
 
 	fn request(&self) -> Result<()> {
-		let w = |t: &'static dyn Display| TmuxPassthrough(t, self.emulator.tmux);
+		let w = |t: &'static dyn Display| TmuxPassthrough(t, self.emulator.mux.is_some());
 
 		writef!(
 			TTY.writer(),
@@ -79,7 +80,7 @@ impl Emulator {
 					return Ok(probe.emulator);
 				}
 
-				Mux::tmux_passthrough().await;
+				Mux::tmux_setup().await;
 				if let Err(e) = probe.restart() {
 					error!("Failed to request terminal capabilities through tmux: {e}");
 					return Ok(probe.emulator);


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/4111

Previously, Yazi passed encoded Sixel data through `tmux` to the real terminal because:

1. Sixel support in `tmux` is optional, and passthrough works with both Sixel-enabled and Sixel-disabled builds.
2. `tmux` limits parsed escape sequences with `input-buffer-size` (1 MiB by default), while passthrough avoids this limit. Without passthrough:
    - Only ~600-800 KiB of raw image data fits after Sixel overhead. Yazi now raises `input-buffer-size` on startup to work around this, but that's a bit hacky since it changes the user server config.
    - `tmux` must parse and decode the Sixel data before the real terminal does, which doubles the computing and may hurt performance.

Unfortunately, a [`tmux` 3.7b redraw bug](https://github.com/tmux/tmux/pull/5366) broke passthrough, and we have no better option than disabling it when `tmux` supports Sixel, while keeping the old passthrough behavior for builds without Sixel support, images may therefore still fail on those builds.

Terminals that only support the [inline image protocol](https://iterm2.com/3.4/documentation-images.html) may also be broken since `tmux` only supports Sixel but not IIP, so IIP still has to use passthrough.

This is only a best-effort temporary workaround, not a permanent fix. The bug is already [fixed on `tmux` master](https://github.com/tmux/tmux/commit/565db46a1947b829af00bb2ff4acbc0b8c189fcd) for v3.8, so we may revert this workaround once `tmux` v3.8 is released.