### PR TITLE
feat: automatic dark/light theme switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - Keep async I/O non-blocking, preserve platform/fork behavior, and follow existing error boundaries with `?`.
 - For renames or refactors, update all related variables, functions, parameters, modules, methods, types, derived types, exports, tests, configuration keys, documentation, Lua bindings, and, when a type and file share a name, the file as well.
 - When adding a changelog entry, leave the PR number blank for a human to fill in.
-- Do not add or modify tests unless requested.
+- Do not add tests or change test behavior unless requested.
 
 ## Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Bulk create ([#3793])
 - Make help menu a command palette ([#4074])
 - Input history ([#4104])
+- Automatic switching between dark and light theme ([#4196])
 - Experimental `%y`, `%Y`, `%t`, `%T`, `%yN`, `%YN`, `%tN`, `%TN` shell formatting parameters ([#4108])
 - Custom VFS provider ([#4118])
 - Make visual mode support wraparound scrolling ([#4101])
@@ -36,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 - Rename SFTP sections in `vfs.toml` from `[services.domain]` to `[sftp.domain]` ([#4120]).
 - Rename `<BackTab>` to `<S-Tab>` ([#3989])
+- Make `rt.term.light` a function that returns the latest color scheme on each call ([#4196])
 - Remove `Url.is_archive` - `archive://` is no longer built in and can now be registered by plugins ([#4118])
 - Make `mgr::Yanked`, `tab::Selected`, and the `@yank` DDS event return `File` instead of `Url` from `__pairs()` ([#4096])
 - Remove `help:filter` action since the filter input is now always available ([#4074])
@@ -1796,3 +1798,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4184]: https://github.com/sxyazi/yazi/pull/4184
 [#4194]: https://github.com/sxyazi/yazi/pull/4194
 [#4195]: https://github.com/sxyazi/yazi/pull/4195
+[#4196]: https://github.com/sxyazi/yazi/pull/4196

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1083,7 +1083,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1233,7 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1667,7 +1667,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -2262,7 +2262,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3214,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
 dependencies = [
  "aes",
  "bitflags",
@@ -3338,7 +3338,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3687,7 +3687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3871,10 +3871,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4196,7 +4196,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 dependencies = [
- "rand 0.10.2",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -4225,7 +4225,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4477,7 +4477,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ arc-swap              = { version = "1.9.2", features = [ "serde" ] }
 base64                = "0.23.0"
 bitflags              = { version = "2.13.1", features = [ "serde" ] }
 chrono                = "0.4.45"
-clap                  = { version = "4.6.4", features = [ "derive" ] }
+clap                  = { version = "4.6.5", features = [ "derive" ] }
 compact_str           = { version = "0.10.0", features = [ "serde" ] }
 core-foundation-sys   = "0.8.7"
 data-encoding         = "2.11.0"
@@ -68,7 +68,7 @@ ratatui-core          = { version = "0.1.2", default-features = false, features 
 ratatui-widgets       = { version = "0.3.2", default-features = false, features = [ "std", "unstable-rendered-line-info" ] }
 regex                 = "1.13.1"
 regex-syntax          = "0.8.11"
-russh                 = { version = "0.62.4", default-features = false, features = [ "ring", "rsa" ] }
+russh                 = { version = "0.62.5", default-features = false, features = [ "ring", "rsa" ] }
 scopeguard            = "1.2.0"
 serde                 = { version = "1.0.229", features = [ "derive" ] }
 serde_json            = "1.0.151"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Yazi (means "duck") is a terminal file manager written in Rust, based on non-blo
 - 💫 Vim-like input/pick/confirm/which/notify component, auto-completion for cd paths
 - 🏷️ Multi-Tab Support, Cross-directory selection, Scrollable Preview (for videos, PDFs, archives, code, directories, etc.)
 - 🔄 Bulk Rename/Create, Archive Extraction, Visual Mode, File Chooser, [Git Integration](https://github.com/yazi-rs/plugins/tree/main/git.yazi), [Mount Manager](https://github.com/yazi-rs/plugins/tree/main/mount.yazi)
-- 🎨 Theme System, Mouse Support, Drag and Drop, Trash Bin, Custom Layouts, CSI u, OSC 52
+- 🎨 Theme System, Mouse Support, Drag and Drop, Trash Bin, Custom Layouts, CSI u, OSC 52, CSI 2031
 - ... and more!
 
 https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265cc7

--- a/yazi-actor/src/app/report.rs
+++ b/yazi-actor/src/app/report.rs
@@ -19,11 +19,17 @@ impl Actor for Report {
 
 	fn act(cx: &mut Ctx, report: Self::Form) -> Result<Data> {
 		let Some(term) = cx.term.as_mut() else { succ!() };
+		let old_light = term.probe.emulator.light();
 
 		term.probe.emulator.apply(&report);
 		EMULATOR.store(Arc::new(term.probe.emulator.clone()));
 
-		if !matches!(report, TermReport::Da1(_)) {
+		if report.is_color_scheme()
+			&& old_light.zip(term.probe.emulator.light()).is_some_and(|(a, b)| a != b)
+			&& !term.probe.needs_passthrough()
+		{
+			return act!(app:theme, cx);
+		} else if !report.is_da_1() {
 			succ!();
 		} else if !term.probe.needs_passthrough() {
 			ADAPTOR.resolve(&term.probe.emulator);

--- a/yazi-actor/src/app/theme.rs
+++ b/yazi-actor/src/app/theme.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use yazi_actor::Ctx;
 use yazi_config::{THEME, build_flavor};
 use yazi_emulator::EMULATOR;
-use yazi_macro::{render, succ};
+use yazi_macro::{act, render, succ};
 use yazi_parser::VoidForm;
 use yazi_scheduler::NotifyProxy;
 use yazi_shared::data::Data;
@@ -17,13 +17,19 @@ impl Actor for Theme {
 
 	const NAME: &str = "theme";
 
-	fn act(_cx: &mut Ctx, _: Self::Form) -> Result<Data> {
-		match build_flavor(EMULATOR.load().light) {
+	fn act(cx: &mut Ctx, _: Self::Form) -> Result<Data> {
+		match build_flavor(EMULATOR.load().light().unwrap_or_default()) {
 			Ok(theme) => THEME.overlay(theme),
 			Err(e) => succ!(NotifyProxy::push_error("Theme load failed", format!("{e:#}"))),
 		};
 
 		yazi_plugin::theme::reset()?;
+
+		act!(mgr:peek, cx, true)?;
+		if cx.tab().spot.visible() {
+			act!(mgr:spot, cx, true)?;
+		}
+
 		succ!(render!());
 	}
 }

--- a/yazi-actor/src/mgr/spot.rs
+++ b/yazi-actor/src/mgr/spot.rs
@@ -32,7 +32,7 @@ impl Actor for Spot {
 			cx.tab_mut().spot.skip = 0;
 		}
 
-		cx.tab_mut().spot.go(hovered, mime);
+		cx.tab_mut().spot.go(hovered, mime, form.force);
 		succ!();
 	}
 }

--- a/yazi-adapter/src/drivers/drivers.rs
+++ b/yazi-adapter/src/drivers/drivers.rs
@@ -18,8 +18,8 @@ impl DerefMut for Drivers {
 	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
 }
 
-impl From<&yazi_emulator::Emulator> for Drivers {
-	fn from(value: &yazi_emulator::Emulator) -> Self {
+impl From<&Emulator> for Drivers {
+	fn from(value: &Emulator) -> Self {
 		match value.brand {
 			Brand::Unknown => Self(match (value.kgp, value.sixel) {
 				(true, true) => vec![D::Sixel, D::KgpOld],
@@ -32,9 +32,9 @@ impl From<&yazi_emulator::Emulator> for Drivers {
 	}
 }
 
-impl From<yazi_emulator::Brand> for Drivers {
-	fn from(value: yazi_emulator::Brand) -> Self {
-		use yazi_emulator::Brand as B;
+impl From<Brand> for Drivers {
+	fn from(value: Brand) -> Self {
+		use Brand as B;
 
 		Self(match value {
 			B::Unknown => vec![],

--- a/yazi-cli/src/env/env.rs
+++ b/yazi-cli/src/env/env.rs
@@ -16,7 +16,7 @@ impl Env {
 	pub(crate) async fn print() -> Result<String> {
 		let mut s = String::new();
 		let emulator = Emulator::probe().await?;
-		let theme = build_flavor(emulator.light)?;
+		let theme = build_flavor(emulator.light().unwrap_or_default())?;
 
 		writeln!(s, "Yazi\n{}", Self::yazi_version())?;
 		writeln!(s, "    Backtrace: {:?}", env::var_os("RUST_BACKTRACE"))?;

--- a/yazi-core/src/highlighter.rs
+++ b/yazi-core/src/highlighter.rs
@@ -1,6 +1,7 @@
-use std::{io::{BufRead, BufReader, Cursor, Seek}, path::PathBuf, sync::OnceLock};
+use std::{io::{BufRead, BufReader, Cursor, Seek}, path::PathBuf, sync::{Arc, OnceLock}};
 
 use anyhow::{Result, anyhow, bail};
+use parking_lot::Mutex;
 use ratatui_core::{layout::Size, text::{Line, Span, Text}};
 use syntect::{LoadingError, dumps, easy::HighlightLines, highlighting::{self, Theme, ThemeSet}, parsing::{SyntaxReference, SyntaxSet}};
 use yazi_config::{THEME, YAZI};
@@ -18,9 +19,8 @@ pub struct Highlighter {
 	size:   Size,
 	ticket: Id,
 
-	theme:    &'static Theme,
+	theme:    Arc<Theme>,
 	syntaxes: &'static SyntaxSet,
-	inner:    Option<HighlightLines<'static>>,
 	syntax:   Option<&'static SyntaxReference>,
 }
 
@@ -37,10 +37,11 @@ impl Highlighter {
 	where
 		P: Into<PathBuf>,
 	{
-		static CACHE: OnceLock<(Theme, SyntaxSet)> = OnceLock::new();
+		static SYNTAXES: OnceLock<SyntaxSet> = OnceLock::new();
 
 		let path = path.into();
-		let (theme, syntaxes) = CACHE.get_or_init(Self::load);
+		let syntaxes =
+			SYNTAXES.get_or_init(|| dumps::from_uncompressed_data(yazi_prebuilt::syntaxes()).unwrap());
 
 		Ok(Self {
 			reader: BufReader::new(std::fs::File::open(&path)?),
@@ -50,9 +51,8 @@ impl Highlighter {
 			size,
 			ticket: INCR.current(),
 
-			theme,
+			theme: Self::load_theme(),
 			syntaxes,
-			inner: None,
 			syntax: None,
 		})
 	}
@@ -62,6 +62,7 @@ impl Highlighter {
 	fn highlight(mut self) -> Result<Text<'static>, PeekError> {
 		self.load_syntax()?;
 		let mut plain = self.syntax.is_none();
+		let mut h = self.syntax.map(|syntax| HighlightLines::new(syntax, &self.theme));
 
 		let mut i = 0;
 		let mut buf = vec![];
@@ -80,7 +81,7 @@ impl Highlighter {
 			self.ensure_not_cancelled()?;
 			if plain && !self.process_plain(&buf, &mut i, &mut lines)? {
 				break;
-			} else if !plain && !self.process_hyper(&buf, &mut i, &mut lines)? {
+			} else if !plain && !self.process_hyper(&buf, &mut i, &mut lines, h.as_mut())? {
 				break;
 			}
 			buf.clear();
@@ -93,7 +94,7 @@ impl Highlighter {
 		Ok(Text::from(lines))
 	}
 
-	fn process_plain(&mut self, buf: &[u8], i: &mut usize, lines: &mut Vec<Line>) -> Result<bool> {
+	fn process_plain(&self, buf: &[u8], i: &mut usize, lines: &mut Vec<Line>) -> Result<bool> {
 		let b = replace_to_printable(buf, true, YAZI.preview.tab_size, false);
 		let s = String::from_utf8_lossy(&b);
 
@@ -114,10 +115,14 @@ impl Highlighter {
 		Ok(true)
 	}
 
-	fn process_hyper(&mut self, buf: &[u8], i: &mut usize, lines: &mut Vec<Line>) -> Result<bool> {
-		let Some(syntax) = self.syntax else { bail!("No syntax") };
-		let h = self.inner.get_or_insert_with(|| HighlightLines::new(syntax, self.theme));
-
+	fn process_hyper(
+		&self,
+		buf: &[u8],
+		i: &mut usize,
+		lines: &mut Vec<Line>,
+		h: Option<&mut HighlightLines<'_>>,
+	) -> Result<bool> {
+		let Some(h) = h else { bail!("No syntax") };
 		let s = String::from_utf8_lossy(buf);
 		let line = [Self::to_line_widget(h.highlight_line(&s, self.syntaxes)?)];
 
@@ -143,15 +148,23 @@ impl Highlighter {
 		if self.ticket != INCR.current() { Err(anyhow!("Highlighting cancelled"))? } else { Ok(()) }
 	}
 
-	fn load() -> (Theme, SyntaxSet) {
-		let theme = std::fs::File::open(&**THEME.mgr.syntect_theme.load())
-			.map_err(LoadingError::Io)
-			.and_then(|f| ThemeSet::load_from_reader(&mut std::io::BufReader::new(f)))
-			.or_else(|_| ThemeSet::load_from_reader(&mut Cursor::new(yazi_prebuilt::ansi_theme())));
+	fn load_theme() -> Arc<Theme> {
+		static CACHE: Mutex<Option<(Arc<PathBuf>, Arc<Theme>)>> = Mutex::new(None);
 
-		let syntaxes = dumps::from_uncompressed_data(yazi_prebuilt::syntaxes());
+		let path = &*THEME.mgr.syntect_theme.load();
+		let load = || {
+			let theme = std::fs::File::open(path.as_path())
+				.map_err(LoadingError::Io)
+				.and_then(|f| ThemeSet::load_from_reader(&mut std::io::BufReader::new(f)))
+				.or_else(|_| ThemeSet::load_from_reader(&mut Cursor::new(yazi_prebuilt::ansi_theme())))
+				.unwrap();
+			(path.clone(), Arc::new(theme))
+		};
 
-		(theme.unwrap(), syntaxes.unwrap())
+		match &mut *CACHE.lock() {
+			Some((p, theme)) if p == path => theme.clone(),
+			slot => slot.insert(load()).1.clone(),
+		}
 	}
 
 	fn load_syntax(&mut self) -> Result<()> {

--- a/yazi-core/src/spot/spot.rs
+++ b/yazi-core/src/spot/spot.rs
@@ -16,10 +16,10 @@ pub struct Spot {
 }
 
 impl Spot {
-	pub fn go(&mut self, file: File, mime: Symbol<str>) {
+	pub fn go(&mut self, file: File, mime: Symbol<str>, force: bool) {
 		if mime.is_empty() {
 			return; // Wait till mimetype is resolved to avoid flickering
-		} else if self.same_lock(&file, &mime) {
+		} else if !force && self.same_lock(&file, &mime) {
 			return;
 		}
 

--- a/yazi-emulator/src/emulator.rs
+++ b/yazi-emulator/src/emulator.rs
@@ -2,7 +2,6 @@ use std::io::{BufWriter, Write};
 
 use anyhow::Result;
 use arc_swap::ArcSwap;
-use tracing::debug;
 use yazi_macro::writef;
 use yazi_shim::cell::RoCell;
 use yazi_term::{TERM, event::Report};
@@ -18,7 +17,8 @@ pub struct Emulator {
 	pub version:      String,
 	pub kgp:          bool,
 	pub sixel:        bool,
-	pub light:        bool,
+	pub background:   Option<[u16; 3]>,
+	pub color_scheme: Option<bool>,
 	pub csi_16t:      (u16, u16),
 	pub force_16t:    bool,
 	pub cursor_blink: bool,
@@ -46,15 +46,22 @@ impl Emulator {
 				self.csi_16t = (*width, *height);
 				self.force_16t = Self::force_16t(self.csi_16t);
 			}
-			Report::BackgroundColor([r, g, b]) => {
-				let luma = *r as f32 * 0.2627 / 65535.0
-					+ *g as f32 * 0.6780 / 65535.0
-					+ *b as f32 * 0.0593 / 65535.0;
-				debug!("Detected background color: {r:04x}/{g:04x}/{b:04x} (luma = {luma:.2})");
-				self.light = luma > 0.6;
-			}
+			Report::BackgroundColor(rgb) => self.background = Some(*rgb),
+			Report::ColorScheme(light) => self.color_scheme = Some(*light),
 			Report::KittyGraphics { id: 31, ok } => self.kgp = *ok,
 			_ => {}
+		}
+	}
+
+	pub const fn light(&self) -> Option<bool> {
+		if let Some(light) = self.color_scheme {
+			Some(light)
+		} else if let Some([r, g, b]) = self.background {
+			let luma =
+				r as f32 * 0.2627 / 65535.0 + g as f32 * 0.6780 / 65535.0 + b as f32 * 0.0593 / 65535.0;
+			Some(luma > 0.6)
+		} else {
+			None
 		}
 	}
 

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -6,7 +6,7 @@ use tracing::error;
 use yazi_macro::writef;
 use yazi_shared::id::{Id, Ids};
 use yazi_term::{TERM, event::{Event, Report}, stream::EventStream};
-use yazi_tty::{TTY, sequence::{If, KittyGraphicsQuery, RequestBgColor, RequestCellPixelSize, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestXtVersion, RestoreCursorPos, SaveCursorPos, TmuxPassthrough}};
+use yazi_tty::{TTY, sequence::{If, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKittyGraphics, RequestXtVersion, RestoreCursorPos, SaveCursorPos, TmuxPassthrough}};
 
 use crate::{Brand, Emulator, Mux};
 
@@ -40,9 +40,9 @@ impl Probe {
 
 		writef!(
 			TTY.writer(),
-			"{SaveCursorPos}{}{}{RequestCursorStyle}{RequestCursorBlink}{RequestCellPixelSize}{RequestBgColor}{}{RestoreCursorPos}",
+			"{SaveCursorPos}{}{RequestCursorBlink}{RequestCursorStyle}{RequestColorScheme}{RequestBgColor}{}{RequestCellPixelSize}{}{RestoreCursorPos}",
 			w(&RequestXtVersion),
-			If(self.emulator.brand == Brand::Unknown, w(&KittyGraphicsQuery)),
+			If(self.emulator.brand == Brand::Unknown, w(&RequestKittyGraphics)),
 			w(&RequestDA1),
 		)?;
 

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -59,6 +59,7 @@ impl App {
 	fn bootstrap(&mut self) -> Result<Data> {
 		let cx = &mut Ctx::active(&mut self.core, &mut self.term);
 		act!(app:bootstrap, cx)?;
+		act!(app:reflow, cx, crate::Root::reflow as fn(_) -> _)?;
 		succ!(render!())
 	}
 

--- a/yazi-parser/src/mgr/spot.rs
+++ b/yazi-parser/src/mgr/spot.rs
@@ -5,6 +5,8 @@ use yazi_shared::event::ActionCow;
 #[derive(Debug, Default, Deserialize)]
 pub struct SpotOpt {
 	pub skip: Option<usize>,
+	#[serde(default)]
+	pub force: bool,
 }
 
 impl TryFrom<ActionCow> for SpotOpt {
@@ -14,7 +16,11 @@ impl TryFrom<ActionCow> for SpotOpt {
 }
 
 impl From<usize> for SpotOpt {
-	fn from(skip: usize) -> Self { Self { skip: Some(skip) } }
+	fn from(skip: usize) -> Self { Self { skip: Some(skip), ..Default::default() } }
+}
+
+impl From<bool> for SpotOpt {
+	fn from(force: bool) -> Self { Self { force, ..Default::default() } }
 }
 
 impl FromLua for SpotOpt {

--- a/yazi-parser/src/mgr/spot.rs
+++ b/yazi-parser/src/mgr/spot.rs
@@ -4,7 +4,7 @@ use yazi_shared::event::ActionCow;
 
 #[derive(Debug, Default, Deserialize)]
 pub struct SpotOpt {
-	pub skip: Option<usize>,
+	pub skip:  Option<usize>,
 	#[serde(default)]
 	pub force: bool,
 }

--- a/yazi-plugin/src/runtime/term.rs
+++ b/yazi-plugin/src/runtime/term.rs
@@ -5,7 +5,7 @@ use yazi_emulator::{Dimension, EMULATOR};
 pub(super) fn term() -> Composer<ComposerGet, ComposerSet> {
 	fn get(lua: &Lua, key: &[u8]) -> mlua::Result<Value> {
 		match key {
-			b"light" => EMULATOR.load().light.into_lua(lua),
+			b"light" => light(lua)?.into_lua(lua),
 			b"cell_size" => cell_size(lua)?.into_lua(lua),
 			_ => Ok(Value::Nil),
 		}
@@ -14,6 +14,10 @@ pub(super) fn term() -> Composer<ComposerGet, ComposerSet> {
 	fn set(_: &Lua, _: &[u8], value: Value) -> mlua::Result<Value> { Ok(value) }
 
 	Composer::new(get, set)
+}
+
+fn light(lua: &Lua) -> mlua::Result<Function> {
+	lua.create_function(|lua, ()| EMULATOR.load().light().into_lua(lua))
 }
 
 fn cell_size(lua: &Lua) -> mlua::Result<Function> {

--- a/yazi-term/src/event/report.rs
+++ b/yazi-term/src/event/report.rs
@@ -1,7 +1,8 @@
 use compact_str::CompactString;
 use mlua::{ExternalError, IntoLua, Lua, Value};
+use strum::EnumIs;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, EnumIs, Eq, PartialEq)]
 pub enum Report {
 	CursorBlink(bool),
 	CursorShape(u8),
@@ -9,6 +10,7 @@ pub enum Report {
 	XtVersion(CompactString),
 	CellPixelSize { width: u16, height: u16 },
 	BackgroundColor([u16; 3]),
+	ColorScheme(bool),
 	KittyGraphics { id: u32, ok: bool },
 }
 

--- a/yazi-term/src/parser/csi.rs
+++ b/yazi-term/src/parser/csi.rs
@@ -44,8 +44,8 @@ impl Parser {
 			b'Q' => Event::Key(KeyCode::Fn(2).into()),
 			b'S' => Event::Key(KeyCode::Fn(4).into()),
 			b'?' => match last {
-				b'c' | b'y' => return self.parse_csi_report(),
-				b'u' | b'n' => return Err(ParseError::Ignored),
+				b'c' | b'n' | b'y' => return self.parse_csi_report(),
+				b'u' => return Err(ParseError::Ignored),
 				_ => bail!(),
 			},
 			b'>' => match seq[seq.len() - 2..] {

--- a/yazi-term/src/parser/report.rs
+++ b/yazi-term/src/parser/report.rs
@@ -19,6 +19,15 @@ impl Parser {
 					.collect::<Result<_, _>>()?,
 			),
 
+			// `CSI 6 ; Ph ; Pw t` (`\x1b[6;...;...t`) - XTWINOPS character-cell size report.
+			(Some(b'6'), Some(b't')) => {
+				let (h, w) = str::from_utf8(&seq[3..seq.len() - 1])?
+					.strip_prefix(';')
+					.and_then(|s| s.split_once(';'))
+					.ok_or(ParseError::Invalid)?;
+				Report::CellPixelSize { width: w.parse()?, height: h.parse()? }
+			}
+
 			// `CSI ? 12 ; Ps $ y` (`\x1b[?12;...$y`) - DECRPM response for DEC mode 12.
 			(Some(b'?'), Some(b'y')) => {
 				let status: u8 = str::from_utf8(&seq[3..seq.len() - 1])?
@@ -34,14 +43,12 @@ impl Parser {
 				})
 			}
 
-			// `CSI 6 ; Ph ; Pw t` (`\x1b[6;...;...t`) - XTWINOPS character-cell size report.
-			(Some(b'6'), Some(b't')) => {
-				let (h, w) = str::from_utf8(&seq[3..seq.len() - 1])?
-					.strip_prefix(';')
-					.and_then(|s| s.split_once(';'))
-					.ok_or(ParseError::Invalid)?;
-				Report::CellPixelSize { width: w.parse()?, height: h.parse()? }
-			}
+			// `CSI ? 997 ; Ps n` (`\x1b[?997;...n`) - current color scheme report.
+			(Some(b'?'), Some(b'n')) => Report::ColorScheme(match &seq[3..seq.len() - 1] {
+				b"997;1" => false,
+				b"997;2" => true,
+				_ => bail!(),
+			}),
 
 			_ => bail!(),
 		}))

--- a/yazi-tty/src/sequence/mode.rs
+++ b/yazi-tty/src/sequence/mode.rs
@@ -59,3 +59,17 @@ impl Display for DisableMouseCapture {
 		f.write_str("\x1b[?1006l\x1b[?1015l\x1b[?1002l\x1b[?1000l")
 	}
 }
+
+/// Enable color scheme update notifications
+pub struct EnableColorSchemeUpdates;
+
+impl Display for EnableColorSchemeUpdates {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("\x1b[?2031h") }
+}
+
+/// Disable color scheme update notifications
+pub struct DisableColorSchemeUpdates;
+
+impl Display for DisableColorSchemeUpdates {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("\x1b[?2031l") }
+}

--- a/yazi-tty/src/sequence/query.rs
+++ b/yazi-tty/src/sequence/query.rs
@@ -14,6 +14,13 @@ impl Display for RequestCellPixelSize {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("\x1b[16t") }
 }
 
+/// Request the current color scheme
+pub struct RequestColorScheme;
+
+impl Display for RequestColorScheme {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("\x1b[?996n") }
+}
+
 /// Request background color via OSC 11
 pub struct RequestBgColor;
 
@@ -29,9 +36,9 @@ impl Display for RequestDA1 {
 }
 
 /// Query Kitty graphics protocol capabilities
-pub struct KittyGraphicsQuery;
+pub struct RequestKittyGraphics;
 
-impl Display for KittyGraphicsQuery {
+impl Display for RequestKittyGraphics {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		f.write_str("\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\")
 	}

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -9,7 +9,7 @@ use yazi_macro::writef;
 use yazi_proxy::AppProxy;
 use yazi_shim::cell::SyncCell;
 use yazi_term::{TERM, event::{Event, KeyEventKind}, stream::EventStream};
-use yazi_tty::{TTY, TtyWriter, sequence::{DisableBracketedPaste, DisableDrag, DisableDrop, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste, EnableDrag, EnableDrop, EnableFocusChange, EnableMouseCapture, EnterAlternateScreen, If, LeaveAlternateScreen, PopKeyboardFlags, PushKeyboardFlags, RestoreCursorStyle, SetTitle, ShowCursor}};
+use yazi_tty::{TTY, TtyWriter, sequence::{DisableBracketedPaste, DisableColorSchemeUpdates, DisableDrag, DisableDrop, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste, EnableColorSchemeUpdates, EnableDrag, EnableDrop, EnableFocusChange, EnableMouseCapture, EnterAlternateScreen, If, LeaveAlternateScreen, PopKeyboardFlags, PushKeyboardFlags, RestoreCursorStyle, SetTitle, ShowCursor}};
 
 use crate::{RatermBackend, RatermOption, RatermState};
 
@@ -48,7 +48,7 @@ impl Raterm {
 		let mut stream = EventStream::from(&*TERM);
 		writef!(
 			TTY.writer(),
-			"{EnterAlternateScreen}{EnableBracketedPaste}{EnableFocusChange}{}{}{}{}",
+			"{EnterAlternateScreen}{EnableBracketedPaste}{EnableFocusChange}{EnableColorSchemeUpdates}{}{}{}{}",
 			PushKeyboardFlags::DISAMBIGUATE_ESCAPE_CODES
 				| PushKeyboardFlags::REPORT_ALTERNATE_KEYS
 				| PushKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
@@ -79,7 +79,7 @@ impl Raterm {
 
 		_ = writef!(
 			TTY.writer(),
-			"{}{PopKeyboardFlags}{DisableDrop}{DisableDrag}{}{}{DisableFocusChange}{DisableBracketedPaste}{LeaveAlternateScreen}{ShowCursor}",
+			"{}{PopKeyboardFlags}{DisableDrop}{DisableDrag}{}{}{DisableColorSchemeUpdates}{DisableFocusChange}{DisableBracketedPaste}{LeaveAlternateScreen}{ShowCursor}",
 			If(state.mouse, DisableMouseCapture),
 			RestoreCursorStyle { blink: emu.cursor_blink, shape: emu.cursor_shape },
 			If(state.title, SetTitle("")),


### PR DESCRIPTION
An implementation of the feature request: https://github.com/sxyazi/yazi/issues/988, https://github.com/sxyazi/yazi/pull/3906#issuecomment-4309471295, and https://github.com/sxyazi/yazi/issues/4134

Closes https://github.com/sxyazi/yazi/issues/4134

---

This PR follows up on:

- https://github.com/sxyazi/yazi/pull/3906 - allows Yazi to switch themes at runtime
- https://github.com/sxyazi/yazi/pull/3989 - migrates from Crossterm to our own terminal library, enabling escape sequences that Crossterm doesn't support, which is the biggest blocker for this feature

With this PR, Yazi supports [`CSI ? 997`](https://contour-terminal.org/vt-extensions/color-palette-update-notifications/#query-the-current-theme-mode) (query the current color scheme) and [`CSI ? 2031`](https://contour-terminal.org/vt-extensions/color-palette-update-notifications/#request-unsolicited-dsr-on-color-palette-updates) (subscribe to color scheme changes), which lets Yazi follow the OS dark/light mode and switch themes automatically.

## Demo

```toml
# ~/.config/yazi/theme.toml
[flavor]
dark  = "catppuccin-macchiato"
light = "catppuccin-latte"
```

https://github.com/user-attachments/assets/95f3e688-171a-4fb1-88b2-ac3ed02feec2

## ⚠️ Breaking changes

`rt.term.light` is now a function returning `bool?` instead of a boolean. This allows it to be called multiple times to get the latest color scheme info.

Also extended it with a new `nil` value, which is returned when the scheme is unknown, e.g. no terminal responses received yet (returned `false` previously).