### PR TITLE
fix: improve preview cache directory ownership error messages

### DIFF
--- a/yazi-config/src/preview/preview.rs
+++ b/yazi-config/src/preview/preview.rs
@@ -50,7 +50,7 @@ impl DeserializeOverHook for Preview {
 	fn deserialize_over_hook(self) -> Result<Self, toml::de::Error> {
 		create_owned_dir_blocking(&self.cache_dir)
 			.context(format!("Failed to create cache directory: {}", self.cache_dir.display()))
-			.map_err(serde::de::Error::custom)?;
+			.map_err(|err| serde::de::Error::custom(format!("{err:#}")))?;
 
 		Ok(self)
 	}


### PR DESCRIPTION
Resolves https://github.com/sxyazi/yazi/issues/4166

Now the full error chain is preserved:

```
Failed to parse config "/tmp/cache-error-test/yazi.toml"

Caused by:
Failed to create cache directory: /private/tmp: directory "/private/tmp" is owned by uid 0 but current uid is 501


Press <Enter> to continue with preset settings...
```