### PR TITLE
fix: use tmux_sixel_flag() for native sixel detection in probe restart

### DIFF
--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -27,8 +27,7 @@ impl Probe {
 	pub fn restart(&mut self) -> Result<()> {
 		self.id = IDS.next();
 		let sixel = Mux::tmux_sixel_flag() == "Supported";
-		self.emulator =
-			Emulator { mux: Some(Mux { sixel }), ..Default::default() };
+		self.emulator = Emulator { mux: Some(Mux { sixel }), ..Default::default() };
 		self.request()
 	}
 

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -26,8 +26,9 @@ impl Probe {
 
 	pub fn restart(&mut self) -> Result<()> {
 		self.id = IDS.next();
+		let sixel = Mux::tmux_sixel_flag() == "Supported";
 		self.emulator =
-			Emulator { mux: Some(Mux { sixel: self.emulator.sixel }), ..Default::default() };
+			Emulator { mux: Some(Mux { sixel }), ..Default::default() };
 		self.request()
 	}
 


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4111

## Rationale

When yazi runs inside tmux 3.7b (built with `--enable-sixel`), image previews flash for a split second then disappear. The root cause is in `Probe::restart()` (`yazi-emulator/src/probe.rs`):

```rust
self.emulator =
    Emulator { mux: Some(Mux { sixel: self.emulator.sixel }), ..Default::default() };
```

`self.emulator.sixel` here comes from tmux's own DA1 response, but tmux 3.7b does not report attribute 4 (sixel) in DA1 even when compiled with `--enable-sixel`. So `mux.sixel` is always `false`, the native sixel fast-path in `Drivers::matches()` never triggers, and sixel data gets wrapped in DCS passthrough (`\ePtmux;\e...`). The outer terminal renders the image briefly, but tmux redraws over it immediately because it doesn't track passthrough content.

The fix replaces the DA1-derived flag with `Mux::tmux_sixel_flag()`, which already exists and correctly detects native sixel by querying `#{sixel_support}`. When tmux reports native sixel support, `MuxSequence` skips passthrough wrapping and tmux renders images directly — persistent, no flashing.

The existing code path where tmux does *not* have native sixel is unchanged — passthrough wrapping still applies as before.

## Testing

Tested on:
- tmux 3.7b (`--enable-sixel`) + WezTerm (Windows, via WSL bridge)
- Image previews render crisply and persist across redraws
- Works in both regular tmux panes and tmux popup sessions (`display-popup`)
- Verified `ya env` shows `tmux build flags: enable-sixel=Supported`

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] **AI disclosure**: Claude Code (claude-opus-4-6) was used to assist with researching the codebase, identifying the root cause, and drafting this PR. All code was reviewed and tested by a human. The AI tool does not assert copyright over any contributions.