### PR TITLE
feat: new options to zoxide plugin for adding entries to the database

### DIFF
--- a/yazi-plugin/preset/plugins/zoxide.lua
+++ b/yazi-plugin/preset/plugins/zoxide.lua
@@ -9,13 +9,75 @@ end)
 
 local set_state = ya.sync(function(st, empty) st.empty = empty end)
 
+-- Bump the entry token and record the directory, so stale `cd` handlers (from
+-- directories we've already moved away from) can tell they're no longer current.
+local next_entry = ya.sync(function(st, dir)
+	st.entry_token = (st.entry_token or 0) + 1
+	st.entry_dir = dir
+	return st.entry_token
+end)
+
+local get_entry = ya.sync(function(st) return st.entry_token, st.entry_dir end)
+
+-- Rate-limit adding the same directory again until `interval` seconds pass.
+local try_add = ya.sync(function(st, dir)
+	local now = ya.time()
+	local prev = st.last[dir]
+	if prev and st.interval > 0 and now - prev < st.interval then
+		return false
+	end
+	st.last[dir] = now
+	return true
+end)
+
+local function display(dir)
+	dir = dir:gsub("\\", "/")
+	local home = os.getenv("HOME") or os.getenv("USERPROFILE")
+	if home then
+		home = home:gsub("\\", "/"):gsub("/+$", "")
+		local lower_dir, lower_home = dir:lower(), home:lower()
+		if lower_dir:sub(1, #lower_home) == lower_home then
+			local rest = dir:sub(#lower_home + 1)
+			if rest == "" then
+				return "~"
+			elseif rest:sub(1, 1) == "/" then
+				return "~" .. rest
+			end
+		end
+	end
+	return dir
+end
+
 function M:setup(opts)
 	opts = opts or {}
 
 	if opts.update_db then
+		M.last = M.last or {}
+		M.interval = opts.interval or 0
+
+		local delay = opts.delay or 0
+		local notify_time = opts.notify_time or 0
+
 		ps.sub("cd", function()
 			local cwd = cx.active.current.cwd
-			ya.async(function() Command("zoxide"):arg({ "add", tostring(cwd) }):status() end)
+			local dir = tostring(cwd)
+
+			local token = next_entry(dir)
+
+			ya.async(function()
+				ya.sleep(delay)
+				local cur_token, cur_dir = get_entry()
+				if cur_token ~= token or cur_dir ~= dir then
+					return
+				end
+				if not try_add(dir) then
+					return
+				end
+				Command("zoxide"):arg({ "add", dir }):status()
+				if notify_time > 0 then
+					ya.notify { title = "Zoxide", content = "Added " .. display(dir), timeout = notify_time }
+				end
+			end)
 		end)
 	end
 end


### PR DESCRIPTION
## Which issue does this PR resolve?

The zoxide plugin has an `update_db` setting that adds every directory you travel to the zoxide database. This pr adds some options on top of that while preserving backwards compatibility, all default options behave the same as before the pr and only have an effect if `update_db = true`.

```lua
require("zoxide"):setup {
    update_db = true,
    delay = 3,        -- seconds you must stay in a directory before it's added (default 0)
    interval = 60,    -- seconds that must pass before adding the same directory again (default 0)
    notify_time = 1.5 -- seconds to show a notification with a message saying the directory added (default 0)
}
```

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

## Rationale of this PR

Adds a middle point between just adding everything to `zoxide` and nothing at all. Should provide better results when searching with by not adding every directory in a path while navigating for example.
<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

<!-- AI bots are not allowed to open PRs in this repository. All PRs must be made by humans and comply with the AI policy. -->
