### PR TITLE
feat: preview images in Zellij via kitty graphics protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - New `--follow` option for the `link` action ([#4184])
 - New `ui.Input` element ([#4040])
 - New `theme` DDS event for plugins to watch theme reloads ([#4203])
+- Preview images in Zellij via kitty graphics protocol ([#4216])
 - Image preview with Überzug++ on Niri ([#3990])
 - Unicode normalization for user regex patterns in `find`, `filter`, and `search` actions ([#4177])
 - New gait for input `backward` and `forward` actions ([#4012])
@@ -1808,3 +1809,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4203]: https://github.com/sxyazi/yazi/pull/4203
 [#4204]: https://github.com/sxyazi/yazi/pull/4204
 [#4212]: https://github.com/sxyazi/yazi/pull/4212
+[#4216]: https://github.com/sxyazi/yazi/pull/4216

--- a/yazi-actor/src/app/report.rs
+++ b/yazi-actor/src/app/report.rs
@@ -32,6 +32,7 @@ impl Actor for Report {
 		} else if !report.is_da_1() {
 			succ!();
 		} else if !term.probe.needs_passthrough() {
+			term.clear().ok();
 			ADAPTOR.resolve(&term.probe.emulator);
 			return act!(app:theme, cx);
 		}

--- a/yazi-adapter/src/drivers/drivers.rs
+++ b/yazi-adapter/src/drivers/drivers.rs
@@ -27,6 +27,12 @@ impl From<&Emulator> for Drivers {
 				(false, true) => vec![D::Sixel],
 				(false, false) => vec![],
 			}),
+			Brand::Zellij => Self(match (value.kgp, value.sixel) {
+				(true, true) => vec![D::KgpOld, D::Sixel],
+				(true, false) => vec![D::KgpOld],
+				(false, true) => vec![D::Sixel],
+				(false, false) => vec![],
+			}),
 			brand => brand.into(),
 		}
 	}
@@ -53,6 +59,7 @@ impl From<Brand> for Drivers {
 			B::Hyper => vec![D::Iip, D::Sixel],
 			B::Mintty => vec![D::Iip],
 			B::Tmux => vec![],
+			B::Zellij => vec![],
 			B::VTerm => vec![],
 			B::Apple => vec![],
 			B::Urxvt => vec![],
@@ -64,9 +71,7 @@ impl From<Brand> for Drivers {
 impl Drivers {
 	pub fn matches(emu: &Emulator) -> D {
 		let mut drivers: Self = emu.into();
-		if env_exists("ZELLIJ_SESSION_NAME") {
-			drivers.retain(|p| *p == D::Sixel);
-		} else if emu.sixel && emu.mux.is_some_and(|mux| mux.sixel) {
+		if emu.sixel && emu.mux.is_some_and(|mux| mux.sixel) {
 			return D::Sixel;
 		} else if emu.mux.is_some() {
 			drivers.retain(|p| *p != D::KgpOld);

--- a/yazi-emulator/src/brand.rs
+++ b/yazi-emulator/src/brand.rs
@@ -22,6 +22,7 @@ pub enum Brand {
 	Hyper,
 	Mintty,
 	Tmux,
+	Zellij,
 	VTerm,
 	Apple,
 	Urxvt,
@@ -40,6 +41,7 @@ impl Brand {
 			("Warp", Self::Warp),
 			("Rio ", Self::Rio),
 			("tmux ", Self::Tmux),
+			("Zellij", Self::Zellij),
 			("libvterm", Self::VTerm),
 			("Bobcat", Self::Bobcat),
 		];

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -6,7 +6,7 @@ use tracing::error;
 use yazi_macro::writef;
 use yazi_shared::id::{Id, Ids};
 use yazi_term::{TERM, event::{Event, Report}, stream::EventStream};
-use yazi_tty::{TTY, sequence::{If, ProbeClipboard, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKittyGraphics, RequestXtVersion, RestoreCursorPos, SaveCursorPos, TmuxPassthrough}};
+use yazi_tty::{TTY, sequence::{ProbeClipboard, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKittyGraphics, RequestXtVersion, RestoreCursorPos, SaveCursorPos, TmuxPassthrough}};
 
 use crate::{Brand, Emulator, Mux};
 
@@ -42,7 +42,7 @@ impl Probe {
 			TTY.writer(),
 			"{SaveCursorPos}{}{RequestCursorBlink}{RequestCursorStyle}{RequestColorScheme}{RequestBgColor}{}{RequestCellPixelSize}{ProbeClipboard}{}{RestoreCursorPos}",
 			w(&RequestXtVersion),
-			If(self.emulator.brand == Brand::Unknown, w(&RequestKittyGraphics)),
+			w(&RequestKittyGraphics),
 			w(&RequestDA1),
 		)?;
 

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -135,4 +135,9 @@ impl Raterm {
 	pub fn can_partial(&mut self) -> bool {
 		self.inner.autoresize().is_ok() && self.last_area == self.inner.get_frame().area()
 	}
+
+	pub fn clear(&mut self) -> io::Result<()> {
+		self.inner.clear()?;
+		self.inner.flush()
+	}
 }


### PR DESCRIPTION
Zellij's main branch now supports the kitty graphics protocol, this PR is a quick follow-up to https://github.com/zellij-org/zellij/pull/5428#issuecomment-5147634942.

Yazi will now prefer KGP for terminals that support it, then fall back to Sixel.

## Demo

kitty + Zellij tip combo:

<img width="2538" height="1632" alt="aYhSjIBj" src="https://github.com/user-attachments/assets/e6f15db3-9e36-44eb-8540-6979cf9fce2a" />
