### PR TITLE
feat: reduce binary size and build time

### DIFF
--- a/.cargo/release.toml
+++ b/.cargo/release.toml
@@ -2,4 +2,17 @@
 trim-paths = "all"
 
 [target.'cfg(all())']
-rustflags = [ "-Cpasses=mergefunc" ]
+rustflags = [
+	"-Cpasses=mergefunc",
+	"-Zshare-generics=true",
+]
+
+[target.'cfg(target_os = "linux")']
+rustflags = [
+	"-Clink-arg=-fuse-ld=lld",
+	"-Clink-arg=-Wl,--icf=safe",
+	"-Clink-arg=-Wl,-z,pack-relative-relocs",
+]
+
+[target.'cfg(target_os = "macos")']
+rustflags = [ "-Clink-arg=-Wl,-O1" ]

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -19,9 +19,8 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            gcc: gcc-aarch64-linux-gnu
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             gcc: gcc-i686-linux-gnu
@@ -37,7 +36,6 @@ jobs:
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     env:
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER: i686-linux-gnu-gcc
       CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER: riscv64-linux-gnu-gcc
       CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER: sparc64-linux-gnu-gcc

--- a/nix/yazi-unwrapped.nix
+++ b/nix/yazi-unwrapped.nix
@@ -4,6 +4,7 @@
   rev ? "unknown",
   date ? "19700101",
   lib,
+  stdenv,
 
   installShellFiles,
   fetchFromGitHub,
@@ -15,6 +16,7 @@ let
   src = lib.fileset.toSource {
     root = ../.;
     fileset = lib.fileset.unions [
+      ../.cargo
       ../assets
       ../Cargo.toml
       ../Cargo.lock
@@ -34,6 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     YAZI_GEN_COMPLETIONS = true;
     VERGEN_GIT_SHA = rev;
     VERGEN_BUILD_DATE = builtins.concatStringsSep "-" (builtins.match "(.{4})(.{2})(.{2}).*" date);
+    CARGO_NET_OFFLINE = "true";
   };
 
   nativeBuildInputs = [
@@ -44,6 +47,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     rust-jemalloc-sys
   ];
+
+  buildPhase = ''
+    runHook preBuild
+    cargo xtask build --target ${stdenv.hostPlatform.rust.rustcTarget}
+    runHook postBuild
+  '';
 
   postInstall = ''
     installShellCompletion --cmd yazi \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,7 @@ parts:
       - xclip
       - zoxide
     override-build: |
-      craftctl default
+      cargo xtask install --bin-dir "$CRAFT_PART_INSTALL"
       craftctl set version=$(git describe --tags --abbrev=0)
     build-attributes:
       - enable-patchelf

--- a/yazi-build/src/build.rs
+++ b/yazi-build/src/build.rs
@@ -1,8 +1,9 @@
-use std::process::Command;
+use std::{env, fs, iter, path::{Path, PathBuf}, process::Command};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
+use yazi_macro::ok_or_not_found;
 
-use super::{cargo, is_windows_target, run};
+use super::{cargo, is_linux_target, is_windows_target, run, workspace_root};
 
 pub(super) struct Build {
 	pub(super) target: String,
@@ -33,11 +34,64 @@ impl Build {
 		if self.completions {
 			cmd.env("YAZI_GEN_COMPLETIONS", "1");
 		}
+		if is_linux_target(&self.target) {
+			self.expose_lld(&mut cmd)?;
+		}
 
 		run(&mut cmd).context("failed to build Yazi")
 	}
 
 	pub(super) fn profile(&self) -> &'static str {
 		if is_windows_target(&self.target) { "release-windows" } else { "release" }
+	}
+
+	fn expose_lld(&self, cmd: &mut Command) -> Result<()> {
+		let rust_lld = Self::rustc_libdir()?
+			.parent()
+			.context("Rust target libdir has no parent")?
+			.join("bin/rust-lld");
+		ensure!(rust_lld.is_file(), "{} does not exist", rust_lld.display());
+
+		let temp_dir = workspace_root()?.join("target/.rust-lld");
+		fs::create_dir_all(&temp_dir).context("failed to create `target/.rust-lld` directory")?;
+		for name in ["ld.lld".to_owned()].into_iter().chain(self.lld_alias()) {
+			let link = temp_dir.join(name);
+			ok_or_not_found!(fs::remove_file(&link));
+			#[cfg(unix)]
+			std::os::unix::fs::symlink(&rust_lld, link)?;
+			#[cfg(not(unix))]
+			anyhow::bail!("bundled rust-lld setup requires a Unix host");
+		}
+
+		let path = env::var_os("PATH").unwrap_or_default();
+		cmd.env("PATH", env::join_paths(iter::once(temp_dir).chain(env::split_paths(&path)))?);
+		Ok(())
+	}
+
+	fn rustc_libdir() -> Result<PathBuf> {
+		let output = Command::new(env::var_os("RUSTC").unwrap_or_else(|| "rustc".into()))
+			.args(["--print", "target-libdir"])
+			.output()
+			.context("failed to locate the Rust target libdir")?;
+
+		ensure!(output.status.success(), "`rustc --print target-libdir` failed");
+		Ok(String::from_utf8(output.stdout)?.trim().into())
+	}
+
+	// Cross GCC resolves `-fuse-ld=lld` as `<toolchain-prefix>ld.lld`.
+	// For example:
+	//   `aarch64-linux-musl-gcc.sh` => `aarch64-linux-musl-ld.lld`
+	// if Cargo has no configured linker:
+	//   `CROSS_TOOLCHAIN_PREFIX=x86_64-linux-musl-` => `x86_64-linux-musl-ld.lld`
+	fn lld_alias(&self) -> Option<String> {
+		let var = env::var_os(format!(
+			"CARGO_TARGET_{}_LINKER",
+			self.target.replace('-', "_").to_ascii_uppercase()
+		))
+		.or_else(|| env::var_os("CROSS_TOOLCHAIN_PREFIX"))?;
+
+		let prefix = Path::new(&var).file_stem()?.to_str()?.trim_end_matches("gcc");
+
+		Some(format!("{prefix}ld.lld"))
 	}
 }

--- a/yazi-build/src/common.rs
+++ b/yazi-build/src/common.rs
@@ -29,6 +29,10 @@ pub(super) fn workspace_root() -> Result<PathBuf> {
 		.context("yazi-build must be inside the Yazi workspace")
 }
 
+pub(super) fn is_linux_target(target: &str) -> bool {
+	target.contains("-linux-") || (target.is_empty() && cfg!(target_os = "linux"))
+}
+
 pub(super) fn is_windows_target(target: &str) -> bool {
 	target.contains("-windows-") || (target.is_empty() && cfg!(windows))
 }


### PR DESCRIPTION
Before: https://github.com/sxyazi/yazi/commit/7595a1c573b30006ec56a030077daeb95de99146 (commit before this PR)

After: https://github.com/sxyazi/yazi/commit/5ab58e3029c023ca1ae4bd788716b3da927fb525 (this PR)

With this PR, the Yazi build reduced size by 12.01% overall, while every target also had a shorter build time.

## Binary size

| Target | Before | After | Reduction |
|---|---:|---:|---:|
| x86_64-pc-windows-msvc | 35.96 MiB | 30.89 MiB | -14.11% (-5.07 MiB) |
| x86_64-unknown-linux-musl | 25.93 MiB | 22.43 MiB | -13.51% (-3.50 MiB) |
| x86_64-unknown-linux-gnu | 25.79 MiB | 22.31 MiB | -13.50% (-3.48 MiB) |
| aarch64-pc-windows-msvc | 30.11 MiB | 26.12 MiB | -13.25% (-3.99 MiB) |
| i686-unknown-linux-gnu | 26.82 MiB | 23.33 MiB | -13.01% (-3.49 MiB) |
| riscv64gc-unknown-linux-gnu | 22.98 MiB | 20.01 MiB | -12.89% (-2.96 MiB) |
| aarch64-apple-darwin | 19.66 MiB | 17.47 MiB | -11.16% (-2.19 MiB) |
| aarch64-unknown-linux-gnu | 22.34 MiB | 19.86 MiB | -11.13% (-2.49 MiB) |
| x86_64-apple-darwin | 23.25 MiB | 20.73 MiB | -10.85% (-2.52 MiB) |
| aarch64-unknown-linux-musl | 21.64 MiB | 19.48 MiB | -9.96% (-2.16 MiB) |
| sparc64-unknown-linux-gnu | 27.35 MiB | 25.35 MiB | -7.31% (-2.00 MiB) |
| Total across 11 targets | 281.84 MiB | 247.98 MiB | -12.01% (-33.86 MiB) |

## Build time

| Target | Before | After | Reduction |
|---|---:|---:|---:|
| x86_64-apple-darwin | 11:37 | 5:31 | -52.5% |
| aarch64-apple-darwin | 9:40 | 5:48 | -40.0% |
| i686-unknown-linux-gnu | 7:50 | 5:03 | -35.5% |
| aarch64-unknown-linux-gnu | 9:09 | 6:05 | -33.5% |
| x86_64-pc-windows-msvc | 17:44 | 12:53 | -27.3% |
| aarch64-pc-windows-msvc | 18:31 | 13:35 | -26.6% |
| x86_64-unknown-linux-gnu | 8:30 | 7:11 | -15.5% |
| sparc64-unknown-linux-gnu | 7:13 | 6:09 | -14.8% |
| riscv64gc-unknown-linux-gnu | 7:35 | 6:31 | -14.1% |
| aarch64-unknown-linux-musl | 8:42 | 7:29 | -14.0% |
| x86_64-unknown-linux-musl | 7:11 | 6:24 | -10.9% |

