### PR TITLE
feat: dynamic Lua API for preloader, spotter, fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - Context-aware icons for inputs ([#4080])
 - Show file icons in trash/delete/overwrite confirmations ([#4096])
 - Dynamic keymap Lua API ([#4031])
+- Dynamic Lua API for preloader, spotter, fetcher ([#4235])
 - Configurable border for the which component ([#4189])
 - Official APT repository for Debian and Ubuntu ([#4198])
 - New `--follow` option for the `link` action ([#4184])
@@ -1813,3 +1814,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4216]: https://github.com/sxyazi/yazi/pull/4216
 [#4225]: https://github.com/sxyazi/yazi/pull/4225
 [#4228]: https://github.com/sxyazi/yazi/pull/4228
+[#4235]: https://github.com/sxyazi/yazi/pull/4235

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",

--- a/yazi-config/src/plugin/fetcher.rs
+++ b/yazi-config/src/plugin/fetcher.rs
@@ -13,8 +13,6 @@ use crate::{Mixable, Pattern, Priority, Selectable, Selector, YAZI, plugin::{Fet
 pub struct Fetcher {
 	#[serde(skip, default = "fetcher_id")]
 	pub id:       Id,
-	#[serde(skip)]
-	pub idx:      u8,
 	#[serde(flatten)]
 	pub selector: Selector,
 	pub run:      Cmd,
@@ -55,7 +53,20 @@ impl From<&Fetchers> for FetcherMatcher<'_> {
 	}
 }
 
-impl FetcherMatcher<'_> {
+impl<'a> FetcherMatcher<'a> {
+	pub fn new<F, M>(fetchers: &Arc<Vec<FetcherArc>>, file: F, mime: M) -> Self
+	where
+		F: Into<Cow<'a, File>>,
+		M: Into<Cow<'a, str>>,
+	{
+		Self {
+			fetchers: fetchers.clone(),
+			file: Some(file.into()),
+			mime: Some(mime.into()),
+			..Default::default()
+		}
+	}
+
 	pub fn matches(&self, fetcher: &Fetcher) -> bool {
 		if self.all {
 			true

--- a/yazi-config/src/plugin/fetcher_arc.rs
+++ b/yazi-config/src/plugin/fetcher_arc.rs
@@ -1,29 +1,40 @@
 use std::{ops::{Deref, DerefMut}, sync::Arc};
 
-use mlua::{UserData, UserDataFields};
+use mlua::{FromLua, Lua, LuaSerdeExt, UserData, UserDataFields, Value};
 use serde::Deserialize;
 use yazi_shim::mlua::UserDataFieldsExt;
 
 use crate::{Mixable, plugin::Fetcher};
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct FetcherArc(Arc<Fetcher>);
+#[serde(from = "Fetcher")]
+pub struct FetcherArc {
+	inner:   Arc<Fetcher>,
+	pub idx: u8,
+	pub rev: u16,
+}
 
 impl Deref for FetcherArc {
 	type Target = Arc<Fetcher>;
 
-	fn deref(&self) -> &Self::Target { &self.0 }
+	fn deref(&self) -> &Self::Target { &self.inner }
 }
 
 impl DerefMut for FetcherArc {
-	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.inner }
 }
 
 impl From<Fetcher> for FetcherArc {
-	fn from(value: Fetcher) -> Self { Self(value.into()) }
+	fn from(value: Fetcher) -> Self { Self { inner: value.into(), idx: 0, rev: 0 } }
 }
 
 impl Mixable for FetcherArc {}
+
+impl FromLua for FetcherArc {
+	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+		Ok(lua.from_value::<Fetcher>(value)?.into())
+	}
+}
 
 impl UserData for FetcherArc {
 	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {

--- a/yazi-config/src/plugin/fetchers.rs
+++ b/yazi-config/src/plugin/fetchers.rs
@@ -1,14 +1,15 @@
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 
+use anyhow::{Result, ensure};
 use arc_swap::ArcSwap;
-use mlua::{MetaMethod, UserData, UserDataMethods};
+use mlua::{ExternalError, ExternalResult, MetaMethod, UserData, UserDataMethods};
 use serde::Deserialize;
 use yazi_fs::file::File;
 use yazi_macro::warn;
-use yazi_shim::arc_swap::IntoPointee;
+use yazi_shim::{arc_swap::{ArcSwapExt, IntoPointee}, vec::VecExt};
 
-use super::MAX_FETCHERS;
-use crate::plugin::{FetcherArc, FetcherMatcher};
+use super::{Fetcher, MAX_FETCHERS};
+use crate::{mix, plugin::{FetcherArc, FetcherMatcher, fetcher_rev}};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Fetchers(ArcSwap<Vec<FetcherArc>>);
@@ -19,12 +20,14 @@ impl Deref for Fetchers {
 	fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-impl From<Vec<FetcherArc>> for Fetchers {
-	fn from(inner: Vec<FetcherArc>) -> Self { Self(inner.into_pointee()) }
-}
+impl TryFrom<Vec<FetcherArc>> for Fetchers {
+	type Error = anyhow::Error;
 
-impl From<Arc<Vec<FetcherArc>>> for Fetchers {
-	fn from(inner: Arc<Vec<FetcherArc>>) -> Self { Self(inner.into()) }
+	fn try_from(inner: Vec<FetcherArc>) -> Result<Self> {
+		ensure!(inner.len() <= MAX_FETCHERS as usize, "Fetchers exceed the limit of {MAX_FETCHERS}");
+
+		Ok(Self(Self::reindex(inner).into_pointee()))
+	}
 }
 
 impl Fetchers {
@@ -46,10 +49,11 @@ impl Fetchers {
 	}
 
 	pub fn mime(&self, files: Vec<File>) -> impl Iterator<Item = (FetcherArc, Vec<File>)> {
+		let fetchers = self.load_full();
 		let mut tasks: [Vec<_>; MAX_FETCHERS as usize] = Default::default();
 
 		for file in files {
-			let found = self.matches(&file, "").find(|f| f.group == "mime");
+			let found = FetcherMatcher::new(&fetchers, &file, "").find(|f| f.group == "mime");
 			if let Some(fetcher) = found {
 				tasks[fetcher.idx as usize].push(file);
 			} else {
@@ -57,10 +61,47 @@ impl Fetchers {
 			}
 		}
 
-		let fetchers = self.load();
 		tasks.into_iter().enumerate().filter_map(move |(i, tasks)| {
 			if tasks.is_empty() { None } else { Some((fetchers[i].clone(), tasks)) }
 		})
+	}
+
+	pub fn insert(&self, index: isize, fetcher: FetcherArc) -> Result<()> {
+		self.0.try_rcu(|fetchers| {
+			let i = fetchers.index_at(index)?;
+			let next = if i == fetchers.len() {
+				mix(Vec::<Fetcher>::new(), fetchers.iter().cloned(), [fetcher.clone()])
+			} else {
+				let (before, after) = fetchers.split_at(i);
+				mix(
+					Vec::<Fetcher>::new(),
+					before.iter().cloned().chain([fetcher.clone()]).chain(after.iter().cloned()),
+					Vec::<Fetcher>::new(),
+				)
+			};
+
+			ensure!(next.len() <= MAX_FETCHERS as usize, "Fetchers exceed the limit of {MAX_FETCHERS}");
+			Ok(Self::reindex(next))
+		})?;
+
+		Ok(())
+	}
+
+	pub fn remove(&self, matcher: FetcherMatcher) {
+		self.0.rcu(|fetchers| {
+			let mut next = Vec::clone(fetchers);
+			next.retain(|fetcher| !matcher.matches(fetcher));
+			if next.len() == fetchers.len() { next } else { Self::reindex(next) }
+		});
+	}
+
+	fn reindex(mut fetchers: Vec<FetcherArc>) -> Vec<FetcherArc> {
+		let rev = fetcher_rev();
+		for (i, fetcher) in fetchers.iter_mut().enumerate() {
+			fetcher.idx = i as u8;
+			fetcher.rev = rev;
+		}
+		fetchers
 	}
 
 	pub(crate) fn unwrap_unchecked(self) -> Vec<FetcherArc> {
@@ -75,6 +116,22 @@ impl UserData for &'static Fetchers {
 				Some(matcher) => matcher,
 				None => me.into(),
 			})
+		});
+
+		methods.add_method("insert", |_, &me, (index, fetcher): (isize, FetcherArc)| {
+			let index = match index {
+				1.. => index - 1,
+				0 => return Err("index must be 1-based or negative".into_lua_err()),
+				_ => index,
+			};
+
+			me.insert(index, fetcher.clone()).into_lua_err()?;
+			Ok(fetcher)
+		});
+
+		methods.add_method("remove", |_, &me, matcher: FetcherMatcher| {
+			me.remove(matcher);
+			Ok(())
 		});
 
 		methods.add_meta_method(MetaMethod::Len, |_, me, ()| Ok(me.load().len()));

--- a/yazi-config/src/plugin/ids.rs
+++ b/yazi-config/src/plugin/ids.rs
@@ -5,9 +5,19 @@ pub fn fetcher_id() -> Id {
 	IDS.next()
 }
 
+pub fn fetcher_rev() -> u16 {
+	static IDS: Ids = Ids::new();
+	((IDS.next().get() - 1) % u16::MAX as u64 + 1) as u16
+}
+
 pub fn preloader_id() -> Id {
 	static IDS: Ids = Ids::new();
 	IDS.next()
+}
+
+pub fn preloader_rev() -> u16 {
+	static IDS: Ids = Ids::new();
+	((IDS.next().get() - 1) % u16::MAX as u64 + 1) as u16
 }
 
 pub fn previewer_id() -> Id {

--- a/yazi-config/src/plugin/plugin.rs
+++ b/yazi-config/src/plugin/plugin.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use serde::{Deserialize, de};
 use yazi_codegen::DeserializeOver2;
 use yazi_shim::toml::DeserializeOverHook;
 
 use super::{Fetcher, Fetchers, Preloader, Preloaders, Previewer, Previewers, Spotter, Spotters};
-use crate::{mix, plugin::{FetcherArc, MAX_FETCHERS, MAX_PRELOADERS, PreloaderArc, PreviewerArc, SpotterArc}};
+use crate::{mix, plugin::{FetcherArc, PreloaderArc, PreviewerArc, SpotterArc}};
 
 #[derive(Default, Deserialize, DeserializeOver2)]
 pub struct Plugin {
@@ -37,32 +35,19 @@ pub struct Plugin {
 
 impl DeserializeOverHook for Plugin {
 	fn deserialize_over_hook(self) -> Result<Self, toml::de::Error> {
-		let mut fetchers: Vec<FetcherArc> =
+		let fetchers: Vec<FetcherArc> =
 			mix(self.prepend_fetchers, self.fetchers.unwrap_unchecked(), self.append_fetchers);
 		let spotters: Vec<SpotterArc> =
 			mix(self.prepend_spotters, self.spotters.unwrap_unchecked(), self.append_spotters);
-		let mut preloaders: Vec<PreloaderArc> =
+		let preloaders: Vec<PreloaderArc> =
 			mix(self.prepend_preloaders, self.preloaders.unwrap_unchecked(), self.append_preloaders);
 		let previewers: Vec<PreviewerArc> =
 			mix(self.prepend_previewers, self.previewers.unwrap_unchecked(), self.append_previewers);
 
-		if fetchers.len() > MAX_FETCHERS as usize {
-			Err(de::Error::custom(format!("Fetchers exceed the limit of {MAX_FETCHERS}")))?;
-		} else if preloaders.len() > MAX_PRELOADERS as usize {
-			Err(de::Error::custom(format!("Preloaders exceed the limit of {MAX_PRELOADERS}")))?;
-		}
-
-		for (i, p) in fetchers.iter_mut().enumerate() {
-			Arc::get_mut(p).ok_or_else(|| de::Error::custom("non-unique fetcher arc"))?.idx = i as u8;
-		}
-		for (i, p) in preloaders.iter_mut().enumerate() {
-			Arc::get_mut(p).ok_or_else(|| de::Error::custom("non-unique preloader arc"))?.idx = i as u8;
-		}
-
 		Ok(Self {
-			fetchers: fetchers.into(),
+			fetchers: fetchers.try_into().map_err(de::Error::custom)?,
 			spotters: spotters.into(),
-			preloaders: preloaders.into(),
+			preloaders: preloaders.try_into().map_err(de::Error::custom)?,
 			previewers: previewers.into(),
 			..Default::default()
 		})

--- a/yazi-config/src/plugin/preloader.rs
+++ b/yazi-config/src/plugin/preloader.rs
@@ -12,8 +12,6 @@ use crate::{Mixable, Pattern, Priority, Selectable, Selector, YAZI, plugin::{Pre
 pub struct Preloader {
 	#[serde(skip, default = "preloader_id")]
 	pub id:       Id,
-	#[serde(skip)]
-	pub idx:      u8,
 	#[serde(flatten)]
 	pub selector: Selector,
 	pub run:      Cmd,

--- a/yazi-config/src/plugin/preloader_arc.rs
+++ b/yazi-config/src/plugin/preloader_arc.rs
@@ -1,6 +1,6 @@
 use std::{ops::{Deref, DerefMut}, sync::Arc};
 
-use mlua::{UserData, UserDataFields};
+use mlua::{FromLua, Lua, LuaSerdeExt, UserData, UserDataFields, Value};
 use serde::Deserialize;
 use yazi_shared::data::Sendable;
 use yazi_shim::mlua::UserDataFieldsExt;
@@ -8,23 +8,34 @@ use yazi_shim::mlua::UserDataFieldsExt;
 use crate::{Mixable, plugin::Preloader};
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct PreloaderArc(Arc<Preloader>);
+#[serde(from = "Preloader")]
+pub struct PreloaderArc {
+	inner:   Arc<Preloader>,
+	pub idx: u8,
+	pub rev: u16,
+}
 
 impl Deref for PreloaderArc {
 	type Target = Arc<Preloader>;
 
-	fn deref(&self) -> &Self::Target { &self.0 }
+	fn deref(&self) -> &Self::Target { &self.inner }
 }
 
 impl DerefMut for PreloaderArc {
-	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.inner }
 }
 
 impl From<Preloader> for PreloaderArc {
-	fn from(value: Preloader) -> Self { Self(value.into()) }
+	fn from(value: Preloader) -> Self { Self { inner: value.into(), idx: 0, rev: 0 } }
 }
 
 impl Mixable for PreloaderArc {}
+
+impl FromLua for PreloaderArc {
+	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+		Ok(lua.from_value::<Preloader>(value)?.into())
+	}
+}
 
 impl UserData for PreloaderArc {
 	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {

--- a/yazi-config/src/plugin/preloaders.rs
+++ b/yazi-config/src/plugin/preloaders.rs
@@ -1,12 +1,14 @@
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 
+use anyhow::{Result, ensure};
 use arc_swap::ArcSwap;
-use mlua::{MetaMethod, UserData, UserDataMethods};
+use mlua::{ExternalError, ExternalResult, MetaMethod, UserData, UserDataMethods};
 use serde::Deserialize;
 use yazi_fs::file::File;
-use yazi_shim::arc_swap::IntoPointee;
+use yazi_shim::{arc_swap::{ArcSwapExt, IntoPointee}, vec::VecExt};
 
-use crate::plugin::{PreloaderArc, PreloaderMatcher};
+use super::{MAX_PRELOADERS, Preloader};
+use crate::{mix, plugin::{PreloaderArc, PreloaderMatcher, preloader_rev}};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Preloaders(ArcSwap<Vec<PreloaderArc>>);
@@ -17,12 +19,17 @@ impl Deref for Preloaders {
 	fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-impl From<Vec<PreloaderArc>> for Preloaders {
-	fn from(inner: Vec<PreloaderArc>) -> Self { Self(inner.into_pointee()) }
-}
+impl TryFrom<Vec<PreloaderArc>> for Preloaders {
+	type Error = anyhow::Error;
 
-impl From<Arc<Vec<PreloaderArc>>> for Preloaders {
-	fn from(inner: Arc<Vec<PreloaderArc>>) -> Self { Self(inner.into()) }
+	fn try_from(inner: Vec<PreloaderArc>) -> Result<Self> {
+		ensure!(
+			inner.len() <= MAX_PRELOADERS as usize,
+			"Preloaders exceed the limit of {MAX_PRELOADERS}"
+		);
+
+		Ok(Self(Self::reindex(inner).into_pointee()))
+	}
 }
 
 impl Preloaders {
@@ -43,6 +50,47 @@ impl Preloaders {
 		}
 	}
 
+	pub fn insert(&self, index: isize, preloader: PreloaderArc) -> Result<()> {
+		self.0.try_rcu(|preloaders| {
+			let i = preloaders.index_at(index)?;
+			let next = if i == preloaders.len() {
+				mix(Vec::<Preloader>::new(), preloaders.iter().cloned(), [preloader.clone()])
+			} else {
+				let (before, after) = preloaders.split_at(i);
+				mix(
+					Vec::<Preloader>::new(),
+					before.iter().cloned().chain([preloader.clone()]).chain(after.iter().cloned()),
+					Vec::<Preloader>::new(),
+				)
+			};
+
+			ensure!(
+				next.len() <= MAX_PRELOADERS as usize,
+				"Preloaders exceed the limit of {MAX_PRELOADERS}"
+			);
+			Ok(Self::reindex(next))
+		})?;
+
+		Ok(())
+	}
+
+	pub fn remove(&self, matcher: PreloaderMatcher) {
+		self.0.rcu(|preloaders| {
+			let mut next = Vec::clone(preloaders);
+			next.retain(|preloader| !matcher.matches(preloader));
+			if next.len() == preloaders.len() { next } else { Self::reindex(next) }
+		});
+	}
+
+	fn reindex(mut preloaders: Vec<PreloaderArc>) -> Vec<PreloaderArc> {
+		let rev = preloader_rev();
+		for (i, preloader) in preloaders.iter_mut().enumerate() {
+			preloader.idx = i as u8;
+			preloader.rev = rev;
+		}
+		preloaders
+	}
+
 	pub(crate) fn unwrap_unchecked(self) -> Vec<PreloaderArc> {
 		Arc::try_unwrap(self.0.into_inner()).expect("unique preloaders arc")
 	}
@@ -55,6 +103,22 @@ impl UserData for &'static Preloaders {
 				Some(matcher) => matcher,
 				None => me.into(),
 			})
+		});
+
+		methods.add_method("insert", |_, &me, (index, preloader): (isize, PreloaderArc)| {
+			let index = match index {
+				1.. => index - 1,
+				0 => return Err("index must be 1-based or negative".into_lua_err()),
+				_ => index,
+			};
+
+			me.insert(index, preloader.clone()).into_lua_err()?;
+			Ok(preloader)
+		});
+
+		methods.add_method("remove", |_, &me, matcher: PreloaderMatcher| {
+			me.remove(matcher);
+			Ok(())
 		});
 
 		methods.add_meta_method(MetaMethod::Len, |_, me, ()| Ok(me.load().len()));

--- a/yazi-config/src/plugin/spotter_arc.rs
+++ b/yazi-config/src/plugin/spotter_arc.rs
@@ -1,6 +1,6 @@
 use std::{ops::{Deref, DerefMut}, sync::Arc};
 
-use mlua::{UserData, UserDataFields};
+use mlua::{FromLua, Lua, LuaSerdeExt, UserData, UserDataFields, Value};
 use serde::Deserialize;
 use yazi_shim::mlua::UserDataFieldsExt;
 
@@ -24,6 +24,12 @@ impl From<Spotter> for SpotterArc {
 }
 
 impl Mixable for SpotterArc {}
+
+impl FromLua for SpotterArc {
+	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+		Ok(lua.from_value::<Spotter>(value)?.into())
+	}
+}
 
 impl UserData for SpotterArc {
 	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {

--- a/yazi-config/src/plugin/spotters.rs
+++ b/yazi-config/src/plugin/spotters.rs
@@ -1,13 +1,14 @@
 use std::{borrow::Cow, ops::Deref, sync::Arc};
 
 use arc_swap::ArcSwap;
-use mlua::{MetaMethod, UserData, UserDataMethods};
+use mlua::{ExternalError, ExternalResult, MetaMethod, UserData, UserDataMethods};
 use serde::Deserialize;
 use yazi_fs::file::File;
 use yazi_shared::id::Id;
-use yazi_shim::arc_swap::IntoPointee;
+use yazi_shim::{arc_swap::{ArcSwapExt, IntoPointee}, vec::{IndexAtError, VecExt}};
 
-use crate::plugin::{SpotterArc, SpotterMatcher};
+use super::Spotter;
+use crate::{mix, plugin::{SpotterArc, SpotterMatcher}};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Spotters(ArcSwap<Vec<SpotterArc>>);
@@ -41,6 +42,32 @@ impl Spotters {
 		}
 	}
 
+	pub fn insert(&self, index: isize, spotter: SpotterArc) -> Result<(), IndexAtError> {
+		self.0.try_rcu(|spotters| {
+			let i = spotters.index_at(index)?;
+			if i == spotters.len() {
+				Ok(mix(Vec::<Spotter>::new(), spotters.iter().cloned(), [spotter.clone()]))
+			} else {
+				let (before, after) = spotters.split_at(i);
+				Ok(mix(
+					Vec::<Spotter>::new(),
+					before.iter().cloned().chain([spotter.clone()]).chain(after.iter().cloned()),
+					Vec::<Spotter>::new(),
+				))
+			}
+		})?;
+
+		Ok(())
+	}
+
+	pub fn remove(&self, matcher: SpotterMatcher) {
+		self.0.rcu(|spotters| {
+			let mut next = Vec::clone(spotters);
+			next.retain(|spotter| !matcher.matches(spotter));
+			next
+		});
+	}
+
 	pub(crate) fn unwrap_unchecked(self) -> Vec<SpotterArc> {
 		Arc::try_unwrap(self.0.into_inner()).expect("unique spotters arc")
 	}
@@ -53,6 +80,22 @@ impl UserData for &'static Spotters {
 				Some(matcher) => matcher,
 				None => me.into(),
 			})
+		});
+
+		methods.add_method("insert", |_, &me, (index, spotter): (isize, SpotterArc)| {
+			let index = match index {
+				1.. => index - 1,
+				0 => return Err("index must be 1-based or negative".into_lua_err()),
+				_ => index,
+			};
+
+			me.insert(index, spotter.clone()).into_lua_err()?;
+			Ok(spotter)
+		});
+
+		methods.add_method("remove", |_, &me, matcher: SpotterMatcher| {
+			me.remove(matcher);
+			Ok(())
 		});
 
 		methods.add_meta_method(MetaMethod::Len, |_, me, ()| Ok(me.load().len()));

--- a/yazi-core/src/tasks/prework.rs
+++ b/yazi-core/src/tasks/prework.rs
@@ -1,5 +1,6 @@
-use yazi_config::{YAZI, plugin::MAX_FETCHERS};
+use yazi_config::{YAZI, plugin::{FetcherMatcher, MAX_FETCHERS}};
 use yazi_fs::{Entries, FsHash64, SortBy, file::{File, FileSig}};
+use yazi_scheduler::Loaded;
 use yazi_shared::pool::InternStr;
 
 use super::Tasks;
@@ -7,22 +8,24 @@ use crate::mgr::Mimetype;
 
 impl Tasks {
 	pub fn fetch_paged(&self, paged: &[File], mimetype: &Mimetype) {
+		let fetchers = YAZI.plugin.fetchers.load_full();
 		let mut loaded = self.scheduler.fetch.loaded.lock();
 		let mut tasks: [Vec<_>; MAX_FETCHERS as usize] = Default::default();
+
 		for f in paged {
 			let hash = FileSig(f).hash_u64();
-			for g in YAZI.plugin.fetchers.matches(f, mimetype.get(&f.url).unwrap_or_default()) {
-				match loaded.get_mut(&hash) {
-					Some(n) if *n & (1 << g.idx) != 0 => continue,
-					Some(n) => *n |= 1 << g.idx,
-					None => _ = loaded.put(hash, 1 << g.idx),
+			for g in FetcherMatcher::new(&fetchers, f, mimetype.get(&f.url).unwrap_or_default()) {
+				let fresh = match loaded.get_mut(&hash) {
+					Some(l) => l.mark(g.idx, g.rev),
+					None => loaded.put(hash, Loaded::new(g.idx, g.rev)).is_none(),
+				};
+				if fresh {
+					tasks[g.idx as usize].push(f.clone());
 				}
-				tasks[g.idx as usize].push(f.clone());
 			}
 		}
 
 		drop(loaded);
-		let fetchers = YAZI.plugin.fetchers.load();
 		for (i, tasks) in tasks.into_iter().enumerate() {
 			if !tasks.is_empty() {
 				self.scheduler.fetch_paged(fetchers[i].clone(), tasks);
@@ -36,12 +39,13 @@ impl Tasks {
 			let hash = FileSig(f).hash_u64();
 			let mime = mimetype.get(&f.url).unwrap_or_default();
 			for p in YAZI.plugin.preloaders.matches(f, mime) {
-				match loaded.get_mut(&hash) {
-					Some(n) if *n & (1 << p.idx) != 0 => continue,
-					Some(n) => *n |= 1 << p.idx,
-					None => _ = loaded.put(hash, 1 << p.idx),
+				let fresh = match loaded.get_mut(&hash) {
+					Some(l) => l.mark(p.idx, p.rev),
+					None => loaded.put(hash, Loaded::new(p.idx, p.rev)).is_none(),
+				};
+				if fresh {
+					self.scheduler.preload_paged(p, f, mime.intern());
 				}
-				self.scheduler.preload_paged(p, f, mime.intern());
 			}
 		}
 	}

--- a/yazi-scheduler/src/fetch/fetch.rs
+++ b/yazi-scheduler/src/fetch/fetch.rs
@@ -8,12 +8,12 @@ use yazi_config::Priority;
 use yazi_macro::error;
 use yazi_runner::RUNNER;
 
-use crate::{HIGH, LOW, TaskOp, TaskOps, fetch::{FetchIn, FetchInFetch, FetchOutFetch}};
+use crate::{HIGH, LOW, Loaded, TaskOp, TaskOps, fetch::{FetchIn, FetchInFetch, FetchOutFetch}};
 
 pub struct Fetch {
 	ops:        TaskOps,
 	tx:         async_priority_channel::Sender<FetchIn, u8>,
-	pub loaded: Mutex<LruCache<u64, u16>>,
+	pub loaded: Mutex<LruCache<u64, Loaded>>,
 }
 
 impl Fetch {
@@ -33,7 +33,7 @@ impl Fetch {
 
 		for status in RUNNER.fetch(task.into()).await? {
 			if status.retry {
-				self.loaded.lock().get_mut(&status.hash).map(|x| *x &= !(1 << fetcher.idx));
+				self.loaded.lock().get_mut(&status.hash).map(|x| x.clear(fetcher.idx, fetcher.rev));
 			}
 			if let Some(e) = status.error {
 				error!("Error when running fetcher '{}':\n{e:?}", fetcher.name);

--- a/yazi-scheduler/src/hook/hook.rs
+++ b/yazi-scheduler/src/hook/hook.rs
@@ -105,7 +105,7 @@ impl Hook {
 	// --- Preload
 	pub(crate) async fn preload(&self, task: HookInPreload) {
 		if !self.ongoing.lock().intact(task.id) {
-			self.preload.loaded.lock().get_mut(&task.hash).map(|x| *x &= !(1 << task.idx));
+			self.preload.loaded.lock().get_mut(&task.hash).map(|x| x.clear(task.idx, task.rev));
 		}
 
 		self.ops.out(task.id, PreloadOut::Clean);

--- a/yazi-scheduler/src/hook/in.rs
+++ b/yazi-scheduler/src/hook/in.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use yazi_config::plugin::PreloaderArc;
 use yazi_shared::{id::Id, url::{UrlBuf, UrlLike}};
 
 use crate::{Task, TaskIn, TaskProg};
@@ -351,6 +352,7 @@ impl HookInUpload {
 pub(crate) struct HookInPreload {
 	pub(crate) id:   Id,
 	pub(crate) idx:  u8,
+	pub(crate) rev:  u16,
 	pub(crate) hash: u64,
 }
 
@@ -368,5 +370,7 @@ impl TaskIn for HookInPreload {
 }
 
 impl HookInPreload {
-	pub(crate) fn new(idx: u8, hash: u64) -> Self { Self { id: Id::ZERO, idx, hash } }
+	pub(crate) fn new(preloader: &PreloaderArc, hash: u64) -> Self {
+		Self { id: Id::ZERO, idx: preloader.idx, rev: preloader.rev, hash }
+	}
 }

--- a/yazi-scheduler/src/lib.rs
+++ b/yazi-scheduler/src/lib.rs
@@ -2,7 +2,7 @@ mod macros;
 
 yazi_macro::mod_pub!(custom fetch file hook plugin preload process size);
 
-yazi_macro::mod_flat!(behavior cleanup handle ongoing op out progress proxy r#in scheduler snap status summary task worker);
+yazi_macro::mod_flat!(behavior cleanup handle loaded ongoing op out progress proxy r#in scheduler snap status summary task worker);
 
 const LOW: u8 = yazi_config::Priority::Low as u8;
 const NORMAL: u8 = yazi_config::Priority::Normal as u8;

--- a/yazi-scheduler/src/loaded.rs
+++ b/yazi-scheduler/src/loaded.rs
@@ -1,0 +1,32 @@
+#[derive(Clone, Copy, Debug)]
+pub struct Loaded(u32);
+
+impl Loaded {
+	pub fn new(idx: u8, rev: u16) -> Self {
+		debug_assert!(idx < 16);
+
+		Self(u32::from(rev) << 16 | 1u32 << idx)
+	}
+
+	pub fn mark(&mut self, idx: u8, rev: u16) -> bool {
+		debug_assert!(idx < 16);
+
+		let (idx, rev) = (1u32 << idx, rev as u32);
+		if self.0 >> 16 != rev {
+			self.0 = rev << 16;
+		} else if self.0 & idx != 0 {
+			return false;
+		}
+
+		self.0 |= idx;
+		true
+	}
+
+	pub fn clear(&mut self, idx: u8, rev: u16) {
+		debug_assert!(idx < 16);
+
+		if self.0 >> 16 == rev as u32 {
+			self.0 &= !(1u32 << idx);
+		}
+	}
+}

--- a/yazi-scheduler/src/preload/preload.rs
+++ b/yazi-scheduler/src/preload/preload.rs
@@ -10,13 +10,13 @@ use yazi_macro::error;
 use yazi_runner::{RUNNER, preloader::{PreloadError, PreloadJob}};
 use yazi_shared::id::Id;
 
-use crate::{HIGH, LOW, NORMAL, TaskOp, TaskOps, preload::{PreloadIn, PreloadInPreload, PreloadOut}};
+use crate::{HIGH, LOW, Loaded, NORMAL, TaskOp, TaskOps, preload::{PreloadIn, PreloadInPreload, PreloadOut}};
 
 pub struct Preload {
 	ops: TaskOps,
 	tx:  async_priority_channel::Sender<PreloadIn, u8>,
 
-	pub loaded:  Mutex<LruCache<u64, u16>>,
+	pub loaded:  Mutex<LruCache<u64, Loaded>>,
 	pub loading: Mutex<LruCache<u64, Id>>,
 }
 
@@ -51,7 +51,7 @@ impl Preload {
 		};
 
 		if !state.complete {
-			self.loaded.lock().get_mut(&hash).map(|x| *x &= !(1 << task.preloader.idx));
+			self.loaded.lock().get_mut(&hash).map(|x| x.clear(task.preloader.idx, task.preloader.rev));
 		}
 		if let Some(e) = state.error {
 			error!("Error when running preloader '{}':\n{e}", task.preloader.name);

--- a/yazi-scheduler/src/scheduler.rs
+++ b/yazi-scheduler/src/scheduler.rs
@@ -189,7 +189,7 @@ impl Scheduler {
 	}
 
 	pub fn preload_paged(&self, preloader: PreloaderArc, file: &File, mime: Symbol<str>) {
-		let hook = HookInPreload::new(preloader.idx, FileSig(file).hash_u64());
+		let hook = HookInPreload::new(&preloader, FileSig(file).hash_u64());
 		let mut r#in = PreloadInPreload { id: Id::ZERO, preloader, file: file.clone(), mime };
 
 		self.add_hooked(&mut r#in, hook, |_| ());


### PR DESCRIPTION
This is a follow-up to https://github.com/sxyazi/yazi/pull/3891 and extends the dynamic plugin Lua API to spotters, preloaders, and fetchers.

Note that this is experimental at the moment. Please file a bug report if you find any weird behavior.

## Fetcher

```lua
-- prepend a fetcher for `*.txt` files
local fetcher = rt.plugin.fetchers:insert(1, {
  url = "*.txt",
  run = "count-lines",
  group = "count",
})

-- loop through all fetchers
for i, f in pairs(rt.plugin.fetchers:match()) do
  ya.dbg(i, f.name)
end

-- remove a fetcher
rt.plugin.fetchers:remove { id = fetcher.id }
```

## Spotter

```lua
-- prepend a spotter for PDF files
local spotter = rt.plugin.spotters:insert(1, {
  mime = "application/pdf",
  run = "spot-pdf",
})

-- loop through all spotters
for i, s in pairs(rt.plugin.spotters:match()) do
  ya.dbg(i, s.name)
end

-- remove a spotter
rt.plugin.spotters:remove { id = spotter.id }
```

## Preloader

```lua
-- prepend a preloader for PDF files
local preloader = rt.plugin.preloaders:insert(1, {
  mime = "application/pdf",
  run = "preload-pdf",
})

-- loop through all preloaders
for i, p in pairs(rt.plugin.preloaders:match()) do
  ya.dbg(i, p.name)
end

-- remove a preloader
rt.plugin.preloaders:remove { id = preloader.id }
```
