### PR TITLE
fix: input value style not applied when the input is empty

### DIFF
--- a/yazi-widgets/src/input/widget.rs
+++ b/yazi-widgets/src/input/widget.rs
@@ -12,6 +12,7 @@ impl Widget for &Input {
 		let normal = self.styles.normal.unwrap_or_default();
 		let selected = self.styles.selected.unwrap_or_default();
 
+		buf.set_style(Rect { height: area.height.min(1), ..area }, normal);
 		Line::styled(self.display(), normal).render(area, buf);
 
 		if let Some(Range { start, end }) = self.selected() {

--- a/yazi-widgets/src/input/widget.rs
+++ b/yazi-widgets/src/input/widget.rs
@@ -12,7 +12,7 @@ impl Widget for &Input {
 		let normal = self.styles.normal.unwrap_or_default();
 		let selected = self.styles.selected.unwrap_or_default();
 
-		buf.set_style(Rect { height: area.height.min(1), ..area }, normal);
+		buf.set_style(area, normal);
 		Line::styled(self.display(), normal).render(area, buf);
 
 		if let Some(Range { start, end }) = self.selected() {


### PR DESCRIPTION
## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #4238

## Rationale of this PR

Value row gets styled unconditionally. Claude Opus 5 reproduced it and traced the cause: 
`display()` returns unpadded text, and `ratatui-core`'s `render_with_alignment` has `if line_width == 0 { return; }` sitting above `buf.set_style` seen [here](https://github.com/ratatui/ratatui/blob/ratatui-core-v0.1.2/ratatui-core/src/text/line.rs#L726-L728)

Upstream might justify the early return as an optimisation, so I thought a fix here would be appropriate.
Claude suggested to guard for display() when empty, but that would introduce a branch and a second display() call to skip a no-op.

I would be happy to re-implement if necessary. 

## AI Policy
PR was created by me, changes were suggested by Claude Opus 5. I have reviewed, compiled and tested the changes myself and am able to justify.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

<!-- AI bots are not allowed to open PRs in this repository. All PRs must be made by humans and comply with the AI policy. -->
