### PR TITLE
feat: new `relay-update-files` customizes which tabs get file updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 - New `theme` DDS event for plugins to watch theme reloads ([#4203])
 - Preview images in Zellij via kitty graphics protocol ([#4216])
 - Image preview with Überzug++ on Niri ([#3990])
-- New `ind-watch` DDS event for custom file watching ([#4237])
 - Unicode normalization for user regex patterns in `find`, `filter`, and `search` actions ([#4177])
 - New gait for input `backward` and `forward` actions ([#4012])
 
@@ -1816,4 +1815,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4225]: https://github.com/sxyazi/yazi/pull/4225
 [#4228]: https://github.com/sxyazi/yazi/pull/4228
 [#4235]: https://github.com/sxyazi/yazi/pull/4235
-[#4237]: https://github.com/sxyazi/yazi/pull/4237

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
+checksum = "337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e"
 dependencies = [
  "generic-array 0.14.9",
  "rustversion",
@@ -1670,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1684,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1711,16 +1711,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1731,15 +1732,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2145,9 +2146,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2844,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3257,7 +3258,7 @@ dependencies = [
  "elliptic-curve",
  "enum_dispatch",
  "futures",
- "generic-array 1.4.4",
+ "generic-array 1.4.5",
  "getrandom 0.4.3",
  "ghash",
  "hex-literal",
@@ -4135,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5056,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -5856,9 +5857,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5867,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5878,13 +5879,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,7 @@ dependencies = [
  "windows 0.62.2",
  "windows-sys 0.61.2",
  "yazi-binding",
+ "yazi-codegen",
  "yazi-ffi",
  "yazi-macro",
  "yazi-shared",

--- a/yazi-actor/src/context.rs
+++ b/yazi-actor/src/context.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use std::{mem, ops::{Deref, DerefMut}};
 
 use anyhow::{Result, anyhow};
 use yazi_core::{Core, mgr::Tabs, tab::{Folder, Tab}};
@@ -29,12 +29,7 @@ impl DerefMut for Ctx<'_> {
 impl<'a> Ctx<'a> {
 	pub fn new(action: &Action, core: &'a mut Core, term: &'a mut Option<Raterm>) -> Result<Self> {
 		let tab = if let Ok(id) = action.get::<Id>("tab") {
-			core
-				.mgr
-				.tabs
-				.iter()
-				.position(|t| t.id == id)
-				.ok_or_else(|| anyhow!("Tab with id {id} not found"))?
+			core.mgr.tabs.idx(id).ok_or_else(|| anyhow!("Tab with id {id} not found"))?
 		} else {
 			core.mgr.tabs.cursor
 		};
@@ -48,6 +43,16 @@ impl<'a> Ctx<'a> {
 			#[cfg(debug_assertions)]
 			backtrace: vec![],
 		})
+	}
+
+	pub fn with<F, T>(&mut self, tab: usize, f: F) -> T
+	where
+		F: FnOnce(&mut Self) -> T,
+	{
+		let prev = mem::replace(&mut self.tab, tab);
+		let result = f(self);
+		self.tab = prev;
+		result
 	}
 
 	pub fn renew<'b>(cx: &'a mut Ctx<'b>) -> Self {

--- a/yazi-actor/src/lives/folder.rs
+++ b/yazi-actor/src/lives/folder.rs
@@ -39,6 +39,7 @@ impl Folder {
 impl UserData for Folder {
 	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
 		fields.add_cached_field("cwd", |_, me| Ok(me.url.clone()));
+		fields.add_cached_field("file", |_, me| Ok(me.file.clone()));
 		fields.add_static_field("files", |_, me| Entries::make(0..me.entries.len(), me, &me.tab));
 		fields.add_cached_field("stage", |_, me| Ok(me.stage.clone()));
 		fields.add_static_field("window", |_, me| Entries::make(me.window.clone(), me, &me.tab));

--- a/yazi-actor/src/mgr/update_files.rs
+++ b/yazi-actor/src/mgr/update_files.rs
@@ -1,9 +1,11 @@
+use std::iter;
+
 use anyhow::Result;
 use yazi_core::{Invalidator, Reconciler};
 use yazi_fs::FilesOp;
 use yazi_macro::{act, render, succ};
-use yazi_parser::mgr::UpdateFilesForm;
-use yazi_shared::{data::Data, url::UrlLike};
+use yazi_parser::{mgr::UpdateFilesForm, spark::SparkKind};
+use yazi_shared::{Source, data::Data, url::UrlLike};
 use yazi_watcher::local::LINKED;
 
 use crate::{Actor, Ctx};
@@ -16,20 +18,39 @@ impl Actor for UpdateFiles {
 	const NAME: &str = "update_files";
 
 	fn act(cx: &mut Ctx, form: Self::Form) -> Result<Data> {
-		let tab = cx.tab;
-		let revision = cx.current().entries.revision;
 		let linked: Vec<_> = LINKED.read().from_dir(form.op.cwd()).map(|u| form.op.chdir(u)).collect();
+		let ops: Vec<_> = iter::once(form.op).chain(linked).collect();
 
-		for op in [form.op].into_iter().chain(linked) {
-			Invalidator::new(&mut cx.mgr).apply(&op);
-			Reconciler::new(&mut cx.mgr, tab).apply(&op);
-			Self::update_tab(cx, op).ok();
+		for op in &ops {
+			Invalidator::new(&mut cx.mgr).apply(op);
+			Reconciler::new(cx.tab, &mut cx.mgr).apply(op);
+		}
+		render!(cx.mgr.yanked.catchup_revision(false));
+
+		let tabs = cx.tabs().indices_or_active(form.tabs);
+		let Some((&last, tabs)) = tabs.split_last() else { succ!() };
+
+		for &tab in tabs {
+			cx.with(tab, |cx| Self::update_tab(cx, ops.iter().cloned()))?;
+		}
+		cx.with(last, |cx| Self::update_tab(cx, ops))
+	}
+
+	fn hook(cx: &Ctx, _: &Self::Form) -> Option<SparkKind> {
+		(cx.source() == Source::Relay).then_some(SparkKind::RelayUpdateFiles)
+	}
+}
+
+impl UpdateFiles {
+	fn update_tab(cx: &mut Ctx, ops: impl IntoIterator<Item = FilesOp>) -> Result<Data> {
+		let revision = cx.current().entries.revision;
+
+		for op in ops {
+			Self::update_pane(cx, op).ok();
 		}
 
-		render!(cx.mgr.yanked.catchup_revision(false));
 		act!(mgr:hidden, cx).ok();
 		act!(mgr:sort, cx).ok();
-
 		if revision != cx.current().entries.revision {
 			act!(mgr:hover, cx)?;
 			act!(mgr:peek, cx)?;
@@ -38,10 +59,8 @@ impl Actor for UpdateFiles {
 		}
 		succ!();
 	}
-}
 
-impl UpdateFiles {
-	fn update_tab(cx: &mut Ctx, op: FilesOp) -> Result<Data> {
+	fn update_pane(cx: &mut Ctx, op: FilesOp) -> Result<Data> {
 		let url = op.cwd();
 
 		if url == cx.cwd() {

--- a/yazi-actor/src/mgr/update_files.rs
+++ b/yazi-actor/src/mgr/update_files.rs
@@ -51,6 +51,7 @@ impl UpdateFiles {
 
 		act!(mgr:hidden, cx).ok();
 		act!(mgr:sort, cx).ok();
+
 		if revision != cx.current().entries.revision {
 			act!(mgr:hover, cx)?;
 			act!(mgr:peek, cx)?;

--- a/yazi-actor/src/mgr/watch.rs
+++ b/yazi-actor/src/mgr/watch.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use anyhow::Result;
-use yazi_macro::succ;
+use yazi_macro::{succ, tab};
 use yazi_parser::{mgr::WatchForm, spark::SparkKind};
 use yazi_shared::{Source, data::Data};
 
@@ -19,7 +19,7 @@ impl Actor for Watch {
 			succ!(cx.core.mgr.watcher.watch(form.files));
 		}
 
-		let tab = cx.core.mgr.tabs.active();
+		let tab = tab!(cx);
 		let it = iter::once(&tab.current.file)
 			.chain(tab.hovered_folder().map(|h| &h.file).or(tab.hovered().filter(|f| f.is_dir())))
 			.chain(tab.parent.as_ref().map(|p| &p.file));

--- a/yazi-core/src/mgr/tabs.rs
+++ b/yazi-core/src/mgr/tabs.rs
@@ -3,6 +3,7 @@ use std::ops::{Deref, DerefMut};
 use yazi_dds::Pubsub;
 use yazi_fs::file::File;
 use yazi_macro::log_if_err;
+use yazi_shared::id::Id;
 
 use crate::tab::{Folder, Tab};
 
@@ -15,7 +16,20 @@ impl Default for Tabs {
 	fn default() -> Self { Self { cursor: 0, items: vec![Default::default()] } }
 }
 
+impl Deref for Tabs {
+	type Target = Vec<Tab>;
+
+	fn deref(&self) -> &Self::Target { &self.items }
+}
+
+impl DerefMut for Tabs {
+	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.items }
+}
+
 impl Tabs {
+	#[inline]
+	pub fn idx(&self, id: Id) -> Option<usize> { self.items.iter().position(|tab| tab.id == id) }
+
 	pub fn set_idx(&mut self, idx: usize) {
 		// Reset the preview of the last active tab
 		if let Some(active) = self.items.get_mut(self.cursor) {
@@ -24,6 +38,14 @@ impl Tabs {
 
 		self.cursor = idx;
 		log_if_err!(Pubsub::pub_after_tab(self.active().id));
+	}
+
+	pub fn indices_or_active(&self, ids: Vec<Id>) -> Vec<usize> {
+		if ids.is_empty() {
+			vec![self.cursor]
+		} else {
+			ids.into_iter().filter_map(|id| self.idx(id)).collect()
+		}
 	}
 }
 
@@ -42,14 +64,4 @@ impl Tabs {
 
 	#[inline]
 	pub fn hovered(&self) -> Option<&File> { self.current().hovered() }
-}
-
-impl Deref for Tabs {
-	type Target = Vec<Tab>;
-
-	fn deref(&self) -> &Self::Target { &self.items }
-}
-
-impl DerefMut for Tabs {
-	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.items }
 }

--- a/yazi-core/src/reconciler.rs
+++ b/yazi-core/src/reconciler.rs
@@ -10,7 +10,7 @@ pub struct Reconciler<'a> {
 }
 
 impl<'a> Reconciler<'a> {
-	pub fn new(mgr: &'a mut Mgr, tab: usize) -> Self {
+	pub fn new(tab: usize, mgr: &'a mut Mgr) -> Self {
 		let Mgr { tabs, yanked, .. } = mgr;
 		Self { selected: &mut tabs[tab].selected, yanked }
 	}

--- a/yazi-fs/Cargo.toml
+++ b/yazi-fs/Cargo.toml
@@ -17,6 +17,7 @@ cfg_aliases = "0.2.2"
 
 [dependencies]
 yazi-binding = { path = "../yazi-binding", version = "26.5.6" }
+yazi-codegen = { path = "../yazi-codegen", version = "26.5.6" }
 yazi-ffi     = { path = "../yazi-ffi", version = "26.5.6" }
 yazi-macro   = { path = "../yazi-macro", version = "26.5.6" }
 yazi-shared  = { path = "../yazi-shared", version = "26.5.6" }

--- a/yazi-fs/src/file/data.rs
+++ b/yazi-fs/src/file/data.rs
@@ -1,8 +1,8 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use yazi_macro::impl_data_any;
 use yazi_shared::data::Data;
 
-use crate::file::File;
+use crate::file::{File, Files};
 
 impl_data_any!(File, from_into_lua = inherit);
 
@@ -19,5 +19,23 @@ impl TryFrom<&Data> for File {
 
 	fn try_from(value: &Data) -> Result<Self, Self::Error> {
 		value.as_any::<Self>().cloned().ok_or_else(|| anyhow!("not a File"))
+	}
+}
+
+impl TryFrom<Data> for Files {
+	type Error = anyhow::Error;
+
+	fn try_from(value: Data) -> Result<Self, Self::Error> {
+		let Data::List(files) = value else { bail!("not a list of Files") };
+		files.into_iter().map(File::try_from).collect::<Result<_, _>>().map(Self)
+	}
+}
+
+impl TryFrom<&Data> for Files {
+	type Error = anyhow::Error;
+
+	fn try_from(value: &Data) -> Result<Self, Self::Error> {
+		let Data::List(files) = value else { bail!("not a list of Files") };
+		files.iter().map(File::try_from).collect::<Result<_, _>>().map(Self)
 	}
 }

--- a/yazi-fs/src/file/files.rs
+++ b/yazi-fs/src/file/files.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use std::{ops::{Deref, DerefMut}, vec};
 
 use mlua::{FromLua, IntoLua, Lua, Value};
 use yazi_shared::url::UrlBuf;
@@ -34,6 +34,13 @@ impl Files {
 	pub fn hashes(&self) -> impl Iterator<Item = u64> + '_ {
 		self.iter().map(|f| FileSig(f).hash_u64())
 	}
+}
+
+impl IntoIterator for Files {
+	type IntoIter = vec::IntoIter<File>;
+	type Item = File;
+
+	fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
 }
 
 impl FromLua for Files {

--- a/yazi-fs/src/op.rs
+++ b/yazi-fs/src/op.rs
@@ -1,6 +1,8 @@
 use std::{iter, path::Path};
 
 use hashbrown::{HashMap, HashSet};
+use mlua::{UserData, UserDataFields};
+use yazi_codegen::FromLuaOwned;
 use yazi_macro::{impl_data_any, relay};
 use yazi_shared::{id::{Id, Ids}, path::{PathBufDyn, PathLike}, url::{UrlBuf, UrlLike, UrlMapExt}};
 
@@ -8,7 +10,7 @@ use crate::file::File;
 
 pub static FILES_TICKET: Ids = Ids::new();
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, FromLuaOwned)]
 pub enum FilesOp {
 	Full(File, Vec<File>),
 	Part(UrlBuf, Vec<File>, Id),
@@ -22,7 +24,7 @@ pub enum FilesOp {
 	Upserting(UrlBuf, HashMap<PathBufDyn, File>),
 }
 
-impl_data_any!(FilesOp);
+impl_data_any!(FilesOp, from_into_lua = inherit);
 
 impl FilesOp {
 	pub fn cwd(&self) -> &UrlBuf {
@@ -152,5 +154,11 @@ impl FilesOp {
 			Self::Updating(_, map) => Self::Updating(w, map!(map)),
 			Self::Upserting(_, map) => Self::Upserting(w, map!(map)),
 		}
+	}
+}
+
+impl UserData for FilesOp {
+	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
+		fields.add_field_method_get("cwd", |_, me| Ok(me.cwd().clone()));
 	}
 }

--- a/yazi-parser/src/mgr/update_files.rs
+++ b/yazi-parser/src/mgr/update_files.rs
@@ -1,11 +1,12 @@
 use anyhow::bail;
-use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use mlua::{FromLua, IntoLua, Lua, Table, Value};
 use yazi_fs::FilesOp;
-use yazi_shared::event::ActionCow;
+use yazi_shared::{event::ActionCow, id::Id};
 
 #[derive(Debug)]
 pub struct UpdateFilesForm {
-	pub op: FilesOp,
+	pub op:   FilesOp,
+	pub tabs: Vec<Id>,
 }
 
 impl TryFrom<ActionCow> for UpdateFilesForm {
@@ -16,18 +17,26 @@ impl TryFrom<ActionCow> for UpdateFilesForm {
 			bail!("Invalid 'op' in UpdateFilesForm");
 		};
 
-		Ok(Self { op })
+		Ok(Self { op, tabs: vec![] })
 	}
 }
 
 impl From<FilesOp> for UpdateFilesForm {
-	fn from(op: FilesOp) -> Self { Self { op } }
+	fn from(op: FilesOp) -> Self { Self { op, tabs: vec![] } }
 }
 
 impl FromLua for UpdateFilesForm {
-	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
+	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+		let t = Table::from_lua(value, lua)?;
+
+		Ok(Self { op: t.raw_get("op")?, tabs: t.raw_get("tabs")? })
+	}
 }
 
 impl IntoLua for UpdateFilesForm {
-	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		lua
+			.create_table_from([("op", self.op.into_lua(lua)?), ("tabs", self.tabs.into_lua(lua)?)])?
+			.into_lua(lua)
+	}
 }

--- a/yazi-parser/src/mgr/watch.rs
+++ b/yazi-parser/src/mgr/watch.rs
@@ -1,26 +1,30 @@
-use mlua::{FromLua, IntoLua, Lua, Value};
-use yazi_fs::file::File;
+use mlua::{FromLua, IntoLua, Lua, Table, Value};
+use yazi_fs::file::Files;
 use yazi_shared::event::ActionCow;
 
 #[derive(Debug, Default)]
 pub struct WatchForm {
-	pub files: Vec<File>,
+	pub files: Files,
 }
 
 impl From<ActionCow> for WatchForm {
-	fn from(mut a: ActionCow) -> Self { Self { files: a.take_seq() } }
+	fn from(mut a: ActionCow) -> Self { Self { files: a.take("files").unwrap_or_default() } }
 }
 
-impl From<Vec<File>> for WatchForm {
-	fn from(files: Vec<File>) -> Self { Self { files } }
+impl From<Files> for WatchForm {
+	fn from(files: Files) -> Self { Self { files } }
 }
 
 impl FromLua for WatchForm {
 	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
-		Ok(Self { files: Vec::from_lua(value, lua)? })
+		let t = Table::from_lua(value, lua)?;
+
+		Ok(Self { files: t.raw_get("files")? })
 	}
 }
 
 impl IntoLua for WatchForm {
-	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> { self.files.into_lua(lua) }
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		lua.create_table_from([("files", self.files)])?.into_lua(lua)
+	}
 }

--- a/yazi-parser/src/spark/kind.rs
+++ b/yazi-parser/src/spark/kind.rs
@@ -17,6 +17,8 @@ pub enum SparkKind {
 	// mgr:stash
 	IndStash,
 	RelayStash,
+	// mgr:update_files
+	RelayUpdateFiles,
 	// mgr:watch
 	IndWatch,
 	// mgr:quit

--- a/yazi-parser/src/spark/spark.rs
+++ b/yazi-parser/src/spark/spark.rs
@@ -184,6 +184,8 @@ impl<'a> Spark<'a> {
 			// mgr:stash
 			IndStash => Self::Stash(<_>::from_lua(value, lua)?),
 			RelayStash => Self::Stash(<_>::from_lua(value, lua)?),
+			// mgr:update_files
+			RelayUpdateFiles => Self::UpdateFiles(<_>::from_lua(value, lua)?),
 			// mgr:watch
 			IndWatch => Self::Watch(<_>::from_lua(value, lua)?),
 			// mgr:quit


### PR DESCRIPTION
Resolves https://github.com/terrakok/split-tabs.yazi/issues/7#issuecomment-4472777655 - turns out https://github.com/sxyazi/yazi/pull/4237 alone is not enough to solve the problem, so this is another one.