### PR TITLE
fix: work around `tmux` 3.7b passthrough breakage

### DIFF
--- a/yazi-emulator/src/mux.rs
+++ b/yazi-emulator/src/mux.rs
@@ -21,7 +21,7 @@ impl Mux {
 				"set",
 				"-p",
 				"allow-passthrough",
-				"on",
+				"all",
 				";",
 				"set",
 				"-s",


### PR DESCRIPTION
Fixes https://github.com/sxyazi/yazi/issues/4243

`tmux` 3.7b breaks passthrough so badly, it's not just the escape sequences being passed through to the terminal that get dropped, but also the ones passed back from the terminal get dropped too. 

This is a follow-up to https://github.com/sxyazi/yazi/pull/4195, where the [same redraw bug](https://github.com/tmux/tmux/pull/5366) broke image previews as well. 

This PR sets `allow-passthrough` to `all` to work around this bug for now utill `tmux` releases its next version that includes [the fix](https://github.com/tmux/tmux/commit/565db46a1947b829af00bb2ff4acbc0b8c189fcd) for that.