### PR TITLE
fix: correct open rule matching for trashed directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 ### Fixed
 
 - Assertion failure on expanding URLs with variables containing absolute paths ([#4256])
+- Correct open rule matching for trashed directories ([#4268])
 - Wait for terminal probe echo back before stopping instance ([#4271])
 - Avoid flicker caused by screen clear on final response from terminal ([#4250])
 - Fall back when `vergen` cannot determine Git SHA ([#4252])
@@ -1835,4 +1836,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4256]: https://github.com/sxyazi/yazi/pull/4256
 [#4260]: https://github.com/sxyazi/yazi/pull/4260
 [#4265]: https://github.com/sxyazi/yazi/pull/4265
+[#4268]: https://github.com/sxyazi/yazi/pull/4268
 [#4271]: https://github.com/sxyazi/yazi/pull/4271

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -71,7 +71,7 @@ trash = [
 [open]
 rules = [
 	# Folder
-	{ url = "*/", use = [ "edit", "open", "reveal" ] },
+	{ mime = "folder/*", use = [ "edit", "open", "reveal" ] },
 	# Text
 	{ mime = "text/*", use = [ "edit", "reveal" ] },
 	# Image
@@ -117,7 +117,7 @@ spotters = [
 	# Trash
 	{ mime = "trash/**", run = "trash" },
 	# Folder
-	{ url = "*/", run = "folder" },
+	{ mime = "folder/*", run = "folder" },
 	# Code
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
@@ -150,7 +150,7 @@ preloaders = [
 	{ mime = "trash/**", run = "trash" },
 ]
 previewers = [
-	{ url = "*/", run = "folder" },
+	{ mime = "folder/*", run = "folder" },
 	# Code
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },

--- a/yazi-config/preset/yazi-default.toml
+++ b/yazi-config/preset/yazi-default.toml
@@ -114,8 +114,6 @@ fetchers = [
 spotters = [
 	# Multi-file
 	{ mime = "multi/*", run = "multi" },
-	# Trash
-	{ mime = "trash/**", run = "trash" },
 	# Folder
 	{ mime = "folder/*", run = "folder" },
 	# Code
@@ -129,6 +127,8 @@ spotters = [
 	{ mime = "video/*", run = "video" },
 	# Virtual file system
 	{ mime = "vfs/*", run = "vfs" },
+	# Trash
+	{ mime = "trash/**", run = "trash" },
 	# Error
 	{ mime = "null/*", run = "null" },
 	# Fallback

--- a/yazi-config/src/open/open.rs
+++ b/yazi-config/src/open/open.rs
@@ -49,9 +49,17 @@ impl Open {
 		M: AsRef<str>,
 	{
 		let mime = mime.as_ref();
+
+		let is_dir = match mime.rsplit_once('/') {
+			Some((_, last)) if last.is_empty() => false,
+			Some(("folder", _)) => true,
+			Some((rest, _)) => rest.ends_with("/folder"),
+			None => false,
+		};
+
 		let file = File::from_dummy(
 			url.as_url().to_owned(),
-			Some(if mime.starts_with("folder/") { ChaType::Dir } else { ChaType::File }),
+			Some(if is_dir { ChaType::Dir } else { ChaType::File }),
 		);
 
 		self.matches(&file, mime)

--- a/yazi-plugin/preset/plugins/mime-dir.lua
+++ b/yazi-plugin/preset/plugins/mime-dir.lua
@@ -7,7 +7,7 @@ function M:fetch(job)
 			if file.url.spec.scheme == "sftp" then
 				mime = "folder/remote"
 			elseif file.url.spec.scheme == "trash" then
-				mime = "folder/trash"
+				mime = "trash/folder"
 			else
 				mime = "folder/local"
 			end

--- a/yazi-plugin/preset/plugins/mime-dir.lua
+++ b/yazi-plugin/preset/plugins/mime-dir.lua
@@ -7,7 +7,7 @@ function M:fetch(job)
 			if file.url.spec.scheme == "sftp" then
 				mime = "folder/remote"
 			elseif file.url.spec.scheme == "trash" then
-				mime = "trash/folder"
+				mime = "trash/folder/local"
 			else
 				mime = "folder/local"
 			end


### PR DESCRIPTION
## Context
This PR builds upon the folder mime-types updates in #4212 and the trash bin features #4144  to fix mismatch between folder and trash rules in yazi.toml.

## Which issue does this PR resolve?
* **Trash Folder mime-type** - Changed `folder/trash` mime-type  to `trash/folder`. This ensures trash directories are correctly caught by the `mime = "trash/**"` rules introduced in #4144.
* **Default Folder Rules** - Replaced `url = "*/"` folder rules with `mime = "folder/*"  to avoid mismatch between trash rules and folder rules.


## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

<!-- AI bots are not allowed to open PRs in this repository. All PRs must be made by humans and comply with the AI policy. -->
