### PR TITLE
fix: pass Kitty DnD sequences through tmux

### DIFF
--- a/yazi-actor/src/app/passthrough.rs
+++ b/yazi-actor/src/app/passthrough.rs
@@ -3,6 +3,7 @@ use yazi_emulator::EMULATOR;
 use yazi_macro::{error, render_force, succ};
 use yazi_parser::app::PassthroughForm;
 use yazi_shared::data::Data;
+use yazi_tui::Raterm;
 
 use crate::{Actor, Ctx};
 
@@ -24,9 +25,12 @@ impl Actor for Passthrough {
 
 		if let Err(e) = EMULATOR.restart() {
 			error!("Failed to request terminal capabilities through tmux: {e}");
-		} else {
-			render_force!();
+			succ!();
 		}
+		if let Err(e) = Raterm::enable_dnd() {
+			error!("Failed to enable drag and drop through tmux: {e}");
+		}
+		render_force!();
 
 		succ!();
 	}

--- a/yazi-emulator/src/emulator.rs
+++ b/yazi-emulator/src/emulator.rs
@@ -61,6 +61,7 @@ impl Emulator {
 
 	pub fn restart(&self) -> Result<()> {
 		self.mux.set(Some(Mux { sixel: self.sixel.get() }));
+		TTY.enable_tmux_passthrough();
 
 		// Only these requests are passed through tmux after restarting.
 		self.brand.set(Brand::Unknown);

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -6,7 +6,7 @@ use yazi_macro::{error, writef};
 use yazi_shared::id::{Id, Ids};
 use yazi_shim::cell::SyncCell;
 use yazi_term::{TERM, event::{Event, Report}, stream::EventStream};
-use yazi_tty::{TTY, sequence::{ProbeClipboard, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCsiU, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKittyGraphics, RequestXtVersion, RestoreCursorPos, SaveCursorPos, TmuxPassthrough}};
+use yazi_tty::{TTY, sequence::{ProbeClipboard, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCsiU, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKittyGraphics, RequestXtVersion, RestoreCursorPos, SaveCursorPos}};
 
 use crate::{Emulator, Mux};
 
@@ -103,7 +103,7 @@ impl Emulator {
 	}
 
 	pub(super) fn request(&self) -> Result<()> {
-		let w = |t: &'static dyn Display| TmuxPassthrough(t, self.mux.get().is_some());
+		let w = |t: &'static dyn Display| TTY.tmux_passthrough(t);
 
 		writef!(
 			TTY.writer(),

--- a/yazi-tty/src/lua.rs
+++ b/yazi-tty/src/lua.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::{fmt::Display, io::{self, Write}};
 
 use mlua::{BorrowedBytes, ExternalError, IntoLuaMulti, Lua, LuaString, MultiValue, Table, UserData, UserDataMethods};
 use yazi_shim::{fs::Error, mlua::{ByteString, LuaTableExt}};
@@ -8,7 +8,6 @@ use crate::{Tty, sequence::{AgreeDrag, AgreeDrop, FinishDrop, PresentDrag, Prese
 impl Tty {
 	fn queue(&self, lua: &Lua, kind: &[u8], t: &Table) -> mlua::Result<MultiValue> {
 		let mut w = self.writer();
-
 		let result = match kind {
 			b"Print" => {
 				write!(w, "{}", t.raw_get::<ByteString>(1)?)
@@ -17,7 +16,7 @@ impl Tty {
 			// DnD
 			b"AgreeDrag" => {
 				let it = t.raw_get::<Table>("mimes")?.sequence_iter::<ByteString>(lua).flatten();
-				write!(w, "{}", match &*t.raw_get::<BorrowedBytes>("type")? {
+				self.queue_dnd(&mut w, match &*t.raw_get::<BorrowedBytes>("type")? {
 					b"copy" => AgreeDrag::Copy(it),
 					b"move" => AgreeDrag::Move(it),
 					b"either" => AgreeDrag::Either(it),
@@ -26,30 +25,28 @@ impl Tty {
 			}
 			b"AgreeDrop" => {
 				let it = t.raw_get::<Table>("mimes")?.sequence_iter::<ByteString>(lua).flatten();
-				write!(w, "{}", match &*t.raw_get::<BorrowedBytes>("type")? {
+				self.queue_dnd(&mut w, match &*t.raw_get::<BorrowedBytes>("type")? {
 					b"reject" => AgreeDrop::Reject,
 					b"copy" => AgreeDrop::Copy(it),
 					b"move" => AgreeDrop::Move(it),
 					_ => return Err("invalid AgreeDrop type".into_lua_err()),
 				})
 			}
-			b"StartDrag" => write!(w, "{StartDrag}"),
-			b"StartDrop" => write!(w, "{}", StartDrop(t.raw_get("idx")?)),
+			b"StartDrag" => self.queue_dnd(&mut w, StartDrag),
+			b"StartDrop" => self.queue_dnd(&mut w, StartDrop(t.raw_get("idx")?)),
 			b"PresentDrag" => {
-				write!(w, "{}", PresentDrag(t.raw_get("idx")?, &t.raw_get::<BorrowedBytes>("data")?))
+				self.queue_dnd(&mut w, PresentDrag(t.raw_get("idx")?, &t.raw_get::<BorrowedBytes>("data")?))
 			}
-			b"PresentDragIcon" => {
-				write!(w, "{}", PresentDragIcon {
-					format:  t.raw_get("format")?,
-					opacity: t.raw_get("opacity")?,
-					width:   t.raw_get("width")?,
-					height:  t.raw_get("height")?,
-					data:    &t.raw_get::<BorrowedBytes>("data")?,
-				})
-			}
+			b"PresentDragIcon" => self.queue_dnd(&mut w, PresentDragIcon {
+				format:  t.raw_get("format")?,
+				opacity: t.raw_get("opacity")?,
+				width:   t.raw_get("width")?,
+				height:  t.raw_get("height")?,
+				data:    &t.raw_get::<BorrowedBytes>("data")?,
+			}),
 			b"FinishDrop" => match &*t.raw_get::<BorrowedBytes>("type")? {
-				b"copy" => write!(w, "{}", FinishDrop::Copy),
-				b"move" => write!(w, "{}", FinishDrop::Move),
+				b"copy" => self.queue_dnd(&mut w, FinishDrop::Copy),
+				b"move" => self.queue_dnd(&mut w, FinishDrop::Move),
 				_ => return Err("invalid FinishDrop type".into_lua_err()),
 			},
 
@@ -82,6 +79,10 @@ impl Tty {
 			Ok(()) => true.into_lua_multi(lua),
 			Err(e) => (false, Error::from(e)).into_lua_multi(lua),
 		}
+	}
+
+	fn queue_dnd(&self, w: &mut impl Write, sequence: impl Display) -> io::Result<()> {
+		write!(w, "{}", self.tmux_passthrough(sequence))
 	}
 }
 

--- a/yazi-tty/src/tty.rs
+++ b/yazi-tty/src/tty.rs
@@ -1,13 +1,14 @@
-use std::{io::{BufWriter, Error, ErrorKind, Read}, time::{Duration, Instant}};
+use std::{fmt::Display, io::{BufWriter, Error, ErrorKind, Read}, sync::atomic::{AtomicBool, Ordering}, time::{Duration, Instant}};
 
 use parking_lot::{Mutex, MutexGuard};
 
 use super::Handle;
-use crate::{TtyReader, TtyWriter};
+use crate::{TtyReader, TtyWriter, sequence::TmuxPassthrough};
 
 pub struct Tty {
 	stdin:  Mutex<Handle>,
 	stdout: Mutex<BufWriter<Handle>>,
+	tmux:   AtomicBool,
 }
 
 impl Default for Tty {
@@ -15,6 +16,7 @@ impl Default for Tty {
 		Self {
 			stdin:  Mutex::new(Handle::new(false)),
 			stdout: Mutex::new(BufWriter::new(Handle::new(true))),
+			tmux:   AtomicBool::new(false),
 		}
 	}
 }
@@ -27,6 +29,12 @@ impl Tty {
 	pub fn lockin(&self) -> MutexGuard<'_, Handle> { self.stdin.lock() }
 
 	pub fn lockout(&self) -> MutexGuard<'_, BufWriter<Handle>> { self.stdout.lock() }
+
+	pub fn enable_tmux_passthrough(&self) { self.tmux.store(true, Ordering::Relaxed); }
+
+	pub fn tmux_passthrough<T: Display>(&self, sequence: T) -> TmuxPassthrough<T> {
+		TmuxPassthrough(sequence, self.tmux.load(Ordering::Relaxed))
+	}
 
 	pub fn read_until<P>(&self, timeout: Duration, predicate: P) -> (Vec<u8>, std::io::Result<()>)
 	where

--- a/yazi-tui/src/raterm.rs
+++ b/yazi-tui/src/raterm.rs
@@ -46,15 +46,14 @@ impl Raterm {
 		let mut stream = EventStream::from(&*TERM);
 		writef!(
 			TTY.writer(),
-			"{EnableBracketedPaste}{EnableClipboard}{EnableFocusChange}{EnableColorSchemeUpdates}{}{}{}{}",
+			"{EnableBracketedPaste}{EnableClipboard}{EnableFocusChange}{EnableColorSchemeUpdates}{}{}",
 			PushKeyboardFlags::DISAMBIGUATE_ESCAPE_CODES
 				| PushKeyboardFlags::REPORT_ALTERNATE_KEYS
 				| PushKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
 				| PushKeyboardFlags::REPORT_ASSOCIATED_TEXT,
-			EnableDrag(""),
-			EnableDrop(&["text/uri-list"]),
 			If(opt.mouse, EnableMouseCapture),
 		)?;
+		Self::enable_dnd()?;
 
 		let mut inner = Terminal::new(RatermBackend::new(TTY.writer()))?;
 		inner.hide_cursor()?;
@@ -78,14 +77,26 @@ impl Raterm {
 
 		_ = writef!(
 			TTY.writer(),
-			"{}{PopKeyboardFlags}{DisableDrop}{DisableDrag}{}{}{DisableColorSchemeUpdates}{DisableFocusChange}{DisableClipboard}{DisableBracketedPaste}{ShowCursor}",
+			"{}{PopKeyboardFlags}{}{}{}{}{DisableColorSchemeUpdates}{DisableFocusChange}{DisableClipboard}{DisableBracketedPaste}{ShowCursor}",
 			If(state.mouse, DisableMouseCapture),
+			TTY.tmux_passthrough(DisableDrop),
+			TTY.tmux_passthrough(DisableDrag),
 			RestoreCursorStyle { blink: EMULATOR.cursor_blink.get(), shape: EMULATOR.cursor_shape.get() },
 			If(state.title, SetTitle("")),
 		);
 
 		STATE.set(RatermState::default());
 		EMULATOR.stop();
+	}
+
+	pub fn enable_dnd() -> Result<()> {
+		writef!(
+			TTY.writer(),
+			"{}{}",
+			TTY.tmux_passthrough(EnableDrag("")),
+			TTY.tmux_passthrough(EnableDrop(&["text/uri-list"])),
+		)?;
+		Ok(())
 	}
 
 	fn spawn(stream: &mut EventStream) -> JoinHandle<()> {


### PR DESCRIPTION
## Which issue does this PR resolve?


<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #4273

## Rationale of this PR

<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

- I have looked the #4245
- Kitty DnD worked outside tmux but not inside tmux.
- `set -gq allow-passthrough all` in `.tmux.conf` does not work.
- Yazi's DnD output path was not using the tmux passthrough envelope.

## AI Policy

AI(`Codex/5.6 Sol`) helped with diagnosis and tests. It works successfully.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

<!-- AI bots are not allowed to open PRs in this repository. All PRs must be made by humans and comply with the AI policy. -->
