### PR TITLE
feat: new `visual_arrow` action to reanchor visual selections

### DIFF
--- a/yazi-actor/src/lives/mode.rs
+++ b/yazi-actor/src/lives/mode.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 
 use mlua::{AnyUserData, MetaMethod, UserData, UserDataFields, UserDataMethods};
 use yazi_binding::deprecate;
+use yazi_shim::mlua::UserDataFieldsExt;
 
 use super::{Lives, PtrCell};
 
@@ -26,6 +27,7 @@ impl UserData for Mode {
 		fields.add_field_method_get("is_normal", |_, me| Ok(me.is_normal()));
 		fields.add_field_method_get("is_select", |_, me| Ok(me.is_select()));
 		fields.add_field_method_get("is_unset", |_, me| Ok(me.is_unset()));
+		fields.add_cached_field("visual", |_, me| Ok(me.visual()));
 		fields.add_field_method_get("is_visual", |lua, me| {
 			deprecate!(lua, "{}: `mode.is_visual` is deprecated, use `not mode.is_normal` instead. \nSee #4101 for more details: https://github.com/sxyazi/yazi/pull/4101.");
 			Ok(!me.is_normal())

--- a/yazi-actor/src/mgr/mod.rs
+++ b/yazi-actor/src/mgr/mod.rs
@@ -58,6 +58,7 @@ yazi_macro::mod_flat!(
 	update_spotted
 	update_yanked
 	upload
+	visual_arrow
 	visual_mode
 	watch
 	yank

--- a/yazi-actor/src/mgr/visual_arrow.rs
+++ b/yazi-actor/src/mgr/visual_arrow.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use yazi_macro::{act, render, succ};
+use yazi_parser::mgr::VisualArrowForm;
+use yazi_shared::data::Data;
+
+use crate::{Actor, Ctx};
+
+pub struct VisualArrow;
+
+impl Actor for VisualArrow {
+	type Form = VisualArrowForm;
+
+	const NAME: &str = "visual_arrow";
+
+	fn act(cx: &mut Ctx, form: Self::Form) -> Result<Data> {
+		let tab = cx.tab_mut();
+		let len = tab.current.entries.len() as i128;
+		if len == 0 {
+			succ!();
+		}
+
+		let Some(visual) = tab.mode.visual_mut() else { succ!() };
+		let new = tab.current.cursor as i128 + form.step as i128;
+
+		visual.start = tab.current.cursor;
+		visual.wraps = new.div_euclid(len) as isize;
+		tab.current.cursor = new.rem_euclid(len) as usize;
+
+		tab.current.arrow(0);
+		tab.current.retrace();
+
+		act!(mgr:hover, cx)?;
+		act!(mgr:peek, cx)?;
+		act!(mgr:watch, cx).ok();
+
+		cx.tasks.scheduler.behavior.reset();
+		succ!(render!());
+	}
+}

--- a/yazi-core/src/tab/visual.rs
+++ b/yazi-core/src/tab/visual.rs
@@ -1,13 +1,14 @@
 use std::{iter::Chain, ops::Range};
 
+use mlua::{UserData, UserDataFields};
 use yazi_widgets::Step;
 
 pub type VisualIndices = Chain<Range<usize>, Range<usize>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Visual {
-	start: usize,
-	wraps: isize,
+	pub start: usize,
+	pub wraps: isize,
 }
 
 impl Visual {
@@ -45,5 +46,12 @@ impl Visual {
 			-1 if end > start + 1 => (0..start + 1, end..len),
 			_ => (0..len, 0..0),
 		}
+	}
+}
+
+impl UserData for Visual {
+	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
+		fields.add_field_method_get("start", |_, me| Ok(me.start));
+		fields.add_field_method_get("wraps", |_, me| Ok(me.wraps));
 	}
 }

--- a/yazi-fm/src/app/app.rs
+++ b/yazi-fm/src/app/app.rs
@@ -1,11 +1,11 @@
 use std::{sync::atomic::Ordering, time::{Duration, Instant}};
 
 use anyhow::Result;
-use tokio::{select, sync::mpsc, time::sleep};
+use tokio::{select, time::sleep};
 use yazi_actor::Ctx;
 use yazi_core::Core;
 use yazi_macro::{act, render, succ};
-use yazi_shared::{data::Data, event::{Event, NEED_RENDER}};
+use yazi_shared::{data::Data, event::{Event, EventRx, NEED_RENDER}};
 use yazi_tui::Raterm;
 
 use crate::Dispatcher;
@@ -62,7 +62,7 @@ impl App {
 		succ!(render!())
 	}
 
-	async fn drain(&mut self, rx: &mut mpsc::UnboundedReceiver<Event>) -> Result<bool> {
+	async fn drain(&mut self, rx: &mut EventRx) -> Result<bool> {
 		let Some(event) = rx.recv().await else {
 			return Ok(false);
 		};

--- a/yazi-fm/src/executor.rs
+++ b/yazi-fm/src/executor.rs
@@ -104,6 +104,7 @@ impl<'a> Executor<'a> {
 		// Toggle
 		on!(toggle);
 		on!(toggle_all);
+		on!(visual_arrow);
 		on!(visual_mode);
 
 		// Operation

--- a/yazi-parser/src/mgr/mod.rs
+++ b/yazi-parser/src/mgr/mod.rs
@@ -43,6 +43,7 @@ yazi_macro::mod_flat!(
 	update_spotted
 	update_yanked
 	upload
+	visual_arrow
 	visual_mode
 	watch
 	yank

--- a/yazi-parser/src/mgr/visual_arrow.rs
+++ b/yazi-parser/src/mgr/visual_arrow.rs
@@ -1,0 +1,23 @@
+use mlua::{ExternalError, FromLua, IntoLua, Lua, Value};
+use serde::Deserialize;
+use yazi_shared::event::ActionCow;
+
+#[derive(Debug, Deserialize)]
+pub struct VisualArrowForm {
+	#[serde(alias = "0")]
+	pub step: isize,
+}
+
+impl TryFrom<ActionCow> for VisualArrowForm {
+	type Error = anyhow::Error;
+
+	fn try_from(a: ActionCow) -> Result<Self, Self::Error> { Ok(a.deserialize()?) }
+}
+
+impl FromLua for VisualArrowForm {
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
+}
+
+impl IntoLua for VisualArrowForm {
+	fn into_lua(self, _: &Lua) -> mlua::Result<Value> { Err("unsupported".into_lua_err()) }
+}

--- a/yazi-parser/src/spark/spark.rs
+++ b/yazi-parser/src/spark/spark.rs
@@ -96,6 +96,7 @@ pub enum Spark<'a> {
 	UpdateSpotted(crate::mgr::UpdateSpottedForm),
 	UpdateYanked(crate::mgr::UpdateYankedForm<'a>),
 	Upload(crate::mgr::UploadForm),
+	VisualArrow(crate::mgr::VisualArrowForm),
 	VisualMode(crate::mgr::VisualModeForm),
 	Watch(crate::mgr::WatchForm),
 	Yank(crate::mgr::YankForm),
@@ -299,6 +300,7 @@ impl<'a> IntoLua for Spark<'a> {
 			Self::UpdateSpotted(b) => b.into_lua(lua),
 			Self::UpdateYanked(b) => b.into_lua(lua),
 			Self::Upload(b) => b.into_lua(lua),
+			Self::VisualArrow(b) => b.into_lua(lua),
 			Self::VisualMode(b) => b.into_lua(lua),
 			Self::Watch(b) => b.into_lua(lua),
 			Self::Yank(b) => b.into_lua(lua),
@@ -461,6 +463,7 @@ try_from_spark!(crate::mgr::UpdatePeekedForm, mgr:update_peeked);
 try_from_spark!(crate::mgr::UpdateSpottedForm, mgr:update_spotted);
 try_from_spark!(crate::mgr::UpdateYankedForm<'a>, mgr:update_yanked);
 try_from_spark!(crate::mgr::UploadForm, mgr:upload);
+try_from_spark!(crate::mgr::VisualArrowForm, mgr:visual_arrow);
 try_from_spark!(crate::mgr::VisualModeForm, mgr:visual_mode);
 try_from_spark!(crate::mgr::WatchForm, mgr:watch);
 try_from_spark!(crate::mgr::YankForm, mgr:yank);

--- a/yazi-plugin/src/utils/call.rs
+++ b/yazi-plugin/src/utils/call.rs
@@ -1,7 +1,8 @@
 use mlua::{ExternalError, Function, Lua, Table};
 use tokio::sync::mpsc;
+use yazi_binding::runtime;
 use yazi_macro::emit;
-use yazi_shared::{Layer, Source, data::Sendable, event::Action};
+use yazi_shared::{Layer, Source, data::Sendable, event::{Action, Event}};
 
 use super::Utils;
 
@@ -10,7 +11,15 @@ impl Utils {
 		lua.create_function(|lua, (name, args): (String, Table)| {
 			let mut action = Action::new(name, Source::Emit, Layer::Mgr)?;
 			action.args = Sendable::table_to_args(lua, args)?;
-			Ok(emit!(Call(action)))
+
+			let event = Event::Call(action.into());
+			if runtime!(lua)?.is_blocking() {
+				event.preempt();
+			} else {
+				event.emit();
+			}
+
+			Ok(())
 		})
 	}
 

--- a/yazi-shared/src/event/channel.rs
+++ b/yazi-shared/src/event/channel.rs
@@ -1,0 +1,27 @@
+use tokio::sync::mpsc;
+
+use super::Event;
+
+pub(super) struct EventTx {
+	pub(super) high:   mpsc::UnboundedSender<Event>,
+	pub(super) normal: mpsc::UnboundedSender<Event>,
+}
+
+pub struct EventRx {
+	pub(super) high:   mpsc::UnboundedReceiver<Event>,
+	pub(super) normal: mpsc::UnboundedReceiver<Event>,
+}
+
+impl EventRx {
+	pub async fn recv(&mut self) -> Option<Event> {
+		tokio::select! {
+			biased;
+			event = self.high.recv() => event,
+			event = self.normal.recv() => event,
+		}
+	}
+
+	pub fn try_recv(&mut self) -> Result<Event, mpsc::error::TryRecvError> {
+		self.high.try_recv().or_else(|_| self.normal.try_recv())
+	}
+}

--- a/yazi-shared/src/event/event.rs
+++ b/yazi-shared/src/event/event.rs
@@ -1,10 +1,10 @@
 use tokio::sync::mpsc;
 use yazi_shim::cell::RoCell;
 
-use super::ActionCow;
+use super::{ActionCow, EventRx, channel::EventTx};
 
-static TX: RoCell<mpsc::UnboundedSender<Event>> = RoCell::new();
-static RX: RoCell<mpsc::UnboundedReceiver<Event>> = RoCell::new();
+static TX: RoCell<EventTx> = RoCell::new();
+static RX: RoCell<EventRx> = RoCell::new();
 
 #[derive(Debug)]
 pub enum Event {
@@ -16,14 +16,19 @@ pub enum Event {
 impl Event {
 	#[inline]
 	pub fn init() {
-		let (tx, rx) = mpsc::unbounded_channel();
-		TX.init(tx);
-		RX.init(rx);
+		let (high_tx, high_rx) = mpsc::unbounded_channel();
+		let (normal_tx, normal_rx) = mpsc::unbounded_channel();
+
+		TX.init(EventTx { high: high_tx, normal: normal_tx });
+		RX.init(EventRx { high: high_rx, normal: normal_rx });
 	}
 
 	#[inline]
-	pub fn take() -> mpsc::UnboundedReceiver<Self> { RX.drop() }
+	pub fn take() -> EventRx { RX.drop() }
 
 	#[inline]
-	pub fn emit(self) { TX.send(self).ok(); }
+	pub fn emit(self) { TX.normal.send(self).ok(); }
+
+	#[inline]
+	pub fn preempt(self) { TX.high.send(self).ok(); }
 }

--- a/yazi-shared/src/event/mod.rs
+++ b/yazi-shared/src/event/mod.rs
@@ -1,3 +1,3 @@
-yazi_macro::mod_flat!(action action_cow actions cmd de de_owned event replier);
+yazi_macro::mod_flat!(action action_cow actions channel cmd de de_owned event replier);
 
 pub static NEED_RENDER: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);


### PR DESCRIPTION
An implementation of the feature request: #4254

Closes #4254

---

A new plugin [`visual-pivot.yazi`](https://github.com/yazi-rs/plugins/tree/main/visual-pivot.yazi) - moves the cursor to the other end of the selection while keeping the selected files unchanged:

https://github.com/user-attachments/assets/105d2a75-ac92-4d67-814c-b95942a2d152
