### PR TITLE
feat: persist input history

### DIFF
--- a/yazi-actor/src/input/close.rs
+++ b/yazi-actor/src/input/close.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use yazi_core::input::InputMutGuard;
-use yazi_dds::Pubsub;
-use yazi_macro::{act, log_if_err, render, succ};
+use yazi_macro::{act, render, succ};
 use yazi_parser::{input::CloseForm, spark::SparkKind};
 use yazi_shared::{Source, data::Data};
 use yazi_widgets::input::InputEvent;
@@ -29,11 +28,11 @@ impl Actor for Close {
 		if form.submit
 			&& let InputMutGuard::Main(input) = guard
 		{
-			let group = &input.main.history.name;
-			let value = input.main.value();
-			if input.histories.remember(group, value) {
-				log_if_err!(Pubsub::pub_after_history(group, value))
-			}
+			crate::input::remember_history(
+				&mut input.histories,
+				&input.main.history.name,
+				input.main.value(),
+			);
 		}
 
 		cx.input.main.visible = false;

--- a/yazi-actor/src/input/close.rs
+++ b/yazi-actor/src/input/close.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use yazi_core::input::InputMutGuard;
-use yazi_macro::{act, render, succ};
+use yazi_dds::Pubsub;
+use yazi_macro::{act, log_if_err, render, succ};
 use yazi_parser::{input::CloseForm, spark::SparkKind};
 use yazi_shared::{Source, data::Data};
 use yazi_widgets::input::InputEvent;
@@ -28,7 +29,11 @@ impl Actor for Close {
 		if form.submit
 			&& let InputMutGuard::Main(input) = guard
 		{
-			input.histories.remember(&input.main.history.name, input.main.value());
+			let group = &input.main.history.name;
+			let value = input.main.value();
+			if input.histories.remember(group, value) {
+				log_if_err!(Pubsub::pub_after_history(group, value))
+			}
 		}
 
 		cx.input.main.visible = false;

--- a/yazi-actor/src/input/mod.rs
+++ b/yazi-actor/src/input/mod.rs
@@ -1,1 +1,7 @@
 yazi_macro::mod_flat!(close complete escape recall remember show);
+
+fn remember_history(histories: &mut yazi_core::input::InputHistories, group: &str, value: &str) {
+	if histories.remember(group, value) {
+		yazi_macro::log_if_err!(yazi_dds::Pubsub::pub_after_history(group, value));
+	}
+}

--- a/yazi-actor/src/input/remember.rs
+++ b/yazi-actor/src/input/remember.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use yazi_core::input::InputMutGuard;
-use yazi_dds::Pubsub;
-use yazi_macro::{log_if_err, succ};
+use yazi_macro::succ;
 use yazi_parser::VoidForm;
 use yazi_shared::data::Data;
 
@@ -21,18 +20,14 @@ impl Actor for Remember {
 
 		match &mut input {
 			InputMutGuard::Main(input) => {
-				let group = &input.main.history.name;
-				let value = input.main.value();
-				if input.histories.remember(group, value) {
-					log_if_err!(Pubsub::pub_after_history(group, value));
-				}
+				crate::input::remember_history(
+					&mut input.histories,
+					&input.main.history.name,
+					input.main.value(),
+				);
 			}
 			InputMutGuard::Alt(input, guard) => {
-				let group = &guard.history.name;
-				let value = guard.value();
-				if input.histories.remember(group, value) {
-					log_if_err!(Pubsub::pub_after_history(group, value));
-				}
+				crate::input::remember_history(&mut input.histories, &guard.history.name, guard.value());
 			}
 		}
 

--- a/yazi-actor/src/input/remember.rs
+++ b/yazi-actor/src/input/remember.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use yazi_core::input::InputMutGuard;
-use yazi_macro::succ;
+use yazi_dds::Pubsub;
+use yazi_macro::{log_if_err, succ};
 use yazi_parser::VoidForm;
 use yazi_shared::data::Data;
 
@@ -20,10 +21,18 @@ impl Actor for Remember {
 
 		match &mut input {
 			InputMutGuard::Main(input) => {
-				input.histories.remember(&input.main.history.name, input.main.value());
+				let group = &input.main.history.name;
+				let value = input.main.value();
+				if input.histories.remember(group, value) {
+					log_if_err!(Pubsub::pub_after_history(group, value));
+				}
 			}
 			InputMutGuard::Alt(input, guard) => {
-				input.histories.remember(&guard.history.name, guard.value());
+				let group = &guard.history.name;
+				let value = guard.value();
+				if input.histories.remember(group, value) {
+					log_if_err!(Pubsub::pub_after_history(group, value));
+				}
 			}
 		}
 

--- a/yazi-actor/src/mgr/load_history.rs
+++ b/yazi-actor/src/mgr/load_history.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use yazi_macro::succ;
+use yazi_parser::mgr::LoadHistoryForm;
+use yazi_shared::data::Data;
+
+use crate::{Actor, Ctx};
+
+pub struct LoadHistory;
+
+impl Actor for LoadHistory {
+	type Form = LoadHistoryForm;
+
+	const NAME: &str = "load_history";
+
+	fn act(cx: &mut Ctx, form: Self::Form) -> Result<Data> {
+		cx.input.histories.load(form.entries);
+		succ!();
+	}
+}

--- a/yazi-actor/src/mgr/mod.rs
+++ b/yazi-actor/src/mgr/mod.rs
@@ -26,6 +26,7 @@ yazi_macro::mod_flat!(
 	leave
 	linemode
 	link
+	load_history
 	open
 	open_do
 	paste

--- a/yazi-core/src/input/history.rs
+++ b/yazi-core/src/input/history.rs
@@ -5,6 +5,8 @@ pub struct InputHistories {
 	inner: HashMap<String, Vec<String>>,
 }
 
+const MAX: usize = 20;
+
 impl InputHistories {
 	pub fn get(&self, group: &str) -> &[String] {
 		self.inner.get(group).map(Vec::as_slice).unwrap_or(&[])
@@ -22,10 +24,19 @@ impl InputHistories {
 
 		entries.retain(|entry| entry != value);
 		entries.push(value.to_owned());
-		if entries.len() > 20 {
-			entries.drain(..entries.len() - 20);
+		if entries.len() > MAX {
+			entries.drain(..entries.len() - MAX);
 		}
 
 		true
+	}
+
+	pub fn load(&mut self, entries: HashMap<String, Vec<String>>) {
+		for (group, mut values) in entries {
+			if values.len() > MAX {
+				values.drain(..values.len() - MAX);
+			}
+			self.inner.insert(group, values);
+		}
 	}
 }

--- a/yazi-core/src/input/history.rs
+++ b/yazi-core/src/input/history.rs
@@ -5,9 +5,9 @@ pub struct InputHistories {
 	inner: HashMap<String, Vec<String>>,
 }
 
-const MAX: usize = 20;
-
 impl InputHistories {
+	pub const MAX: usize = 20;
+
 	pub fn get(&self, group: &str) -> &[String] {
 		self.inner.get(group).map(Vec::as_slice).unwrap_or(&[])
 	}
@@ -24,8 +24,8 @@ impl InputHistories {
 
 		entries.retain(|entry| entry != value);
 		entries.push(value.to_owned());
-		if entries.len() > MAX {
-			entries.drain(..entries.len() - MAX);
+		if entries.len() > Self::MAX {
+			entries.drain(..entries.len() - Self::MAX);
 		}
 
 		true
@@ -33,8 +33,8 @@ impl InputHistories {
 
 	pub fn load(&mut self, entries: HashMap<String, Vec<String>>) {
 		for (group, mut values) in entries {
-			if values.len() > MAX {
-				values.drain(..values.len() - MAX);
+			if values.len() > Self::MAX {
+				values.drain(..values.len() - Self::MAX);
 			}
 			self.inner.insert(group, values);
 		}

--- a/yazi-dds/src/ember/ember.rs
+++ b/yazi-dds/src/ember/ember.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, bail};
 use mlua::{IntoLua, Lua, Value};
 use yazi_shared::id::Id;
 
-use super::{EmberBulkRename, EmberBye, EmberCd, EmberCustom, EmberDelete, EmberDownload, EmberDuplicate, EmberHey, EmberHi, EmberHover, EmberInput, EmberLoad, EmberMount, EmberMove, EmberRename, EmberTab, EmberTheme, EmberTrash, EmberYank};
+use super::{EmberBulkRename, EmberBye, EmberCd, EmberCustom, EmberDelete, EmberDownload, EmberDuplicate, EmberHey, EmberHi, EmberHistory, EmberHover, EmberInput, EmberLoad, EmberMount, EmberMove, EmberRename, EmberTab, EmberTheme, EmberTrash, EmberYank};
 use crate::Payload;
 
 #[derive(Clone, Debug)]
@@ -23,6 +23,7 @@ pub enum Ember<'a> {
 	Delete(EmberDelete<'a>),
 	Download(EmberDownload<'a>),
 	Input(EmberInput<'a>),
+	History(EmberHistory<'a>),
 	Mount(EmberMount),
 	Theme(EmberTheme),
 	Custom(EmberCustom),
@@ -49,6 +50,7 @@ impl Ember<'static> {
 			"input" => Self::Input(serde_json::from_str(body)?),
 			"mount" => Self::Mount(serde_json::from_str(body)?),
 			"theme" => Self::Theme(serde_json::from_str(body)?),
+			"history" => Self::History(serde_json::from_str(body)?),
 			_ => EmberCustom::from_str(kind, body)?,
 		})
 	}
@@ -77,6 +79,7 @@ impl Ember<'static> {
 				| "delete"
 				| "download"
 				| "input"
+				| "history"
 				| "mount"
 				| "theme"
 		) || kind.starts_with("key-")
@@ -118,6 +121,7 @@ impl<'a> Ember<'a> {
 			Self::Delete(_) => "delete",
 			Self::Download(_) => "download",
 			Self::Input(_) => "input",
+			Self::History(_) => "history",
 			Self::Mount(_) => "mount",
 			Self::Theme(_) => "theme",
 			Self::Custom(b) => b.kind.as_str(),
@@ -148,6 +152,7 @@ impl<'a> IntoLua for Ember<'a> {
 			Self::Delete(b) => b.into_lua(lua),
 			Self::Download(b) => b.into_lua(lua),
 			Self::Input(b) => b.into_lua(lua),
+			Self::History(b) => b.into_lua(lua),
 			Self::Mount(b) => b.into_lua(lua),
 			Self::Theme(b) => b.into_lua(lua),
 			Self::Custom(b) => b.into_lua(lua),

--- a/yazi-dds/src/ember/history.rs
+++ b/yazi-dds/src/ember/history.rs
@@ -1,0 +1,34 @@
+use std::borrow::Cow;
+
+use mlua::{IntoLua, Lua, Value};
+use serde::{Deserialize, Serialize};
+
+use super::Ember;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EmberHistory<'a> {
+	pub group: Cow<'a, str>,
+	pub value: Cow<'a, str>,
+}
+
+impl<'a> EmberHistory<'a> {
+	pub fn borrowed(group: &'a str, value: &'a str) -> Ember<'a> {
+		Self { group: group.into(), value: value.into() }.into()
+	}
+}
+
+impl EmberHistory<'static> {
+	pub fn owned(group: &str, value: &str) -> Ember<'static> {
+		Self { group: group.to_owned().into(), value: value.to_owned().into() }.into()
+	}
+}
+
+impl<'a> From<EmberHistory<'a>> for Ember<'a> {
+	fn from(value: EmberHistory<'a>) -> Self { Self::History(value) }
+}
+
+impl IntoLua for EmberHistory<'_> {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		lua.create_table_from([("group", self.group), ("value", self.value)])?.into_lua(lua)
+	}
+}

--- a/yazi-dds/src/ember/mod.rs
+++ b/yazi-dds/src/ember/mod.rs
@@ -1,3 +1,3 @@
 yazi_macro::mod_flat!(
-	bulk_rename bye cd custom delete download duplicate ember hey hi hover input load mount r#move rename tab theme trash yank
+	bulk_rename bye cd custom delete download duplicate ember hey hi history hover input load mount r#move rename tab theme trash yank
 );

--- a/yazi-dds/src/payload.rs
+++ b/yazi-dds/src/payload.rs
@@ -104,6 +104,7 @@ impl Display for Payload<'_> {
 			Ember::Delete(b) => serde_json::to_string(b),
 			Ember::Download(b) => serde_json::to_string(b),
 			Ember::Input(b) => serde_json::to_string(b),
+			Ember::History(b) => serde_json::to_string(b),
 			Ember::Mount(b) => serde_json::to_string(b),
 			Ember::Theme(b) => serde_json::to_string(b),
 			Ember::Custom(b) => serde_json::to_string(b),

--- a/yazi-dds/src/pubsub.rs
+++ b/yazi-dds/src/pubsub.rs
@@ -177,6 +177,8 @@ impl Pubsub {
 
 	pub_after!(input(r#type: &'static str, value: &str), (r#type, value));
 
+	pub_after!(history(group: &str, value: &str), (group, value));
+
 	pub_after!(mount(), ());
 
 	pub_after!(theme(), ());

--- a/yazi-fm/src/executor.rs
+++ b/yazi-fm/src/executor.rs
@@ -75,6 +75,7 @@ impl<'a> Executor<'a> {
 
 		on!(cd);
 		on!(update_yanked);
+		on!(load_history);
 
 		on!(update_files);
 		on!(update_mimes);

--- a/yazi-parser/src/mgr/load_history.rs
+++ b/yazi-parser/src/mgr/load_history.rs
@@ -17,9 +17,7 @@ impl TryFrom<ActionCow> for LoadHistoryForm {
 }
 
 impl FromLua for LoadHistoryForm {
-	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> {
-		Err("unexpected LoadHistoryForm from Lua".into_lua_err())
-	}
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> { Err("unsupported".into_lua_err()) }
 }
 
 impl IntoLua for LoadHistoryForm {

--- a/yazi-parser/src/mgr/load_history.rs
+++ b/yazi-parser/src/mgr/load_history.rs
@@ -1,0 +1,27 @@
+use hashbrown::HashMap;
+use mlua::{ExternalError, FromLua, IntoLua, Lua, LuaSerdeExt, Value};
+use serde::{Deserialize, Serialize};
+use yazi_shared::event::ActionCow;
+use yazi_shim::mlua::SER_OPT;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LoadHistoryForm {
+	#[serde(alias = "0")]
+	pub entries: HashMap<String, Vec<String>>,
+}
+
+impl TryFrom<ActionCow> for LoadHistoryForm {
+	type Error = anyhow::Error;
+
+	fn try_from(a: ActionCow) -> Result<Self, Self::Error> { Ok(a.deserialize()?) }
+}
+
+impl FromLua for LoadHistoryForm {
+	fn from_lua(_: Value, _: &Lua) -> mlua::Result<Self> {
+		Err("unexpected LoadHistoryForm from Lua".into_lua_err())
+	}
+}
+
+impl IntoLua for LoadHistoryForm {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> { lua.to_value_with(&self.entries, SER_OPT) }
+}

--- a/yazi-parser/src/mgr/mod.rs
+++ b/yazi-parser/src/mgr/mod.rs
@@ -16,6 +16,7 @@ yazi_macro::mod_flat!(
 	hover
 	linemode
 	link
+	load_history
 	open
 	open_do
 	paste

--- a/yazi-parser/src/spark/spark.rs
+++ b/yazi-parser/src/spark/spark.rs
@@ -62,6 +62,7 @@ pub enum Spark<'a> {
 	Leave(crate::VoidForm),
 	Linemode(crate::mgr::LinemodeForm),
 	Link(crate::mgr::LinkForm),
+	LoadHistory(crate::mgr::LoadHistoryForm),
 	Open(crate::mgr::OpenForm),
 	OpenDo(crate::mgr::OpenDoForm),
 	Paste(crate::mgr::PasteForm),
@@ -266,6 +267,7 @@ impl<'a> IntoLua for Spark<'a> {
 			Self::Leave(b) => b.into_lua(lua),
 			Self::Linemode(b) => b.into_lua(lua),
 			Self::Link(b) => b.into_lua(lua),
+			Self::LoadHistory(b) => b.into_lua(lua),
 			Self::Open(b) => b.into_lua(lua),
 			Self::OpenDo(b) => b.into_lua(lua),
 			Self::Paste(b) => b.into_lua(lua),
@@ -436,6 +438,7 @@ try_from_spark!(crate::mgr::HiddenForm, mgr:hidden);
 try_from_spark!(crate::mgr::HoverForm, mgr:hover);
 try_from_spark!(crate::mgr::LinemodeForm, mgr:linemode);
 try_from_spark!(crate::mgr::LinkForm, mgr:link);
+try_from_spark!(crate::mgr::LoadHistoryForm, mgr:load_history);
 try_from_spark!(crate::mgr::OpenDoForm, mgr:open_do);
 try_from_spark!(crate::mgr::OpenForm, mgr:open);
 try_from_spark!(crate::mgr::PasteForm, mgr:paste);

--- a/yazi-plugin/preset/plugins/history.lua
+++ b/yazi-plugin/preset/plugins/history.lua
@@ -1,0 +1,67 @@
+-- MAX set in code at yazi-core/src/input/history.rs
+local MAX = 20
+
+local function state_path()
+	-- Follows state logic in yazi-fs/src/xdg.rs
+	if ya.target_family() == "windows" then
+		-- As per rust Rust dirs crate
+		return (os.getenv("APPDATA") or "") .. "Roaming/yazi/state/history.json"
+	end
+	return (os.getenv("XDG_STATE_HOME") or ((os.getenv("HOME") or "") .. "/.local/state")) .. "/yazi/history.json"
+end
+
+local function remember(entries, group, value)
+	local list = entries[group] or {}
+	for i = #list, 1, -1 do
+		if list[i] == value then
+			table.remove(list, i)
+		end
+	end
+	list[#list+1] = value
+	while #list > MAX do
+		-- `while` is defensive programming, should never happen
+		table.remove(list, 1)
+	end
+	entries[group] = list
+end
+
+-- Needs a `require("history").setup()` in ~/.config/yazi/init.lua to work for any/all plugins using this
+local function setup()
+	local path = state_path()
+	local entries = {}
+
+	ya.async(function()
+		local f = io.open(path, "r")
+		if not f then return end -- Return early if file doesn't exist
+
+		local raw = f:read("*a")
+		f:close()
+
+		local json = ya.json_decode(raw)
+		if not json then
+			return nil, Err("Failed to decode history file %s: %s", path, raw)
+		elseif type(json) ~= "table" then
+			return nil, Err("Invalid history file %s: %s", path, raw)
+		end
+
+		if next(json) then
+			ya.emit("load_history", json)
+		end
+	end)
+
+	ps.sub("history", function(body)
+		remember(entries, body.group, body.value)
+
+		ya.async(function()
+			fs.create("dir_all", Url(path).parent)
+			local f = io.open(path, "w")
+			if not f then
+				return nil, Err("Failed to open history file %s for writing", path)
+			end
+			f:write(ya.json_encode(entries))
+			f:close()
+		end)
+	end)
+end
+
+return { setup = setup }

--- a/yazi-plugin/preset/plugins/history.lua
+++ b/yazi-plugin/preset/plugins/history.lua
@@ -1,5 +1,4 @@
--- MAX set in code at yazi-core/src/input/history.rs
-local MAX = 20
+local MAX = ya.input_history_max()
 
 local function state_path()
 	-- Follows state logic in yazi-fs/src/xdg.rs
@@ -25,8 +24,8 @@ local function remember(entries, group, value)
 	entries[group] = list
 end
 
--- Needs a `require("history").setup()` in ~/.config/yazi/init.lua to work for any/all plugins using this
-local function setup()
+-- Needs a `require("history"):setup()` in ~/.config/yazi/init.lua to work for any/all plugins using this
+local function setup(_)
 	local path = state_path()
 	local entries = {}
 
@@ -44,8 +43,12 @@ local function setup()
 			return nil, Err("Invalid history file %s: %s", path, raw)
 		end
 
+		for group, list in pairs(json) do
+			entries[group] = entries[group] or list
+		end
+
 		if next(json) then
-			ya.emit("load_history", json)
+			ya.emit("load_history", { json })
 		end
 	end)
 

--- a/yazi-plugin/preset/plugins/history.lua
+++ b/yazi-plugin/preset/plugins/history.lua
@@ -1,5 +1,7 @@
 local MAX = ya.input_history_max()
 
+local M = {}
+
 local function state_path()
 	-- Follows state logic in yazi-fs/src/xdg.rs
 	if ya.target_family() == "windows" then
@@ -25,7 +27,7 @@ local function remember(entries, group, value)
 end
 
 -- Needs a `require("history"):setup()` in ~/.config/yazi/init.lua to work for any/all plugins using this
-local function setup(_)
+function M:setup(_)
 	local path = state_path()
 	local entries = {}
 
@@ -67,4 +69,4 @@ local function setup(_)
 	end)
 end
 
-return { setup = setup }
+return M

--- a/yazi-plugin/preset/plugins/history.lua
+++ b/yazi-plugin/preset/plugins/history.lua
@@ -6,7 +6,7 @@ local function state_path()
 	-- Follows state logic in yazi-fs/src/xdg.rs
 	if ya.target_family() == "windows" then
 		-- As per rust Rust dirs crate
-		return (os.getenv("APPDATA") or "") .. "Roaming/yazi/state/history.json"
+		return (os.getenv("APPDATA") or "") .. "/yazi/state/history.json"
 	end
 	return (os.getenv("XDG_STATE_HOME") or ((os.getenv("HOME") or "") .. "/.local/state")) .. "/yazi/history.json"
 end

--- a/yazi-plugin/src/utils/history.rs
+++ b/yazi-plugin/src/utils/history.rs
@@ -1,0 +1,10 @@
+use mlua::{Function, Lua};
+use yazi_core::input::InputHistories;
+
+use super::Utils;
+
+impl Utils {
+	pub(super) fn input_history_max(lua: &Lua) -> mlua::Result<Function> {
+		lua.create_function(|_, ()| Ok(InputHistories::MAX))
+	}
+}

--- a/yazi-plugin/src/utils/mod.rs
+++ b/yazi-plugin/src/utils/mod.rs
@@ -1,5 +1,5 @@
 yazi_macro::mod_flat!(
-	app cache call hold http image json layer log preview process spot sync target tasks text time user utils
+	app cache call history hold http image json layer log preview process spot sync target tasks text time user utils
 );
 
 pub(crate) fn shutdown() { HELD.lock().clear(); }

--- a/yazi-plugin/src/utils/utils.rs
+++ b/yazi-plugin/src/utils/utils.rs
@@ -89,6 +89,9 @@ pub(crate) fn compose(
 			#[cfg(unix)]
 			b"host_name" => Utils::host_name(lua)?,
 
+			// History
+			b"input_history_max" => Utils::input_history_max(lua)?,
+
 			// HTTP
 			b"http" => return Utils::http(lua)?.into_lua(lua),
 

--- a/yazi-runner/src/loader/loader.rs
+++ b/yazi-runner/src/loader/loader.rs
@@ -38,6 +38,7 @@ impl Default for Loader {
 			("folder".to_owned(), preset!("plugins/folder").into()),
 			("font".to_owned(), preset!("plugins/font").into()),
 			("fzf".to_owned(), preset!("plugins/fzf").into()),
+			("history".to_owned(), preset!("plugins/history").into()),
 			("image".to_owned(), preset!("plugins/image").into()),
 			("init".to_owned(), preset!("plugins/init").into()),
 			("json".to_owned(), preset!("plugins/json").into()),


### PR DESCRIPTION
## Which issue does this PR resolve?

Implements disk persistence for `ya.input()` history via a DDS hook. Yazi core fires a `history` DDS event on input submission. Disk I/O lives in new `history.lua` preset plugin; users opt-in to this feature by adding `require("history"):setup()` in their `~/.config/yazi/init.lua`.

Technically no issue for this rn, but resolves an idea from #4104

## Rationale of this PR

- Core and plugin don't reference each other directly. [`pub_after_history()`](https://github.com/alastairsounds/yazi/blob/feat/input-history-hook/yazi-dds/src/pubsub.rs#L180) fires a `history` event on the DDS bus so `history.lua` can subscribe/handle the event itself. Core is kept storage-agnostic, and the plugin can be swapped out for a different persistence approach as needed.
- `history.lua` loads state from `~/.local/state/yazi/history.json` at startup and saves on every change. It enforces the 20-item cap from [`InputHistories::MAX`](https://github.com/alastairsounds/yazi/blob/feat/input-history-hook/yazi-core/src/input/history.rs#L9). Tried to keep implementation a similar shape to `projects.yazi`.
- Chose JSON for storage because `serde` is already used in core and it's a simple format for users to inspect.
- Reused the actor-dispatch pattern ([`Form` and `act()`](https://github.com/alastairsounds/yazi/blob/feat/input-history-hook/yazi-actor/src/actor.rs#L7)) for the new [`LoadHistory`](https://github.com/alastairsounds/yazi/blob/feat/input-history-hook/yazi-actor/src/mgr/load_history.rs#L8) actor. Shaped [`Ember::History`](https://github.com/alastairsounds/yazi/blob/feat/input-history-hook/yazi-dds/src/ember/ember.rs#L26) the same way as other `ember` variants.

### Known tradeoffs

Currently, two concurrent `yazi` processes will resolve to "last writer wins". Need to rethink the approach if we want histories to be shared across processes.

No user configurable "max" history length yet. Still hardcoded to 20.

## AI disclosure

Used Claude (Sonnet 5, claude code CLI) for `/code-review` to review my three original commits (`scaffold history pub/sub for persistence`, `wire up publish/load round trip`, and `add history.lua plugin for disk persistence`). Claude caught some issues where my code strayed from codebase standards (as referenced in `AGENTS.md`) and some lua/Windows implementation bugs, then proposed changes. I checked all the fixes and approved them.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
