### PR TITLE
feat: partial image erasure in legacy kitty graphics protocol

### DIFF
--- a/yazi-adapter/src/drivers/kgp.rs
+++ b/yazi-adapter/src/drivers/kgp.rs
@@ -409,7 +409,7 @@ impl Kgp {
 		Ok(buf)
 	}
 
-	fn image_id() -> u32 {
+	pub(super) fn image_id() -> u32 {
 		static CACHE: SyncCell<Option<u32>> = SyncCell::new(None);
 		match CACHE.get() {
 			Some(n) => n,

--- a/yazi-adapter/src/drivers/kgp_old.rs
+++ b/yazi-adapter/src/drivers/kgp_old.rs
@@ -6,35 +6,50 @@ use base64::{Engine, engine::general_purpose};
 use image::DynamicImage;
 use ratatui_core::layout::Rect;
 use yazi_emulator::{CLOSE, ESCAPE, Emulator, START};
-use yazi_tty::TTY;
+use yazi_macro::writef;
+use yazi_tty::{TTY, sequence::MoveTo};
 
-use crate::{ADAPTOR, Image};
+use crate::{ADAPTOR, Image, drivers::Kgp};
 
 pub(super) struct KgpOld;
 
 impl KgpOld {
 	pub(super) async fn image_show(path: PathBuf, max: Rect) -> Result<Rect> {
 		let img = Image::downscale(path, max).await?;
-		let area = Image::pixel_area((img.width(), img.height()), max);
-		let b = Self::encode(img).await?;
+		let size = (img.width(), img.height());
+		let area = Image::pixel_area(size, max);
+
+		let b1 = Self::encode(img, size).await?;
+		let b2 = Self::place(area, size)?;
 
 		ADAPTOR.image_hide()?;
 		ADAPTOR.shown_store(area);
 		Emulator::move_lock((area.x, area.y), |w| {
-			w.write_all(&b)?;
+			w.write_all(&b1)?;
+			w.write_all(&b2)?;
 			Ok(area)
 		})
 	}
 
-	pub(super) fn image_erase(_: Rect) -> Result<()> {
+	pub(super) fn image_erase(area: Rect) -> Result<()> {
 		let mut w = TTY.lockout();
-		write!(w, "{START}_Gq=2,a=d,d=A{ESCAPE}\\{CLOSE}")?;
+		let Some(shown) = ADAPTOR.shown_area() else {
+			writef!(w, "{START}_Gq=2,a=d,d=I,i={}{ESCAPE}\\{CLOSE}", Kgp::image_id())?;
+			return Ok(());
+		};
+
+		for y in area.top()..area.bottom() {
+			for x in area.left()..area.right() {
+				let p = (y - shown.y) as u32 * shown.width as u32 + (x - shown.x) as u32 + 1;
+				write!(w, "{START}_Gq=2,a=d,d=i,i={},p={p}{ESCAPE}\\{CLOSE}", Kgp::image_id())?;
+			}
+		}
 		w.flush()?;
 		Ok(())
 	}
 
-	async fn encode(img: DynamicImage) -> Result<Vec<u8>> {
-		fn output(raw: &[u8], format: u8, size: (u32, u32)) -> Result<Vec<u8>> {
+	async fn encode(img: DynamicImage, size: (u32, u32)) -> Result<Vec<u8>> {
+		fn output(raw: &[u8], format: u8, (w, h): (u32, u32)) -> Result<Vec<u8>> {
 			let b64 = general_purpose::STANDARD.encode(raw).into_bytes();
 
 			let mut it = b64.chunks(4096).peekable();
@@ -42,9 +57,8 @@ impl KgpOld {
 			if let Some(first) = it.next() {
 				write!(
 					buf,
-					"{START}_Gq=2,a=T,z=-1,C=1,f={format},s={},v={},m={};{}{ESCAPE}\\{CLOSE}",
-					size.0,
-					size.1,
+					"{START}_Gq=2,a=t,i={},f={format},s={w},v={h},m={};{}{ESCAPE}\\{CLOSE}",
+					Kgp::image_id(),
 					it.peek().is_some() as u8,
 					unsafe { str::from_utf8_unchecked(first) },
 				)?;
@@ -60,12 +74,37 @@ impl KgpOld {
 			Ok(buf)
 		}
 
-		let size = (img.width(), img.height());
 		tokio::task::spawn_blocking(move || match img {
 			DynamicImage::ImageRgb8(v) => output(v.as_raw(), 24, size),
 			DynamicImage::ImageRgba8(v) => output(v.as_raw(), 32, size),
 			v => output(v.into_rgb8().as_raw(), 24, size),
 		})
 		.await?
+	}
+
+	fn place(area: Rect, (w, h): (u32, u32)) -> Result<Vec<u8>> {
+		let mut buf = Vec::with_capacity(area.width as usize * area.height as usize * 100);
+		let (cols, rows) = (area.width as u32, area.height as u32);
+
+		for y in 0..area.height as u32 {
+			let top = h * y / rows;
+			let bottom = (h * (y + 1) / rows).max(top + 1);
+			for x in 0..area.width as u32 {
+				let left = w * x / cols;
+				let right = (w * (x + 1) / cols).max(left + 1);
+
+				let p = y * cols + x + 1;
+				write!(
+					buf,
+					"{}{START}_Gq=2,a=p,i={},p={p},x={left},y={top},w={},h={},c=1,r=1,z=-1,C=1{ESCAPE}\\{CLOSE}",
+					MoveTo(area.x + x as u16, area.y + y as u16),
+					Kgp::image_id(),
+					right - left,
+					bottom - top,
+				)?;
+			}
+		}
+
+		Ok(buf)
 	}
 }


### PR DESCRIPTION
Yazi uses kitty Unicode placeholders to render images, but for terminals that don't support it, it falls back to a legacy non-Unicode placeholder impl. That legacy impl has an issue: it can't partially erase images, but a bunch of popup components (input, confirm, etc.) in Yazi can be drawn on top of images.

Previously, when a popup was detected drawn over an image, the legacy impl would just clear all images on screen. With this PR, Yazi can now partially erase images, only erasing the parts that overlap with the popup:

<img width="1528" height="878" alt="9zJqSjAw" src="https://github.com/user-attachments/assets/ea4a10a7-9318-489d-919f-c5e61b3ce93b" />
