### PR TITLE
Fixed stuck backstack on invalid entries

### DIFF
--- a/yazi-core/src/tab/backstack.rs
+++ b/yazi-core/src/tab/backstack.rs
@@ -53,7 +53,9 @@ impl Backstack {
 	}
 
 	pub fn shift_backward(&mut self) -> Option<&UrlBuf> {
-		while self.cursor > 0 && self.stack[self.cursor - 1].as_local().map(Path::exists) == Some(false)
+		while self.cursor > 0
+			&& self.stack[self.cursor - 1].is_absolute()
+			&& self.stack[self.cursor - 1].as_local().map(Path::exists) == Some(false)
 		{
 			let _ = self.stack.remove(self.cursor - 1);
 			self.cursor -= 1;
@@ -70,6 +72,7 @@ impl Backstack {
 
 	pub fn shift_forward(&mut self) -> Option<&UrlBuf> {
 		while self.cursor + 1 < self.stack.len()
+			&& self.stack[self.cursor + 1].is_absolute()
 			&& self.stack[self.cursor + 1].as_local().map(Path::exists) == Some(false)
 		{
 			let _ = self.stack.remove(self.cursor + 1);

--- a/yazi-core/src/tab/backstack.rs
+++ b/yazi-core/src/tab/backstack.rs
@@ -1,4 +1,6 @@
-use yazi_shared::url::{Url, UrlBuf};
+use std::path::Path;
+
+use yazi_shared::url::{Url, UrlBuf, UrlLike as _};
 
 #[derive(Default)]
 pub struct Backstack {
@@ -35,7 +37,29 @@ impl Backstack {
 
 	pub fn current(&self) -> Option<&UrlBuf> { self.stack.get(self.cursor) }
 
+	fn remove_duplicates(&mut self) {
+		loop {
+			if self.cursor > 0 && self.stack[self.cursor] == self.stack[self.cursor - 1] {
+				let _ = self.stack.remove(self.cursor);
+				self.cursor -= 1;
+			} else if self.cursor + 1 < self.stack.len()
+				&& self.stack[self.cursor] == self.stack[self.cursor + 1]
+			{
+				let _ = self.stack.remove(self.cursor + 1);
+			} else {
+				break;
+			}
+		}
+	}
+
 	pub fn shift_backward(&mut self) -> Option<&UrlBuf> {
+		while self.cursor > 0 && self.stack[self.cursor - 1].as_local().map(Path::exists) == Some(false)
+		{
+			let _ = self.stack.remove(self.cursor - 1);
+			self.cursor -= 1;
+		}
+		self.remove_duplicates();
+
 		if self.cursor > 0 {
 			self.cursor -= 1;
 			Some(&self.stack[self.cursor])
@@ -45,6 +69,14 @@ impl Backstack {
 	}
 
 	pub fn shift_forward(&mut self) -> Option<&UrlBuf> {
+		while self.cursor + 1 < self.stack.len()
+			&& self.stack[self.cursor + 1].as_local().map(Path::exists) == Some(false)
+		{
+			let _ = self.stack.remove(self.cursor + 1);
+		}
+
+		self.remove_duplicates();
+
 		if self.cursor + 1 >= self.stack.len() {
 			None
 		} else {


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves [#4292](https://github.com/sxyazi/yazi/issues/4292)

## Rationale of this PR

Upon every shift, be in backward or forward, there are now checks that check for validity. Furthermore, if an entry is found invalid, the entry is removed from the backtrace and nearby entries are checks for duplication. That prevent "no-op" situation where three entries would be A-X-A, X would be found invalid and now A-A would be next to each other. That would result in shift not doing anything, because it'd check the position from position A to A -> nothing would happen

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

I did not use any LLM for anything at all. I looked at yazi to understand the problem, I wrote the code and tested it to check if it's working or not