### PR TITLE
perf: kitty graphics over shared memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Style
 
-- Follow nearby code and use idiomatic Rust and Lua. Rust uses `snake_case` for modules, functions, and fields and `PascalCase` for types, traits, and variants. Lua uses PascalCase component tables, `local M` plugin modules, `snake_case` methods/locals, and `_name` private fields.
+- Follow nearby code and use idiomatic Rust and Lua. In Rust, treat directories as modules and files as types: always prefer `mod_pub!` for directory exports and `mod_flat!` for file exports. Keep `mod.rs` and `lib.rs` limited to exports; put module-wide implementation in a same-named file (for example, `core/core.rs`). Rust uses `snake_case` for modules, functions, and fields and `PascalCase` for types, traits, and variants. Lua uses PascalCase component tables, `local M` plugin modules, `snake_case` methods/locals, and `_name` private fields.
 - Preserve established terms and type families: `Url`/`UrlBuf`/`UrlCow`, `PathDyn`/`PathBufDyn`/`PathCow`, `*Ref`, `*Arc`, `*Opt`, `*State`, `*Job`, `*Prog`, `File`, `Folder`, `Tab`, `Mgr`, and `Task`. Use `Url` for logical locations and `Path` for filesystem paths.
 - `key()` identifies a file-list entry; `urn()` is the raw URL path tail. Use `key()` for list state and `urn()` for filesystem-path semantics; do not substitute them mechanically.
 - Reuse established plugin and event names (`fetch`, `preload`, `peek`, `seek`, `spot`, `entry`, `setup`, `yank`, `hover`, and `select`) across Rust, Lua, and configuration.
@@ -27,7 +27,7 @@
 - Search and reuse first. For new features, extend existing infrastructure or data structures with general, reusable capabilities when that keeps the final code concise.
 - Use `gh` to read GitHub issues, pull requests, and their discussions.
 - For refactors, inspect the whole target module, its callers, and the surrounding lifecycle first. Understand the system's established assumptions before adding local safeguards; distinguish required invariants from acceptable compromises, and ask when that boundary materially affects the design. Look for duplicated work, redundant I/O, underpowered return values, one-use wrappers, and reusable cross-platform abstractions; implement high-confidence, behavior-preserving simplifications while preserving error, fallback, and platform semantics.
-- Keep diffs minimal and avoid unrelated refactors, speculative abstractions, and defensive handling for states the system already excludes. Prefer clear, flat control flow, expressions, and positive predicates; use standard combinators, early returns, ordered branches, and match guards to avoid nested conditionals, compound negation, and unnecessary wrapper syntax. When idiomatic and equivalent, prefer visually parallel forms such as `true as usize` over `usize::from(true)`. Comment only behavior the code cannot explain.
+- Prefer the simplest design that satisfies the requirements. Keep diffs minimal and avoid overengineering, unrelated refactors, speculative abstractions, and defensive handling for states the system already excludes. Prefer clear, flat control flow, expressions, and positive predicates; use standard combinators, early returns, ordered branches, and match guards to avoid nested conditionals, compound negation, and unnecessary wrapper syntax. When idiomatic and equivalent, prefer visually parallel forms such as `true as usize` over `usize::from(true)`. Comment only behavior the code cannot explain.
 - Keep responsibility boundaries clear and cohesive. Prefer pure functions, explicit invariants, and idempotent operations when repeated calls are natural and idempotency removes coordination or state. Favor convention over configuration when invariants can eliminate state or coordination. Put reusable code in the lowest suitable shared layer; avoid unnecessary dependencies and allocations. Prefer borrowed values and existing wrappers.
 - Initialize crates explicitly from the application entrypoint in dependency order; a module must not initialize another module as a side effect.
 - Use stable Rust APIs; nightly is formatting-only—apply Rust formatting directly with `rustfmt +nightly **/*.rs`. Use only `pub`, `pub(super)`, and `pub(crate)`—never `pub(in ...)`.
@@ -39,7 +39,7 @@
 ## Validation
 
 - Prefer targeted debug checks; use multiple `-p` flags for affected crates before the whole workspace.
-- When investigating bugs, add temporary diagnostics when useful (`tracing` in Rust and `ya.dbg` in Lua), reproduce in a simulated terminal with `YAZI_LOG=debug`, and inspect the log file to pinpoint the cause; remove diagnostics before handoff.
+- When investigating bugs, add temporary diagnostics when useful (`tracing` in Rust and `ya.dbg` in Lua), reproduce in a simulated terminal with `YAZI_LOG=debug`, and inspect the log file to pinpoint the cause. When debugging on a real terminal, use its IPC remote-control interface whenever supported. Remove temporary diagnostics before handoff.
 
 ```sh
 cargo check -p <package>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ### Improved
 
+- Kitty graphics over shared memory ([#4294])
 - Send terminal probe requests immediately at startup ([#4260])
 - Tune light/dark theme detection ([#4265])
 
@@ -1842,3 +1843,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4271]: https://github.com/sxyazi/yazi/pull/4271
 [#4276]: https://github.com/sxyazi/yazi/pull/4276
 [#4279]: https://github.com/sxyazi/yazi/pull/4279
+[#4294]: https://github.com/sxyazi/yazi/pull/4294

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5145,6 +5145,7 @@ dependencies = [
  "tokio",
  "yazi-config",
  "yazi-emulator",
+ "yazi-ffi",
  "yazi-fs",
  "yazi-macro",
  "yazi-shared",
@@ -5359,9 +5360,13 @@ version = "26.8.15"
 dependencies = [
  "anyhow",
  "core-foundation-sys",
+ "data-encoding",
  "libc",
  "objc2",
+ "rand 0.10.2",
+ "rustix",
  "windows 0.62.2",
+ "windows-sys 0.61.2",
  "yazi-macro",
 ]
 
@@ -5710,6 +5715,7 @@ dependencies = [
  "parking_lot",
  "ratatui-core",
  "windows-sys 0.61.2",
+ "yazi-ffi",
  "yazi-macro",
  "yazi-shim",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
  "digest",
 ]
@@ -337,27 +337,25 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
 dependencies = [
  "bon-macros",
- "rustversion",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "ident_case",
  "prettyplease",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -606,9 +604,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -886,12 +884,11 @@ checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
+checksum = "3e98a7e119cd347f4201e1159b19831029e203e2d8b790547708e8157b4acf1e"
 dependencies = [
  "deadpool-runtime",
- "num_cpus",
  "tokio",
 ]
 
@@ -1499,12 +1496,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2441,16 +2432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,7 +2527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
 ]
 
@@ -2862,12 +2843,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2998,9 +2979,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
  "serde",
@@ -4711,9 +4692,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ regex                 = "1.13.1"
 regex-syntax          = "0.8.11"
 reqwest               = { version = "0.13.4", default-features = false, features = [ "rustls-no-provider", "stream" ] }
 rustls                = { version = "0.23.43", default-features = false, features = [ "ring", "std" ] }
+rustix                = { version = "1.1.4", default-features = false, features = [ "std", "fs", "mm", "shm", "stdio", "termios", "event" ] }
 russh                 = { version = "0.63.1", default-features = false, features = [ "ring", "rsa" ] }
 scopeguard            = "1.2.0"
 serde                 = { version = "1.0.229", features = [ "derive" ] }

--- a/yazi-adapter/Cargo.toml
+++ b/yazi-adapter/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 yazi-config   = { path = "../yazi-config", version = "26.8.15" }
 yazi-emulator = { path = "../yazi-emulator", version = "26.8.15" }
+yazi-ffi      = { path = "../yazi-ffi", version = "26.8.15" }
 yazi-fs       = { path = "../yazi-fs", version = "26.8.15" }
 yazi-macro    = { path = "../yazi-macro", version = "26.8.15" }
 yazi-shared   = { path = "../yazi-shared", version = "26.8.15" }

--- a/yazi-adapter/src/drivers/drivers.rs
+++ b/yazi-adapter/src/drivers/drivers.rs
@@ -28,7 +28,7 @@ impl From<&Emulator> for Drivers {
 				(false, false) => vec![],
 			}),
 			Brand::Zellij => Self(match (value.kgp.get(), value.sixel.get()) {
-				(true, true) => vec![D::KgpOld, D::Sixel],
+				(true, true) => vec![D::Sixel, D::KgpOld],
 				(true, false) => vec![D::KgpOld],
 				(false, true) => vec![D::Sixel],
 				(false, false) => vec![],

--- a/yazi-adapter/src/drivers/kgp.rs
+++ b/yazi-adapter/src/drivers/kgp.rs
@@ -1,16 +1,17 @@
 use core::str;
 use std::{io::Write, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use base64::{Engine, engine::general_purpose};
 use image::DynamicImage;
 use ratatui_core::{layout::Rect, style::Color};
 use yazi_config::THEME;
-use yazi_emulator::{CLOSE, ESCAPE, Emulator, START};
-use yazi_shim::cell::SyncCell;
+use yazi_emulator::{CLOSE, EMULATOR, ESCAPE, Emulator, START};
+use yazi_ffi::shm::NamedSharedMemory;
 use yazi_tty::sequence::{MoveTo, ResetAttrs, SetBg, SetFg};
 
-use crate::{ADAPTOR, image::Image};
+use super::KgpPayload;
+use crate::{ADAPTOR, drivers::kgp_id, image::Image};
 
 static DIACRITICS: [char; 297] = [
 	'\u{0305}',
@@ -348,32 +349,49 @@ impl Kgp {
 		})
 	}
 
-	async fn encode(img: DynamicImage) -> Result<Vec<u8>> {
-		fn output(raw: &[u8], format: u8, size: (u32, u32)) -> Result<Vec<u8>> {
-			let b64 = general_purpose::STANDARD.encode(raw).into_bytes();
+	async fn encode(img: DynamicImage) -> Result<KgpPayload> {
+		fn output(raw: &[u8], format: u8, size: (u32, u32)) -> Result<KgpPayload> {
+			output_shm(raw, format, size).or_else(|_| output_b64(raw, format, size))
+		}
 
+		fn output_shm(raw: &[u8], format: u8, (w, h): (u32, u32)) -> Result<KgpPayload> {
+			if !EMULATOR.kgp_shm.get() {
+				bail!("Shared memory is not supported by the terminal")
+			}
+
+			let mut pl = KgpPayload::with(200, NamedSharedMemory::new(raw)?);
+			write!(
+				pl,
+				"{START}_Gq=2,a=T,C=1,U=1,t=s,f={format},s={w},v={h},i={},S={};{}{ESCAPE}\\{CLOSE}",
+				kgp_id(),
+				raw.len(),
+				pl.name(),
+			)?;
+
+			Ok(pl)
+		}
+
+		fn output_b64(raw: &[u8], format: u8, (w, h): (u32, u32)) -> Result<KgpPayload> {
+			let b64 = general_purpose::STANDARD.encode(raw).into_bytes();
 			let mut it = b64.chunks(4096).peekable();
-			let mut buf = Vec::with_capacity(b64.len() + it.len() * 50);
+			let mut pl = KgpPayload::new(b64.len() + it.len() * 50);
 			if let Some(first) = it.next() {
 				write!(
-					buf,
-					"{START}_Gq=2,a=T,C=1,U=1,f={format},s={},v={},i={},m={};{}{ESCAPE}\\{CLOSE}",
-					size.0,
-					size.1,
-					Kgp::image_id(),
+					pl,
+					"{START}_Gq=2,a=T,C=1,U=1,f={format},s={w},v={h},i={},m={};{}{ESCAPE}\\{CLOSE}",
+					kgp_id(),
 					it.peek().is_some() as u8,
 					unsafe { str::from_utf8_unchecked(first) },
 				)?;
 			}
 
 			while let Some(chunk) = it.next() {
-				write!(buf, "{START}_Gm={};{}{ESCAPE}\\{CLOSE}", it.peek().is_some() as u8, unsafe {
+				write!(pl, "{START}_Gm={};{}{ESCAPE}\\{CLOSE}", it.peek().is_some() as u8, unsafe {
 					str::from_utf8_unchecked(chunk)
 				})?;
 			}
 
-			write!(buf, "{CLOSE}")?;
-			Ok(buf)
+			Ok(pl)
 		}
 
 		let size = (img.width(), img.height());
@@ -388,7 +406,7 @@ impl Kgp {
 	fn place(area: &Rect) -> Result<Vec<u8>> {
 		let mut buf = Vec::with_capacity(area.width as usize * area.height as usize * 3 + 500);
 
-		let id = Self::image_id();
+		let id = kgp_id();
 		let (r, g, b) = ((id >> 16) & 0xff, (id >> 8) & 0xff, id & 0xff);
 		write!(buf, "{}", SetFg(Color::Rgb(r as u8, g as u8, b as u8)))?;
 
@@ -407,17 +425,5 @@ impl Kgp {
 
 		write!(buf, "{ResetAttrs}")?;
 		Ok(buf)
-	}
-
-	pub(super) fn image_id() -> u32 {
-		static CACHE: SyncCell<Option<u32>> = SyncCell::new(None);
-		match CACHE.get() {
-			Some(n) => n,
-			None => {
-				let n = std::process::id() % (0xffffff + 1);
-				CACHE.set(Some(n));
-				n
-			}
-		}
 	}
 }

--- a/yazi-adapter/src/drivers/kgp_common.rs
+++ b/yazi-adapter/src/drivers/kgp_common.rs
@@ -1,0 +1,48 @@
+use std::{io::{self, Write}, ops::Deref};
+
+use base64::{Engine, engine::general_purpose};
+use yazi_ffi::shm::NamedSharedMemory;
+use yazi_shim::cell::SyncCell;
+
+pub(super) fn kgp_id() -> u32 {
+	static CACHE: SyncCell<Option<u32>> = SyncCell::new(None);
+	match CACHE.get() {
+		Some(n) => n,
+		None => {
+			let n = std::process::id() % (0xffffff + 1);
+			CACHE.set(Some(n));
+			n
+		}
+	}
+}
+
+// --- KgpPayload
+pub(super) struct KgpPayload {
+	bytes: Vec<u8>,
+	_shm:  Option<NamedSharedMemory>,
+}
+
+impl Deref for KgpPayload {
+	type Target = [u8];
+
+	fn deref(&self) -> &Self::Target { &self.bytes }
+}
+
+impl KgpPayload {
+	pub(super) fn new(cap: usize) -> Self { Self { bytes: Vec::with_capacity(cap), _shm: None } }
+
+	pub(super) fn with(cap: usize, shm: NamedSharedMemory) -> Self {
+		Self { bytes: Vec::with_capacity(cap), _shm: Some(shm) }
+	}
+
+	pub(super) fn name(&self) -> String {
+		let Some(shm) = &self._shm else { return String::new() };
+		general_purpose::STANDARD.encode(&shm.name)
+	}
+}
+
+impl Write for KgpPayload {
+	fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.bytes.write(buf) }
+
+	fn flush(&mut self) -> io::Result<()> { self.bytes.flush() }
+}

--- a/yazi-adapter/src/drivers/kgp_old.rs
+++ b/yazi-adapter/src/drivers/kgp_old.rs
@@ -1,15 +1,17 @@
 use core::str;
 use std::{io::Write, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use base64::{Engine, engine::general_purpose};
 use image::DynamicImage;
 use ratatui_core::layout::Rect;
-use yazi_emulator::{CLOSE, ESCAPE, Emulator, START};
+use yazi_emulator::{CLOSE, EMULATOR, ESCAPE, Emulator, START};
+use yazi_ffi::shm::NamedSharedMemory;
 use yazi_macro::writef;
 use yazi_tty::{TTY, sequence::MoveTo};
 
-use crate::{ADAPTOR, Image, drivers::Kgp};
+use super::KgpPayload;
+use crate::{ADAPTOR, Image, drivers::kgp_id};
 
 pub(super) struct KgpOld;
 
@@ -34,44 +36,63 @@ impl KgpOld {
 	pub(super) fn image_erase(area: Rect) -> Result<()> {
 		let mut w = TTY.lockout();
 		let Some(shown) = ADAPTOR.shown_area() else {
-			writef!(w, "{START}_Gq=2,a=d,d=I,i={}{ESCAPE}\\{CLOSE}", Kgp::image_id())?;
+			writef!(w, "{START}_Gq=2,a=d,d=I,i={}{ESCAPE}\\{CLOSE}", kgp_id())?;
 			return Ok(());
 		};
 
 		for y in area.top()..area.bottom() {
 			for x in area.left()..area.right() {
 				let p = (y - shown.y) as u32 * shown.width as u32 + (x - shown.x) as u32 + 1;
-				write!(w, "{START}_Gq=2,a=d,d=i,i={},p={p}{ESCAPE}\\{CLOSE}", Kgp::image_id())?;
+				write!(w, "{START}_Gq=2,a=d,d=i,i={},p={p}{ESCAPE}\\{CLOSE}", kgp_id())?;
 			}
 		}
 		w.flush()?;
 		Ok(())
 	}
 
-	async fn encode(img: DynamicImage, size: (u32, u32)) -> Result<Vec<u8>> {
-		fn output(raw: &[u8], format: u8, (w, h): (u32, u32)) -> Result<Vec<u8>> {
-			let b64 = general_purpose::STANDARD.encode(raw).into_bytes();
+	async fn encode(img: DynamicImage, size: (u32, u32)) -> Result<KgpPayload> {
+		fn output(raw: &[u8], format: u8, size: (u32, u32)) -> Result<KgpPayload> {
+			output_shm(raw, format, size).or_else(|_| output_b64(raw, format, size))
+		}
 
+		fn output_shm(raw: &[u8], format: u8, (w, h): (u32, u32)) -> Result<KgpPayload> {
+			if !EMULATOR.kgp_shm.get() {
+				bail!("Shared memory is not supported by the terminal")
+			}
+
+			let mut pl = KgpPayload::with(200, NamedSharedMemory::new(raw)?);
+			write!(
+				pl,
+				"{START}_Gq=2,a=t,t=s,i={},f={format},s={w},v={h},S={};{}{ESCAPE}\\{CLOSE}",
+				kgp_id(),
+				raw.len(),
+				pl.name(),
+			)?;
+
+			Ok(pl)
+		}
+
+		fn output_b64(raw: &[u8], format: u8, (w, h): (u32, u32)) -> Result<KgpPayload> {
+			let b64 = general_purpose::STANDARD.encode(raw).into_bytes();
 			let mut it = b64.chunks(4096).peekable();
-			let mut buf = Vec::with_capacity(b64.len() + it.len() * 50);
+			let mut pl = KgpPayload::new(b64.len() + it.len() * 50);
 			if let Some(first) = it.next() {
 				write!(
-					buf,
+					pl,
 					"{START}_Gq=2,a=t,i={},f={format},s={w},v={h},m={};{}{ESCAPE}\\{CLOSE}",
-					Kgp::image_id(),
+					kgp_id(),
 					it.peek().is_some() as u8,
 					unsafe { str::from_utf8_unchecked(first) },
 				)?;
 			}
 
 			while let Some(chunk) = it.next() {
-				write!(buf, "{START}_Gm={};{}{ESCAPE}\\{CLOSE}", it.peek().is_some() as u8, unsafe {
+				write!(pl, "{START}_Gm={};{}{ESCAPE}\\{CLOSE}", it.peek().is_some() as u8, unsafe {
 					str::from_utf8_unchecked(chunk)
 				})?;
 			}
 
-			write!(buf, "{CLOSE}")?;
-			Ok(buf)
+			Ok(pl)
 		}
 
 		tokio::task::spawn_blocking(move || match img {
@@ -98,7 +119,7 @@ impl KgpOld {
 					buf,
 					"{}{START}_Gq=2,a=p,i={},p={p},x={left},y={top},w={},h={},c=1,r=1,z=-1,C=1{ESCAPE}\\{CLOSE}",
 					MoveTo(area.x + x as u16, area.y + y as u16),
-					Kgp::image_id(),
+					kgp_id(),
 					right - left,
 					bottom - top,
 				)?;

--- a/yazi-adapter/src/drivers/mod.rs
+++ b/yazi-adapter/src/drivers/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(chafa driver drivers iip kgp kgp_old sixel ueberzug);
+yazi_macro::mod_flat!(chafa driver drivers iip kgp kgp_common kgp_old sixel ueberzug);

--- a/yazi-emulator/src/emulator.rs
+++ b/yazi-emulator/src/emulator.rs
@@ -17,6 +17,7 @@ pub struct Emulator {
 	version:              ArcSwap<String>,
 	csi_u:                SyncCell<Option<u8>>,
 	pub kgp:              SyncCell<bool>,
+	pub kgp_shm:          SyncCell<bool>,
 	pub sixel:            SyncCell<bool>,
 	background:           SyncCell<Option<[u16; 3]>>,
 	color_scheme:         SyncCell<Option<bool>>,
@@ -65,6 +66,7 @@ impl Emulator {
 		self.brand.set(Brand::Unknown);
 		self.version.store(Default::default());
 		self.kgp.set(false);
+		self.kgp_shm.set(false);
 		self.sixel.set(false);
 
 		self.request()?;
@@ -90,7 +92,8 @@ impl Emulator {
 			}
 			Report::BackgroundColor(rgb) => self.background.set(Some(*rgb)),
 			Report::ColorScheme(light) => self.color_scheme.set(Some(*light)),
-			Report::KittyGraphics { id: 31, ok } => self.kgp.set(*ok),
+			Report::KittyGraphics { id: 278941603, ok } => self.kgp.set(*ok),
+			Report::KittyGraphics { id: 916472805, ok } => self.kgp_shm.set(*ok),
 			Report::Clipboard(supported) => self.osc_5522.set(*supported),
 			_ => {}
 		}

--- a/yazi-emulator/src/probe.rs
+++ b/yazi-emulator/src/probe.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, time::Duration};
+use std::{fmt::{self, Display}, time::Duration};
 
 use anyhow::{Result, bail};
 use tokio::{sync::Notify, time::{self, timeout}};
@@ -6,17 +6,23 @@ use yazi_macro::{error, writef};
 use yazi_shared::id::{Id, Ids};
 use yazi_shim::cell::SyncCell;
 use yazi_term::{TERM, event::{Event, Report}, stream::EventStream};
-use yazi_tty::{TTY, sequence::{EraseLine, ProbeClipboard, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCsiU, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKittyGraphics, RequestXtVersion, RestoreCursor, SaveCursor, TmuxPassthrough}};
+use yazi_tty::{TTY, sequence::{EraseLine, ProbeClipboard, RequestBgColor, RequestCellPixelSize, RequestColorScheme, RequestCsiU, RequestCursorBlink, RequestCursorStyle, RequestDA1, RequestKgp, RequestKgpShm, RequestXtVersion, RestoreCursor, SaveCursor, TmuxPassthrough}};
 
 use crate::{Emulator, Mux};
 
 static IDS: Ids = Ids::new();
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Probe {
 	pub id:    SyncCell<Id>,
 	completed: SyncCell<bool>,
 	notifier:  Notify,
+}
+
+impl fmt::Debug for Probe {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("Probe").field("id", &self.id).field("completed", &self.completed).finish()
+	}
 }
 
 impl Probe {
@@ -106,14 +112,16 @@ impl Emulator {
 	}
 
 	pub(super) fn request(&self) -> Result<()> {
-		let w = |t: &'static dyn Display| TmuxPassthrough(t, self.mux.get().is_some());
+		fn w<T: Display>(t: T, mux: bool) -> impl Display { TmuxPassthrough(t, mux) }
 
+		let mux = self.mux.get().is_some();
 		writef!(
 			TTY.writer(),
-			"{SaveCursor}{RequestColorScheme}{RequestBgColor}{RequestCursorBlink}{RequestCursorStyle}{}{}{RequestCellPixelSize}{ProbeClipboard}{RequestCsiU}{}{}{RestoreCursor}",
-			w(&RequestXtVersion),
-			w(&RequestKittyGraphics),
-			w(&RequestDA1),
+			"{SaveCursor}{RequestColorScheme}{RequestBgColor}{RequestCursorBlink}{RequestCursorStyle}{}{}{}{RequestCellPixelSize}{ProbeClipboard}{RequestCsiU}{}{}{RestoreCursor}",
+			w(RequestXtVersion, mux),
+			w(RequestKgp, mux),
+			w(RequestKgpShm::new(), mux),
+			w(RequestDA1, mux),
 			EraseLine::BeforeCursor
 		)?;
 

--- a/yazi-ffi/Cargo.toml
+++ b/yazi-ffi/Cargo.toml
@@ -16,14 +16,18 @@ workspace = true
 yazi-macro = { path = "../yazi-macro", version = "26.8.15" }
 
 # External dependencies
-anyhow = { workspace = true }
+anyhow        = { workspace = true }
+data-encoding = { workspace = true }
+rand          = { workspace = true }
 
 [target."cfg(unix)".dependencies]
-libc = { workspace = true }
+libc   = { workspace = true }
+rustix = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = { workspace = true }
 objc2               = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.2", features = [ "Win32_System_Com" ] }
+windows     = { version = "0.62.2", features = [ "Win32_System_Com" ] }
+windows-sys = { version = "0.61.2", features = [ "Win32_Foundation", "Win32_System_Memory" ] }

--- a/yazi-ffi/src/lib.rs
+++ b/yazi-ffi/src/lib.rs
@@ -1,3 +1,5 @@
+yazi_macro::mod_pub!(shm);
+
 #[cfg(target_os = "macos")]
 yazi_macro::mod_flat!(cf_dict cf_string disk_arbitration io_kit);
 

--- a/yazi-ffi/src/shm/common.rs
+++ b/yazi-ffi/src/shm/common.rs
@@ -1,0 +1,36 @@
+use std::io;
+
+pub struct NamedSharedMemory {
+	pub name:          Vec<u8>,
+	#[cfg(any(unix, windows))]
+	pub(super) ptr:    *mut std::ffi::c_void,
+	#[cfg(unix)]
+	pub(super) len:    usize,
+	#[cfg(unix)]
+	pub(super) _fd:    std::os::fd::OwnedFd,
+	#[cfg(windows)]
+	pub(super) handle: *mut std::ffi::c_void,
+}
+
+// SAFETY: This value only uses the pointer to clean up the mapping in `Drop`;
+// it never reads or writes through it, so moving the value to another thread is
+// safe.
+#[cfg(any(unix, windows))]
+unsafe impl Send for NamedSharedMemory {}
+
+impl NamedSharedMemory {
+	#[cfg(any(unix, windows))]
+	pub(super) fn random_name(prefix: &[u8]) -> io::Result<Vec<u8>> {
+		use data_encoding::BASE32_NOPAD;
+		use rand::{TryRng, rngs::SysRng};
+
+		let mut bytes = [0; 15];
+		SysRng.try_fill_bytes(&mut bytes)?;
+
+		let mut name = Vec::with_capacity(prefix.len() + 24);
+		name.extend_from_slice(prefix);
+		name.extend_from_slice(BASE32_NOPAD.encode_mut_str(&bytes, &mut [0; 24]).as_bytes());
+
+		Ok(name)
+	}
+}

--- a/yazi-ffi/src/shm/mod.rs
+++ b/yazi-ffi/src/shm/mod.rs
@@ -1,0 +1,10 @@
+yazi_macro::mod_flat!(common);
+
+#[cfg(unix)]
+yazi_macro::mod_flat!(unix);
+
+#[cfg(windows)]
+yazi_macro::mod_flat!(windows);
+
+#[cfg(not(any(unix, windows)))]
+yazi_macro::mod_flat!(unsupported);

--- a/yazi-ffi/src/shm/unix.rs
+++ b/yazi-ffi/src/shm/unix.rs
@@ -1,0 +1,45 @@
+use std::{io::{self, ErrorKind}, ptr};
+
+use rustix::{fs::{self, Mode}, mm::{self, MapFlags, ProtFlags}, shm::{self, OFlags}};
+
+use super::NamedSharedMemory;
+
+impl Drop for NamedSharedMemory {
+	fn drop(&mut self) {
+		// The peer unlinks the object after reading it.
+		unsafe { mm::munmap(self.ptr, self.len) }.ok();
+	}
+}
+
+impl NamedSharedMemory {
+	pub fn new(data: &[u8]) -> io::Result<Self> {
+		if data.is_empty() {
+			return Err(io::Error::new(ErrorKind::InvalidInput, "empty shared memory"));
+		}
+
+		let name = Self::random_name(b"/yazi-")?;
+		let fd =
+			shm::open(&name, OFlags::CREATE | OFlags::EXCL | OFlags::RDWR, Mode::RUSR | Mode::WUSR)?;
+
+		// Resize the shared memory object to the size of our data.
+		fs::ftruncate(&fd, data.len() as u64).inspect_err(|_| _ = shm::unlink(&name))?;
+
+		// Map the shared memory object into our address space.
+		let ptr = unsafe {
+			mm::mmap(
+				ptr::null_mut(),
+				data.len(),
+				ProtFlags::READ | ProtFlags::WRITE,
+				MapFlags::SHARED,
+				&fd,
+				0,
+			)
+		}
+		.inspect_err(|_| _ = shm::unlink(&name))?;
+
+		// Copy the data into the shared memory.
+		unsafe { ptr::copy_nonoverlapping(data.as_ptr(), ptr.cast(), data.len()) };
+
+		Ok(Self { name, _fd: fd, ptr, len: data.len() })
+	}
+}

--- a/yazi-ffi/src/shm/unsupported.rs
+++ b/yazi-ffi/src/shm/unsupported.rs
@@ -1,0 +1,9 @@
+use std::io::{self, ErrorKind};
+
+use super::NamedSharedMemory;
+
+impl NamedSharedMemory {
+	pub fn new(_data: &[u8]) -> io::Result<Self> {
+		Err(io::Error::new(ErrorKind::Unsupported, "shared memory is unsupported on this platform"))
+	}
+}

--- a/yazi-ffi/src/shm/windows.rs
+++ b/yazi-ffi/src/shm/windows.rs
@@ -1,0 +1,50 @@
+use std::{io::{self, ErrorKind}, ptr};
+
+use windows_sys::Win32::{Foundation::{CloseHandle, INVALID_HANDLE_VALUE}, System::Memory::{CreateFileMappingW, FILE_MAP_WRITE, MEMORY_MAPPED_VIEW_ADDRESS, MapViewOfFile, PAGE_READWRITE, UnmapViewOfFile}};
+
+use super::NamedSharedMemory;
+
+impl Drop for NamedSharedMemory {
+	fn drop(&mut self) {
+		unsafe {
+			UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS { Value: self.ptr });
+			CloseHandle(self.handle);
+		}
+	}
+}
+
+impl NamedSharedMemory {
+	pub fn new(data: &[u8]) -> io::Result<Self> {
+		if data.is_empty() {
+			return Err(io::Error::new(ErrorKind::InvalidInput, "empty shared memory"));
+		}
+
+		let name = Self::random_name(b"yazi-")?;
+		let wide: Vec<u16> = name.iter().map(|&b| b as u16).chain([0]).collect();
+
+		let size = data.len() as u64;
+		let handle = unsafe {
+			CreateFileMappingW(
+				INVALID_HANDLE_VALUE,
+				ptr::null(),
+				PAGE_READWRITE,
+				(size >> 32) as u32,
+				size as u32,
+				wide.as_ptr(),
+			)
+		};
+		if handle.is_null() {
+			return Err(io::Error::last_os_error());
+		}
+
+		let view = unsafe { MapViewOfFile(handle, FILE_MAP_WRITE, 0, 0, data.len()) };
+		if view.Value.is_null() {
+			let err = io::Error::last_os_error();
+			unsafe { CloseHandle(handle) };
+			return Err(err);
+		}
+
+		unsafe { ptr::copy_nonoverlapping(data.as_ptr(), view.Value.cast(), data.len()) };
+		Ok(Self { name, ptr: view.Value, handle })
+	}
+}

--- a/yazi-shared/src/non_empty_string.rs
+++ b/yazi-shared/src/non_empty_string.rs
@@ -1,8 +1,8 @@
-use std::{borrow::Borrow, ffi::{OsStr, OsString}, fmt::{Display, Formatter}, ops::Deref};
+use std::{borrow::Borrow, ffi::{OsStr, OsString}, fmt::{Debug, Display, Formatter}, ops::Deref};
 
 use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct NonEmptyString(String);
 
@@ -40,6 +40,10 @@ impl AsRef<OsStr> for NonEmptyString {
 
 impl Display for NonEmptyString {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result { Display::fmt(&self.0, f) }
+}
+
+impl Debug for NonEmptyString {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result { Debug::fmt(&self.0, f) }
 }
 
 impl From<NonEmptyString> for String {

--- a/yazi-term/Cargo.toml
+++ b/yazi-term/Cargo.toml
@@ -32,7 +32,7 @@ tokio       = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.4.4"
-rustix      = { version = "1.1.4" , default-features = false, features = [ "std", "stdio", "termios", "event" ] }
+rustix      = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [ "Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Threading" ] }

--- a/yazi-tty/Cargo.toml
+++ b/yazi-tty/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+yazi-ffi   = { path = "../yazi-ffi", version = "26.8.15" }
 yazi-macro = { path = "../yazi-macro", version = "26.8.15" }
 yazi-shim  = { path = "../yazi-shim", version = "26.8.15" }
 

--- a/yazi-tty/src/sequence/query.rs
+++ b/yazi-tty/src/sequence/query.rs
@@ -1,5 +1,8 @@
 use std::fmt::{self, Display};
 
+use base64::{Engine, engine::general_purpose};
+use yazi_ffi::shm::NamedSharedMemory;
+
 /// XTVERSION request (secondary DA)
 pub struct RequestXtVersion;
 
@@ -36,11 +39,34 @@ impl Display for RequestDA1 {
 }
 
 /// Query Kitty graphics protocol capabilities
-pub struct RequestKittyGraphics;
+pub struct RequestKgp;
 
-impl Display for RequestKittyGraphics {
+impl Display for RequestKgp {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.write_str("\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\")
+		f.write_str("\x1b_Gi=278941603,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\")
+	}
+}
+
+/// Query Kitty graphics protocol capabilities through shared memory.
+pub struct RequestKgpShm {
+	shm: Option<NamedSharedMemory>,
+}
+
+impl RequestKgpShm {
+	pub fn new() -> Self { Self { shm: NamedSharedMemory::new(&[0; 3]).ok() } }
+}
+
+impl Display for RequestKgpShm {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		if let Some(shm) = &self.shm {
+			write!(
+				f,
+				"\x1b_Gi=916472805,s=1,v=1,a=q,t=s,f=24,S=3;{}\x1b\\",
+				general_purpose::STANDARD.encode(&shm.name),
+			)?;
+		}
+
+		Ok(())
 	}
 }
 

--- a/yazi-vfs/Cargo.toml
+++ b/yazi-vfs/Cargo.toml
@@ -24,7 +24,7 @@ yazi-shim    = { path = "../yazi-shim", version = "26.8.15" }
 
 # External dependencies
 chrono      = { workspace = true }
-deadpool    = { version = "0.13.0", default-features = false, features = [ "managed", "rt_tokio_1" ] }
+deadpool    = { version = "0.13.1", default-features = false, features = [ "managed", "rt_tokio_1" ] }
 either      = { workspace = true }
 futures     = { workspace = true }
 hashbrown   = { workspace = true }


### PR DESCRIPTION
With this PR, Yazi will support transmitting kitty graphics data via shared memory. 

This means images will no longer need to go through base64 encoding, sending to the terminal, and terminal-side decoding for display, which has a lot of overhead. Instead, the decoded image memory will be shared directly with the terminal, which should give a noticeable speed boost when displaying large images.

You can run `ya env` and look for `kgp_shm: true` to check whether your terminal supports shared memory.

## This PR

https://github.com/user-attachments/assets/6903a7af-b83e-400b-91c3-64d10d3a4380

## Before this PR (https://github.com/sxyazi/yazi/commit/1fbf3ef17158b3acd2f74cda4ab478adf3251b03)

https://github.com/user-attachments/assets/295046f9-149d-4fe9-87dd-d821e4b7c477

Both tests were conducted with [`image_delay = 0`](https://yazi-rs.github.io/docs/configuration/yazi/#preview.image_delay) in kitty v0.48.2.