### PR TITLE
feat(theme): zebra row styles with per-pane overrides

### DIFF
--- a/yazi-config/preset/theme-dark.toml
+++ b/yazi-config/preset/theme-dark.toml
@@ -29,6 +29,16 @@ overall = {}
 [mgr]
 cwd = { fg = "cyan" }
 
+# Rows: styles cycled by row index; `darken`/`lighten` (0–1) shift the bg
+# relative to the terminal's (or the entry's own `bg`).
+# rows_parent/current/preview override per pane; empty falls back to `rows`.
+# Lowest priority: hover, markers, and filetype rules always win.
+rows         = []
+rows_parent  = []
+rows_current = []
+rows_preview = []
+
+
 # Find
 find_keyword  = { fg = "yellow", bold = true, italic = true, underline = true }
 find_position = { fg = "magenta", bg = "reset", bold = true, italic = true }

--- a/yazi-config/preset/theme-light.toml
+++ b/yazi-config/preset/theme-light.toml
@@ -29,6 +29,16 @@ overall = {}
 [mgr]
 cwd = { fg = "cyan" }
 
+# Rows: styles cycled by row index; `darken`/`lighten` (0–1) shift the bg
+# relative to the terminal's (or the entry's own `bg`).
+# rows_parent/current/preview override per pane; empty falls back to `rows`.
+# Lowest priority: hover, markers, and filetype rules always win.
+rows         = []
+rows_parent  = []
+rows_current = []
+rows_preview = []
+
+
 # Find
 find_keyword  = { fg = "yellow", bold = true, italic = true, underline = true }
 find_position = { fg = "magenta", bg = "reset", bold = true, italic = true }

--- a/yazi-config/src/theme/theme.rs
+++ b/yazi-config/src/theme/theme.rs
@@ -62,10 +62,27 @@ pub struct App {
 	pub overall: SyncCell<StyleFlat>,
 }
 
+#[derive(Deserialize)]
+pub struct RowFlat {
+	#[serde(flatten)]
+	pub style: StyleFlat,
+
+	#[serde(default)]
+	pub darken:  Option<f32>,
+	#[serde(default)]
+	pub lighten: Option<f32>,
+}
+
 // --- Mgr
 #[derive(Deserialize, DeserializeOver, DeserializeOver2, Overlay)]
 pub struct Mgr {
 	pub cwd: SyncCell<StyleFlat>,
+
+	// Rows
+	pub rows:         ArcSwap<Vec<RowFlat>>,
+	pub rows_parent:  ArcSwap<Vec<RowFlat>>,
+	pub rows_current: ArcSwap<Vec<RowFlat>>,
+	pub rows_preview: ArcSwap<Vec<RowFlat>>,
 
 	// Find
 	pub find_keyword:  SyncCell<StyleFlat>,

--- a/yazi-emulator/src/emulator.rs
+++ b/yazi-emulator/src/emulator.rs
@@ -111,6 +111,8 @@ impl Emulator {
 		}
 	}
 
+	pub fn background(&self) -> Option<[u16; 3]> { self.background.get() }
+
 	pub fn move_lock<F, T>((x, y): (u16, u16), cb: F) -> Result<T>
 	where
 		F: FnOnce(&mut BufWriter<Handle>) -> Result<T>,

--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -101,7 +101,9 @@ function Entity:style()
 	local s = self._file:style() or ui.Style()
 	if not self._file.is_hovered then
 		local row = Rows.pick(self._file)
-		if row then s = row:patch(s) end
+		if row then
+			s = row:patch(s)
+		end
 		return s
 	elseif self._file.in_current then
 		return s:patch(th.indicator.current)

--- a/yazi-plugin/preset/components/entity.lua
+++ b/yazi-plugin/preset/components/entity.lua
@@ -100,6 +100,8 @@ end
 function Entity:style()
 	local s = self._file:style() or ui.Style()
 	if not self._file.is_hovered then
+		local row = Rows.pick(self._file)
+		if row then s = row:patch(s) end
 		return s
 	elseif self._file.in_current then
 		return s:patch(th.indicator.current)

--- a/yazi-plugin/preset/components/linemode.lua
+++ b/yazi-plugin/preset/components/linemode.lua
@@ -85,7 +85,9 @@ function Linemode:redraw()
 	local line = ui.Line(lines)
 	if not self._file.is_hovered then
 		local row = Rows.pick(self._file)
-		if row then return line:style(row) end
+		if row then
+			return line:style(row)
+		end
 	end
 	return line
 end

--- a/yazi-plugin/preset/components/linemode.lua
+++ b/yazi-plugin/preset/components/linemode.lua
@@ -82,7 +82,12 @@ function Linemode:redraw()
 	for _, c in ipairs(self._children) do
 		lines[#lines + 1] = (type(c[1]) == "string" and self[c[1]] or c[1])(self)
 	end
-	return ui.Line(lines)
+	local line = ui.Line(lines)
+	if not self._file.is_hovered then
+		local row = Rows.pick(self._file)
+		if row then return line:style(row) end
+	end
+	return line
 end
 
 -- Children

--- a/yazi-plugin/preset/components/rows.lua
+++ b/yazi-plugin/preset/components/rows.lua
@@ -2,9 +2,9 @@ Rows = {}
 
 -- Picks the row style for a file; override in init.lua for per-dir or time-based rules.
 function Rows.pick(file)
-	local pane = file.in_current and th.mgr.rows_current
-		or file.in_preview and th.mgr.rows_preview
-		or th.mgr.rows_parent
+	local pane = file.in_current and th.mgr.rows_current or file.in_preview and th.mgr.rows_preview or th.mgr.rows_parent
 	local rows = #pane > 0 and pane or th.mgr.rows
-	if #rows > 0 then return rows[(file.idx % #rows) + 1] end
+	if #rows > 0 then
+		return rows[(file.idx % #rows) + 1]
+	end
 end

--- a/yazi-plugin/preset/components/rows.lua
+++ b/yazi-plugin/preset/components/rows.lua
@@ -1,0 +1,10 @@
+Rows = {}
+
+-- Picks the row style for a file; override in init.lua for per-dir or time-based rules.
+function Rows.pick(file)
+	local pane = file.in_current and th.mgr.rows_current
+		or file.in_preview and th.mgr.rows_preview
+		or th.mgr.rows_parent
+	local rows = #pane > 0 and pane or th.mgr.rows
+	if #rows > 0 then return rows[(file.idx % #rows) + 1] end
+end

--- a/yazi-plugin/src/standard.rs
+++ b/yazi-plugin/src/standard.rs
@@ -58,6 +58,7 @@ fn stage_1(lua: &Lua) -> Result<()> {
 	lua.load(preset!("components/rail")).set_name("rail.lua").exec()?;
 	lua.load(preset!("components/rails")).set_name("rails.lua").exec()?;
 	lua.load(preset!("components/root")).set_name("root.lua").exec()?;
+	lua.load(preset!("components/rows")).set_name("rows.lua").exec()?;
 	lua.load(preset!("components/status")).set_name("status.lua").exec()?;
 	lua.load(preset!("components/tab")).set_name("tab.lua").exec()?;
 	lua.load(preset!("components/tabs")).set_name("tabs.lua").exec()?;

--- a/yazi-plugin/src/theme/theme.rs
+++ b/yazi-plugin/src/theme/theme.rs
@@ -1,9 +1,43 @@
 use mlua::{IntoLua, Lua, Value};
-use yazi_binding::{Composer, ComposerGet, ComposerSet, style::Style};
-use yazi_config::{THEME, theme::CustomSectionArc};
+use ratatui_core::style::Color;
+use yazi_binding::{Composer, ComposerGet, ComposerSet, style::{Style, StyleFlat}};
+use yazi_config::{THEME, theme::{CustomSectionArc, RowFlat}};
+use yazi_emulator::EMULATOR;
 use yazi_shared::url::UrlBuf;
 
 use crate::{LUA, theme::icon};
+
+// Resolves darken/lighten against the terminal bg (OSC 11) or the entry's own
+// bg.
+fn row(r: &RowFlat) -> StyleFlat {
+	let mut s = r.style;
+	let k = (r.lighten.unwrap_or(0.0) - r.darken.unwrap_or(0.0)).clamp(-1.0, 1.0);
+	if k != 0.0 {
+		let base = match s.bg {
+			Some(Color::Rgb(r, g, b)) => Some((r, g, b)),
+			_ => EMULATOR.background().map(|c| {
+				let [r, g, b] = c.map(|v| (v / 257) as u8);
+				(r, g, b)
+			}),
+		};
+		if let Some((r, g, b)) = base {
+			let f = |c: u8| {
+				(if k >= 0.0 { c as f32 + (255.0 - c as f32) * k } else { c as f32 * (1.0 + k) }).round()
+					as u8
+			};
+			s.bg = Some(Color::Rgb(f(r), f(g), f(b)));
+		}
+	}
+	s
+}
+
+fn rows(lua: &Lua, list: &[RowFlat]) -> mlua::Result<Value> {
+	lua
+		.create_sequence_from(
+			list.iter().map(|r| Style::from(row(r)).into_lua(lua)).collect::<mlua::Result<Vec<_>>>()?,
+		)?
+		.into_lua(lua)
+}
 
 pub(crate) fn compose() -> Composer<ComposerGet, ComposerSet> {
 	fn get(lua: &Lua, key: &[u8]) -> mlua::Result<Value> {
@@ -56,6 +90,11 @@ fn mgr() -> Composer<ComposerGet, ComposerSet> {
 		let m = &THEME.mgr;
 		match key {
 			b"cwd" => Style::from(&m.cwd).into_lua(lua),
+
+			b"rows" => rows(lua, &m.rows.load()),
+			b"rows_parent" => rows(lua, &m.rows_parent.load()),
+			b"rows_current" => rows(lua, &m.rows_current.load()),
+			b"rows_preview" => rows(lua, &m.rows_preview.load()),
 
 			b"find_keyword" => Style::from(&m.find_keyword).into_lua(lua),
 			b"find_position" => Style::from(&m.find_position).into_lua(lua),


### PR DESCRIPTION
Closes #4299

## Summary

Adds zebra row styles for the file list, with optional per-pane overrides and relative background shifts.

```toml

[mgr]
rows         = [ { darken = 0.2 }, { } ]
rows_parent  = []
rows_current = []
rows_preview = []

```

- `rows` is cycled by row index (`rows[i % len]`). Empty (default) = no stripes; one entry = uniform; two or more = zebra.
- `rows_parent` / `rows_current` / `rows_preview` override `rows` per pane; empty falls back to it.
- Each entry accepts any style field (`bg`, `fg`, `bold`, …) plus optional `darken` / `lighten` (0–1) to shift the row bg relative to the terminal's actual background (OSC 11) or the entry's own `bg`.
- Lowest priority: hover, markers, and filetype rules still win.

## Design

Resolution lives in a single Lua function (`Rows.pick`) consumed by `entity.lua` and `linemode.lua`. It picks the row style by pane, falling back to `rows` when a per-pane key is empty.

## Tested

- `cargo check -p yazi-config -p yazi-emulator -p yazi-plugin`
- `cargo clippy -p yazi-config -p yazi-emulator -p yazi-plugin --no-deps`
- `rustfmt +nightly` and `stylua --check .`
- Manual pty capture with an OSC 11 reply fixture: zebra stripes emit the expected ANSI escapes, blend math verified at k=0..1, per-pane escape counts match expectations.

## AI Assistance Disclosure

This PR was developed with AI assistance (GLM 5.3). The model helped draft the implementation, edit the diff, and review the changes against the project's conventions. I manually reviewed every line of the final diff, ran the project's validation commands, and verified the runtime behavior before each commit.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)
