### PR TITLE
fix: clean entry URLs on boot

### DIFF
--- a/yazi-boot/src/boot.rs
+++ b/yazi-boot/src/boot.rs
@@ -19,23 +19,17 @@ impl Boot {
 			return (vec![CWD.load().as_ref().clone()], vec![Default::default()]);
 		}
 
-		async fn go(entry: &UrlBuf) -> (UrlBuf, StrandBuf) {
-			let mut entry = clean_url(entry);
+		async fn go(ent: &UrlBuf) -> (UrlBuf, StrandBuf) {
+			let ent = clean_url(engine::absolute(ent).await.unwrap_or(ent.into()));
 
-			if let Ok(u) = engine::absolute(&entry).await
-				&& u.is_owned()
-			{
-				entry = u.into_owned();
-			}
-
-			let Some((trail, child)) = entry.pair() else {
-				return (entry, Default::default());
+			let Some((trail, child)) = ent.pair() else {
+				return (ent, Default::default());
 			};
 
-			if engine::metadata(&entry).await.is_ok_and(|m| m.is_file()) {
+			if engine::metadata(&ent).await.is_ok_and(|m| m.is_file()) {
 				(trail.into(), child.into())
 			} else {
-				(entry, Default::default())
+				(ent, Default::default())
 			}
 		}
 

--- a/yazi-fs/src/engine/local/absolute.rs
+++ b/yazi-fs/src/engine/local/absolute.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use yazi_shared::{loc::LocBuf, url::{AsUrl, Url, UrlBuf, UrlCow, UrlLike}};
 
-use crate::CWD;
+use crate::{CWD, path::clean_url};
 
 pub fn try_absolute<'a, U>(url: U) -> Option<UrlCow<'a>>
 where
@@ -43,12 +43,18 @@ fn try_absolute_impl<'a>(url: UrlCow<'a>) -> Option<UrlCow<'a>> {
 		)
 		.expect("Loc from home directory")
 	} else if !url.is_absolute() {
-		LocBuf::<PathBuf>::with(
-			CWD.path().join(path),
-			url.uri().components().count(),
-			url.urn().components().count(),
-		)
-		.expect("Loc from relative path")
+		// Clean the joined path so a trailing "." or ".." doesn't erase the key.
+		let joined =
+			clean_url(UrlBuf::from(CWD.path().join(path))).into_loc().into_os().expect("local path");
+		match url.as_url() {
+			Url::Regular(_) => LocBuf::<PathBuf>::from(joined),
+			_ => LocBuf::<PathBuf>::with(
+				joined,
+				url.uri().components().count(),
+				url.urn().components().count(),
+			)
+			.expect("Loc from relative path"),
+		}
 	} else {
 		return Some(url);
 	};

--- a/yazi-fs/src/engine/local/absolute.rs
+++ b/yazi-fs/src/engine/local/absolute.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use yazi_shared::{loc::LocBuf, url::{AsUrl, Url, UrlBuf, UrlCow, UrlLike}};
 
-use crate::{CWD, path::clean_url};
+use crate::CWD;
 
 pub fn try_absolute<'a, U>(url: U) -> Option<UrlCow<'a>>
 where
@@ -43,18 +43,12 @@ fn try_absolute_impl<'a>(url: UrlCow<'a>) -> Option<UrlCow<'a>> {
 		)
 		.expect("Loc from home directory")
 	} else if !url.is_absolute() {
-		// Clean the joined path so a trailing "." or ".." doesn't erase the key.
-		let joined =
-			clean_url(UrlBuf::from(CWD.path().join(path))).into_loc().into_os().expect("local path");
-		match url.as_url() {
-			Url::Regular(_) => LocBuf::<PathBuf>::from(joined),
-			_ => LocBuf::<PathBuf>::with(
-				joined,
-				url.uri().components().count(),
-				url.urn().components().count(),
-			)
-			.expect("Loc from relative path"),
-		}
+		LocBuf::<PathBuf>::with(
+			CWD.path().join(path),
+			url.uri().components().count(),
+			url.urn().components().count(),
+		)
+		.expect("Loc from relative path")
 	} else {
 		return Some(url);
 	};


### PR DESCRIPTION

## Which issue does this PR resolve?

<!--
For any fixes and enhancements, we usually require an associated issue to be filed where clearly detailed your proposed changes and why they are necessary, which ensures we are aligned and reduces the risk of re-work.

You can use GitHub syntax to link an issue to this PR, such as `Resolves #1000`, which indicates this PR will resolve issue #1000.
-->

Resolves #4317 

## Rationale of this PR

When launching yazi with an explicit path argument like `yazi .`, the parent
directory pane highlights the first sorted entry instead of the current
directory. Launching with no argument (`yazi`) in the same directory highlights
the correct entry.

Both invocations should behave identically.
<!--
A clear and concise description of the rationale of the changes, to help our reviewers understand your intent and why it is necessary.

If it has already been detailed in the associated issue, please skip this section.
-->

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

<!-- AI bots are not allowed to open PRs in this repository. All PRs must be made by humans and comply with the AI policy. -->
