### PR TITLE
add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Yazi (means "duck") is a terminal file manager written in Rust, based on non-blo
 
 https://github.com/sxyazi/yazi/assets/17523360/92ff23fa-0cd5-4f04-b387-894c12265cc7
 
+[![Live demo by Demoshell](https://build.demoshell.com/v1/embed/badge.svg)](https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Ayazi)
+
 ## Project status
 
 Public beta, can be used as a daily driver.


### PR DESCRIPTION
## Rationale of this PR

Adds a "Online demo" link to the README, pointing to yazi running in the browser.

It's the actual binary inside an emulated Linux VM (WebAssembly). The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution). 

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it. 

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

