### PR TITLE
fix: fall back to data-only copy when destination rejects xattrs

### DIFF
--- a/yazi-fs/src/engine/local/copier.rs
+++ b/yazi-fs/src/engine/local/copier.rs
@@ -1,8 +1,33 @@
+#[cfg(any(test, not(any(target_os = "linux", target_os = "android"))))]
+use std::path::Path;
 use std::{io, path::PathBuf};
 
 use tokio::{select, sync::{mpsc, oneshot}};
 
 use crate::engine::Attrs;
+
+#[cfg(any(test, not(any(target_os = "linux", target_os = "android"))))]
+fn copy_data_only(from: &Path, to: &Path) -> io::Result<u64> {
+	let mut reader = std::fs::File::open(from)?;
+	let perm = reader.metadata()?.permissions();
+	let mut writer = std::fs::OpenOptions::new().write(true).create(true).truncate(true).open(to)?;
+	let written = std::io::copy(&mut reader, &mut writer)?;
+	writer.set_permissions(perm).ok();
+	Ok(written)
+}
+
+#[cfg(any(test, not(any(target_os = "linux", target_os = "android"))))]
+fn copy_or_fallback(from: &Path, to: &Path) -> io::Result<u64> {
+	copy_or_fallback_with(from, to, |from, to| std::fs::copy(from, to))
+}
+
+#[cfg(any(test, not(any(target_os = "linux", target_os = "android"))))]
+fn copy_or_fallback_with<F>(from: &Path, to: &Path, primary: F) -> io::Result<u64>
+where
+	F: FnOnce(&Path, &Path) -> io::Result<u64>,
+{
+	primary(from, to).or_else(|_| copy_data_only(from, to))
+}
 
 pub(super) async fn copy_impl(from: PathBuf, to: PathBuf, attrs: Attrs) -> io::Result<u64> {
 	#[cfg(any(target_os = "linux", target_os = "android"))]
@@ -34,7 +59,7 @@ pub(super) async fn copy_impl(from: PathBuf, to: PathBuf, attrs: Attrs) -> io::R
 	#[cfg(not(any(target_os = "linux", target_os = "android")))]
 	{
 		tokio::task::spawn_blocking(move || {
-			let written = std::fs::copy(from, &to)?;
+			let written = copy_or_fallback(&from, &to)?;
 
 			if let Ok(times) = attrs.try_into()
 				&& let Ok(file) = std::fs::File::options().write(true).open(to)
@@ -97,4 +122,73 @@ pub(super) fn copy_progressive_impl(
 	});
 
 	prog_rx
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn scratch() -> PathBuf {
+		use std::sync::atomic::{AtomicU64, Ordering};
+
+		static N: AtomicU64 = AtomicU64::new(0);
+		let dir = std::env::temp_dir().join(format!(
+			"yazi-copier-{}-{}",
+			std::process::id(),
+			N.fetch_add(1, Ordering::Relaxed)
+		));
+		std::fs::create_dir_all(&dir).unwrap();
+		dir
+	}
+
+	fn reject_xattrs(_from: &Path, to: &Path) -> io::Result<u64> {
+		std::fs::File::create(to)?;
+		Err(io::Error::from_raw_os_error(1))
+	}
+
+	#[test]
+	fn copy_or_fallback_recovers_when_destination_rejects_xattrs() {
+		let dir = scratch();
+		let from = dir.join("from");
+		let to = dir.join("to");
+		std::fs::write(&from, b"copy test\n").unwrap();
+
+		let n = copy_or_fallback_with(&from, &to, reject_xattrs).unwrap();
+		assert_eq!(n, 10);
+		assert_eq!(std::fs::read(&to).unwrap(), b"copy test\n");
+
+		std::fs::remove_dir_all(dir).unwrap();
+	}
+
+	#[test]
+	fn copy_or_fallback_copies_regular_file() {
+		let dir = scratch();
+		let from = dir.join("from");
+		let to = dir.join("to");
+		std::fs::write(&from, b"hello").unwrap();
+
+		let n = copy_or_fallback(&from, &to).unwrap();
+		assert_eq!(n, 5);
+		assert_eq!(std::fs::read(&to).unwrap(), b"hello");
+
+		std::fs::remove_dir_all(dir).unwrap();
+	}
+
+	#[test]
+	fn copy_or_fallback_keeps_successful_primary_copy() {
+		let dir = scratch();
+		let from = dir.join("from");
+		let to = dir.join("to");
+		std::fs::write(&from, b"from-source").unwrap();
+
+		let n = copy_or_fallback_with(&from, &to, |_from, to| {
+			std::fs::write(to, b"from-primary")?;
+			Ok(12)
+		})
+		.unwrap();
+		assert_eq!(n, 12);
+		assert_eq!(std::fs::read(&to).unwrap(), b"from-primary");
+
+		std::fs::remove_dir_all(dir).unwrap();
+	}
 }


### PR DESCRIPTION
## Which issue does this PR resolve?

Resolves #4148

## Rationale of this PR

On non-Linux, `std::fs::copy` (fcopyfile/COPYFILE_ALL) fails with EPERM when the destination rejects extended attributes (macFUSE/Cryptomator), retries, and leaves a 0-byte file. Keep the fast path first, then fall back to a content-only `io::copy` so the copy still succeeds. Linux/Android already use the content-only path.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md)
- [x] I confirm this PR follows the [AI Policy](https://github.com/sxyazi/yazi/blob/main/CONTRIBUTING.md#ai-policy)

AI assistance: Grok (xAI) helped draft the implementation. The author reviewed, tested (`cargo test -p yazi-fs --lib engine::local::copier`, 3 passed), and simplified before publishing. The tool does not assert copyright over the work.

## Test plan

- [x] `cargo test -p yazi-fs --lib engine::local::copier` (3 passed)
- [ ] Copy a file onto a macFUSE/Cryptomator volume that rejects xattrs