### PR TITLE
feat: dynamic virtual filesystem Lua API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 
 ## [Unreleased]
 
+### Added
+
+- Dynamic virtual file system Lua API ([#4338])
+
 ### Changed
 
 - Supersede `search` action with `plugin rg` and `plugin fd` ([#4335])
@@ -1863,3 +1867,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):
 [#4309]: https://github.com/sxyazi/yazi/pull/4309
 [#4319]: https://github.com/sxyazi/yazi/pull/4319
 [#4335]: https://github.com/sxyazi/yazi/pull/4335
+[#4338]: https://github.com/sxyazi/yazi/pull/4338

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,20 +349,20 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
+checksum = "60eafe0d77c3a2fc292c1d1346c3041b33c0a108085a2afabf672b70f69dbbc9"
 dependencies = [
  "bon-macros",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
+checksum = "bd0f9631d8aaaee112c41985d675ef269e02acbd4f33122836af4f0c5f699ff6"
 dependencies = [
- "darling 0.24.1",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -807,35 +807,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.1",
- "darling_macro 0.24.1",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -853,22 +830,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.1",
+ "darling_core",
  "quote",
  "syn 3.0.5",
 ]
@@ -1570,9 +1536,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "ctutils",
  "subtle",
@@ -1650,7 +1616,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1871,7 +1837,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.24.1",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1889,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2167,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "lua-src"
-version = "551.0.1"
+version = "551.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087097f9936a7d819bda525b32d6e96f9c54f3d35ff23ff72fc0c1697d2127db"
+checksum = "d400ffef0e3d4d29287092bdc5a276d0bf468b2c69709d5bab0d469312d9f947"
 dependencies = [
  "cc",
 ]
@@ -2605,7 +2571,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.20",
  "tokio",
- "windows 0.62.2",
+ "windows",
  "windows-strings",
 ]
 
@@ -2775,11 +2741,11 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "indexmap 2.14.2",
  "quick-xml",
  "serde",
@@ -2960,9 +2926,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -3151,11 +3117,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3353,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "once_cell",
  "ring",
@@ -3616,11 +3582,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+checksum = "935177bb8c0cd8ca1a4e6d1a2ac8988bea69cab4f9d3a31311e012ad27868ea4"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "chrono",
  "hex",
@@ -3637,14 +3603,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+checksum = "1d607aa01a3cb0ad757d6fd216136910db3c97b102fe686585689615a02dbcdc"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4391,9 +4357,9 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "5.2.7"
+version = "5.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08676401d031c4a43b7022d90e1748ef4624fabb68ac2abf0cb5812f8c02d78e"
+checksum = "d0cf8ced01d5c32c50f1b71a7256ac3fac5bf38a6c94042206f37292fcf08a49"
 dependencies = [
  "chrono",
  "libc",
@@ -4404,7 +4370,7 @@ dependencies = [
  "percent-encoding",
  "scopeguard",
  "urlencoding",
- "windows 0.56.0",
+ "windows",
 ]
 
 [[package]]
@@ -4764,22 +4730,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
-dependencies = [
- "windows-core 0.56.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -4790,19 +4746,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
-dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4811,10 +4755,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -4824,20 +4768,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -4845,17 +4778,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4885,17 +4807,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5392,7 +5305,7 @@ dependencies = [
  "objc2",
  "rand 0.10.2",
  "rustix",
- "windows 0.62.2",
+ "windows",
  "windows-sys 0.61.2",
  "yazi-macro",
 ]
@@ -5475,7 +5388,7 @@ dependencies = [
  "typed-path",
  "unicode-normalization",
  "uzers",
- "windows 0.62.2",
+ "windows",
  "windows-sys 0.61.2",
  "yazi-binding",
  "yazi-codegen",
@@ -5869,18 +5782,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,14 +71,14 @@ ratatui-core          = { version = "0.1.2", default-features = false, features 
 ratatui-widgets       = { version = "0.3.2", default-features = false, features = [ "std", "unstable-rendered-line-info" ] }
 regex                 = "1.13.1"
 regex-syntax          = "0.8.11"
-reqwest               = { version = "0.13.4", default-features = false, features = [ "rustls-no-provider", "stream" ] }
-rustls                = { version = "0.23.43", default-features = false, features = [ "ring", "std" ] }
+reqwest               = { version = "0.13.5", default-features = false, features = [ "rustls-no-provider", "stream" ] }
+rustls                = { version = "0.23.44", default-features = false, features = [ "ring", "std" ] }
 rustix                = { version = "1.1.4", default-features = false, features = [ "std", "fs", "mm", "shm", "stdio", "termios", "event" ] }
 russh                 = { version = "0.63.2", default-features = false, features = [ "ring", "rsa" ] }
 scopeguard            = "1.2.0"
 serde                 = { version = "1.0.229", features = [ "derive" ] }
 serde_json            = "1.0.151"
-serde_with            = "3.22.0"
+serde_with            = "3.23.0"
 strum                 = { version = "0.28.0", features = [ "derive" ] }
 syntect               = { version = "5.3.0", default-features = false, features = [ "parsing", "plist-load", "regex-onig" ] }
 thiserror             = "2.0.20"

--- a/yazi-config/src/lib.rs
+++ b/yazi-config/src/lib.rs
@@ -16,7 +16,7 @@ use crate::theme::{Flavor, Theme};
 pub static YAZI: RoCell<yazi::Yazi> = RoCell::new();
 pub static KEYMAP: RoCell<keymap::Keymap> = RoCell::new();
 pub static THEME: RoCell<Theme> = RoCell::new();
-pub(crate) static VFS: RoCell<vfs::Vfs> = RoCell::new();
+pub static VFS: RoCell<vfs::Vfs> = RoCell::new();
 pub static LAYOUT: SyncCell<Layout> = SyncCell::new(Layout::default());
 
 pub fn setup() -> anyhow::Result<()> {

--- a/yazi-config/src/vfs/authorities.rs
+++ b/yazi-config/src/vfs/authorities.rs
@@ -1,16 +1,25 @@
+use std::{ops::Deref, sync::Arc};
+
+use arc_swap::ArcSwap;
 use hashbrown::HashMap;
 use serde::{Deserialize, Deserializer, de::{MapAccess, Visitor}};
 use yazi_shared::{auth::{AuthArc, Scheme}, domain::Domain};
-use yazi_shim::toml::DeserializeOverWith;
+use yazi_shim::{arc_swap::IntoPointee, toml::DeserializeOverWith};
 
-use super::{DomainSeed, Domains};
+use super::{DomainSeed, Domains, DomainsArc};
 use crate::vfs::Service;
 
-pub struct Authorities(HashMap<Scheme, Domains>);
+pub struct Authorities(ArcSwap<HashMap<Scheme, DomainsArc>>);
+
+impl Deref for Authorities {
+	type Target = ArcSwap<HashMap<Scheme, DomainsArc>>;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
 
 impl Authorities {
-	pub(crate) fn service(&self, scheme: &Scheme, domain: &Domain<'_>) -> Option<&Service> {
-		self.0.get(scheme)?.get(domain)
+	pub(crate) fn service(&self, scheme: &Scheme, domain: &Domain<'_>) -> Option<Service> {
+		self.load().get(scheme)?.get(domain)
 	}
 
 	pub(crate) fn auth(&self, scheme: &Scheme, domain: &Domain<'_>) -> Option<AuthArc> {
@@ -20,6 +29,26 @@ impl Authorities {
 		} else {
 			service.auth().clone()
 		})
+	}
+
+	pub(super) fn insert(&self, scheme: &Scheme, domains: &DomainsArc) {
+		self.0.rcu(|inner| {
+			let mut next = HashMap::clone(inner);
+			next.insert(scheme.clone(), domains.clone());
+			next
+		});
+	}
+
+	pub(super) fn remove(&self, scheme: &Scheme) {
+		self.0.rcu(|inner| {
+			let mut next = HashMap::clone(inner);
+			next.remove(scheme);
+			next
+		});
+	}
+
+	fn unwrap_unchecked(self) -> HashMap<Scheme, DomainsArc> {
+		Arc::try_unwrap(self.0.into_inner()).expect("unique authorities arc")
 	}
 }
 
@@ -38,9 +67,9 @@ impl<'de> Deserialize<'de> for Authorities {
 				let mut authorities = HashMap::new();
 				while let Some(scheme) = map.next_key()? {
 					let domains = map.next_value_seed(DomainSeed(&scheme))?;
-					authorities.insert(scheme, domains);
+					authorities.insert(scheme, domains.into());
 				}
-				Ok(Authorities(authorities))
+				Ok(Authorities(authorities.into_pointee()))
 			}
 		}
 
@@ -49,10 +78,19 @@ impl<'de> Deserialize<'de> for Authorities {
 }
 
 impl DeserializeOverWith for Authorities {
-	fn deserialize_over_with<'de, D: Deserializer<'de>>(mut self, de: D) -> Result<Self, D::Error> {
-		for (scheme, domains) in Self::deserialize(de)?.0 {
-			self.0.entry(scheme).or_default().extend(domains);
+	fn deserialize_over_with<'de, D: Deserializer<'de>>(self, de: D) -> Result<Self, D::Error> {
+		let mut inner = self.unwrap_unchecked();
+
+		for (scheme, domains) in Self::deserialize(de)?.unwrap_unchecked() {
+			if let Some((k, v)) = inner.remove_entry(&scheme) {
+				let mut map = v.unwrap_unchecked().unwrap_unchecked();
+				map.extend(domains.unwrap_unchecked().unwrap_unchecked());
+				inner.insert(k, Domains::from_unchecked(scheme, map).into());
+			} else {
+				inner.insert(scheme, domains);
+			}
 		}
-		Ok(self)
+
+		Ok(Self(inner.into_pointee()))
 	}
 }

--- a/yazi-config/src/vfs/domains.rs
+++ b/yazi-config/src/vfs/domains.rs
@@ -1,54 +1,64 @@
+use std::{ops::Deref, sync::Arc};
+
+use arc_swap::ArcSwap;
 use hashbrown::HashMap;
-use serde::{Deserialize, Deserializer, de::{self, DeserializeSeed, Error}};
-use yazi_shared::{auth::{AuthArc, Scheme}, domain::Domain};
+use serde::{Deserialize, Deserializer, de::{DeserializeSeed, Error}};
+use yazi_shared::{auth::Scheme, domain::Domain};
+use yazi_shim::arc_swap::IntoPointee;
 
 use super::{Service, ServiceSftp};
 
-#[derive(Default)]
+#[derive(Debug)]
 pub struct Domains {
-	exact:    HashMap<Domain<'static>, Service>,
-	catchall: Option<Service>,
+	pub(super) scheme: Scheme,
+	inner:             ArcSwap<HashMap<Domain<'static>, Service>>,
+}
+
+impl Deref for Domains {
+	type Target = ArcSwap<HashMap<Domain<'static>, Service>>;
+
+	fn deref(&self) -> &Self::Target { &self.inner }
 }
 
 impl Domains {
-	pub(crate) fn get(&self, domain: &Domain<'_>) -> Option<&Service> {
-		self.exact.get(domain.as_ref()).or(self.catchall.as_ref())
-	}
-
-	pub(crate) fn extend(&mut self, other: Self) {
-		self.exact.extend(other.exact);
-		if other.catchall.is_some() {
-			self.catchall = other.catchall;
-		}
-	}
-
-	fn init(&mut self, scheme: &Scheme) {
-		for (domain, service) in &mut self.exact {
-			*service.auth_mut() = AuthArc::new(service.kind(), scheme.clone(), domain);
-		}
-
-		if let Some(service) = &mut self.catchall {
-			*service.auth_mut() = AuthArc::new(service.kind(), scheme.clone(), Domain::CATCHALL);
-		}
-	}
-
-	fn from_map<E>(map: HashMap<Domain<'static>, Service>) -> Result<Self, E>
+	pub(crate) fn get<'a, D>(&self, domain: D) -> Option<Service>
 	where
-		E: de::Error,
+		D: Into<Domain<'a>>,
 	{
-		let mut domains = Self::default();
-		for (domain, service) in map {
-			if domain.is_catchall() {
-				domains.catchall = Some(service);
-				continue;
-			}
+		let inner = self.load();
+		inner.get(&domain.into()).or_else(|| inner.get(&Domain::CATCHALL)).cloned()
+	}
 
-			if service.kind().is_hub() {
-				return Err(E::custom("Hub services require a `*` catch-all domain"));
-			}
-			domains.exact.insert(domain, service);
-		}
-		Ok(domains)
+	pub(crate) fn insert<'a, D>(&self, domain: D, service: Service)
+	where
+		D: Into<Domain<'a>>,
+	{
+		let domain = domain.into();
+		self.rcu(|inner| {
+			let mut next = HashMap::clone(inner);
+			next.insert(domain.to_static(), service.clone());
+			next
+		});
+	}
+
+	pub(crate) fn remove<'a, D>(&self, domain: D)
+	where
+		D: Into<Domain<'a>>,
+	{
+		let domain = domain.into();
+		self.rcu(|inner| {
+			let mut next = HashMap::clone(inner);
+			next.remove(domain.as_ref());
+			next
+		});
+	}
+
+	pub(crate) fn from_unchecked(scheme: Scheme, inner: HashMap<Domain<'static>, Service>) -> Self {
+		Self { scheme, inner: inner.into_pointee() }
+	}
+
+	pub(crate) fn unwrap_unchecked(self) -> HashMap<Domain<'static>, Service> {
+		Arc::try_unwrap(self.inner.into_inner()).expect("unique domains map")
 	}
 }
 
@@ -59,26 +69,19 @@ impl<'de> DeserializeSeed<'de> for DomainSeed<'_> {
 	type Value = Domains;
 
 	fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-		let mut domains = match self.0 {
-			Scheme::Regular => {
-				return Err(D::Error::custom("scheme cannot be configured"));
-			}
+		let mut map = match self.0 {
+			Scheme::Regular => return Err(D::Error::custom("scheme cannot be configured")),
 			Scheme::Sftp => {
 				let map = HashMap::<Domain<'static>, ServiceSftp>::deserialize(deserializer)?;
-				Domains::from_map(
-					map.into_iter().map(|(domain, service)| (domain, Service::Sftp(service))).collect(),
-				)?
+				map.into_iter().map(|(domain, service)| (domain, Service::Sftp(service.into()))).collect()
 			}
-			Scheme::Custom(_) => {
-				let map = HashMap::<Domain<'static>, Service>::deserialize(deserializer)?;
-				if map.values().any(|service| matches!(service, Service::Sftp(_))) {
-					return Err(D::Error::custom("SFTP services must use the `sftp` scheme"));
-				}
-				Domains::from_map(map)?
-			}
+			Scheme::Custom(_) => HashMap::<Domain<'static>, Service>::deserialize(deserializer)?,
 		};
 
-		domains.init(self.0);
-		Ok(domains)
+		for (domain, service) in &mut map {
+			service.configure(self.0, domain).map_err(D::Error::custom)?;
+		}
+
+		Ok(Domains::from_unchecked(self.0.clone(), map))
 	}
 }

--- a/yazi-config/src/vfs/domains_arc.rs
+++ b/yazi-config/src/vfs/domains_arc.rs
@@ -1,0 +1,64 @@
+use std::{ops::{Deref, DerefMut}, sync::Arc};
+
+use mlua::{BorrowedBytes, ExternalError, FromLua, IntoLua, IntoLuaMulti, MetaMethod, UserData, UserDataMethods, Value};
+
+use super::{Domains, DomainsMatcher, Service};
+
+#[derive(Clone, Debug)]
+pub struct DomainsArc(Arc<Domains>);
+
+impl Deref for DomainsArc {
+	type Target = Arc<Domains>;
+
+	fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl DerefMut for DomainsArc {
+	fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+}
+
+impl From<Domains> for DomainsArc {
+	fn from(value: Domains) -> Self { Self(value.into()) }
+}
+
+impl DomainsArc {
+	pub(crate) fn unwrap_unchecked(self) -> Domains {
+		Arc::try_unwrap(self.0).expect("unique domains arc")
+	}
+}
+
+impl UserData for DomainsArc {
+	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+		methods.add_meta_method(MetaMethod::Index, |lua, me, domain: BorrowedBytes| {
+			me.get(&domain).into_lua(lua)
+		});
+
+		methods.add_meta_method(
+			MetaMethod::NewIndex,
+			|lua, me, (domain, value): (BorrowedBytes, Value)| {
+				match value {
+					t @ Value::Table(_) => {
+						let mut service = Service::from_lua(t, lua)?;
+						service.configure(&me.scheme, &domain).map_err(|e| e.into_lua_err())?;
+						me.insert(&domain, service);
+					}
+					Value::Nil => me.remove(&domain),
+					_ => return Err("expected a table or nil".into_lua_err()),
+				}
+				Ok(())
+			},
+		);
+
+		methods.add_meta_method(MetaMethod::Pairs, |lua, me, ()| {
+			let mut matcher = DomainsMatcher::from(me);
+			let iter = lua.create_function_mut(move |lua, ()| {
+				if let Some((domain, service)) = matcher.next() {
+					(domain, service).into_lua_multi(lua)
+				} else {
+					().into_lua_multi(lua)
+				}
+			})?;
+			Ok(iter)
+		});
+	}
+}

--- a/yazi-config/src/vfs/domains_matcher.rs
+++ b/yazi-config/src/vfs/domains_matcher.rs
@@ -1,0 +1,34 @@
+use std::{mem, sync::Arc};
+
+use hashbrown::{HashMap, hash_map};
+use yazi_shared::domain::Domain;
+
+use super::{DomainsArc, Service};
+
+pub struct DomainsMatcher {
+	iter:     hash_map::Iter<'static, Domain<'static>, Service>,
+	_domains: Arc<HashMap<Domain<'static>, Service>>,
+}
+
+impl From<&DomainsArc> for DomainsMatcher {
+	fn from(domains: &DomainsArc) -> Self {
+		let domains = domains.load_full();
+
+		let iter = unsafe {
+			mem::transmute::<
+				hash_map::Iter<'_, Domain<'static>, Service>,
+				hash_map::Iter<'static, Domain<'static>, Service>,
+			>(domains.iter())
+		};
+
+		Self { iter, _domains: domains }
+	}
+}
+
+impl Iterator for DomainsMatcher {
+	type Item = (Domain<'static>, Service);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.iter.next().map(|(domain, service)| (domain.clone(), service.clone()))
+	}
+}

--- a/yazi-config/src/vfs/lua.rs
+++ b/yazi-config/src/vfs/lua.rs
@@ -6,7 +6,7 @@ use tokio::sync::OnceCell;
 use yazi_fs::engine::Capabilities;
 use yazi_shared::{auth::AuthArc, data::{Data, DataKey}, event::Cmd};
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ServiceLua {
 	#[serde(skip)]
 	pub(crate) auth: AuthArc,

--- a/yazi-config/src/vfs/mod.rs
+++ b/yazi-config/src/vfs/mod.rs
@@ -1,1 +1,1 @@
-yazi_macro::mod_flat!(authorities domains lua service sftp vfs);
+yazi_macro::mod_flat!(authorities domains domains_arc domains_matcher lua service sftp vfs vfs_matcher);

--- a/yazi-config/src/vfs/service.rs
+++ b/yazi-config/src/vfs/service.rs
@@ -1,22 +1,26 @@
+use std::sync::Arc;
+
+use mlua::{FromLua, IntoLua, Lua, LuaSerdeExt, LuaString, MetaMethod, Table, UserData, UserDataFields, UserDataMethods, Value};
 use serde::Deserialize;
-use yazi_shared::auth::{AuthArc, AuthKind};
+use yazi_shared::{auth::{AuthArc, AuthKind, Scheme}, path::DynPath, sendable::Sendable};
+use yazi_shim::{mlua::UserDataFieldsExt, strum::IntoStr};
 
 use super::{ServiceLua, ServiceSftp};
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum Service {
-	Sftp(ServiceSftp),
-	Mount(ServiceLua),
-	Hub(ServiceLua),
-	Scope(ServiceLua),
-	View(ServiceLua),
+	Sftp(Arc<ServiceSftp>),
+	Mount(Arc<ServiceLua>),
+	Hub(Arc<ServiceLua>),
+	Scope(Arc<ServiceLua>),
+	View(Arc<ServiceLua>),
 }
 
-impl TryFrom<&'static Service> for &'static ServiceSftp {
+impl TryFrom<Service> for Arc<ServiceSftp> {
 	type Error = &'static str;
 
-	fn try_from(value: &'static Service) -> Result<Self, Self::Error> {
+	fn try_from(value: Service) -> Result<Self, Self::Error> {
 		match value {
 			Service::Sftp(p) => Ok(p),
 			Service::Mount(_) | Service::Hub(_) | Service::Scope(_) | Service::View(_) => {
@@ -26,10 +30,10 @@ impl TryFrom<&'static Service> for &'static ServiceSftp {
 	}
 }
 
-impl TryFrom<&'static Service> for &'static ServiceLua {
+impl TryFrom<Service> for Arc<ServiceLua> {
 	type Error = &'static str;
 
-	fn try_from(value: &'static Service) -> Result<Self, Self::Error> {
+	fn try_from(value: Service) -> Result<Self, Self::Error> {
 		match value {
 			Service::Sftp(_) => Err("expected a custom VFS service, got an SFTP service"),
 			Service::Mount(lua) | Service::Hub(lua) | Service::Scope(lua) | Service::View(lua) => Ok(lua),
@@ -38,6 +42,23 @@ impl TryFrom<&'static Service> for &'static ServiceLua {
 }
 
 impl Service {
+	pub(crate) fn configure<D>(&mut self, scheme: &Scheme, domain: &D) -> Result<(), &'static str>
+	where
+		D: AsRef<[u8]> + ?Sized,
+	{
+		let kind = self.kind();
+		if scheme.is_regular() {
+			return Err("scheme cannot be configured");
+		} else if kind.is_sftp() != scheme.is_sftp() {
+			return Err("service kind does not match scheme");
+		} else if kind.is_hub() && domain.as_ref() != b"*" {
+			return Err("hub services require a `*` catch-all domain");
+		}
+
+		*self.auth_make_mut() = AuthArc::new(kind, scheme.clone(), domain.as_ref());
+		Ok(())
+	}
+
 	pub(crate) fn kind(&self) -> AuthKind {
 		match self {
 			Self::Sftp(_) => AuthKind::Sftp,
@@ -51,20 +72,62 @@ impl Service {
 	pub(crate) fn auth(&self) -> &AuthArc {
 		match self {
 			Self::Sftp(sftp) => &sftp.auth,
-			Self::Mount(lua) => &lua.auth,
-			Self::Hub(lua) => &lua.auth,
-			Self::Scope(lua) => &lua.auth,
-			Self::View(lua) => &lua.auth,
+			Self::Mount(lua) | Self::Hub(lua) | Self::Scope(lua) | Self::View(lua) => &lua.auth,
 		}
 	}
 
-	pub(crate) fn auth_mut(&mut self) -> &mut AuthArc {
+	fn auth_make_mut(&mut self) -> &mut AuthArc {
 		match self {
-			Self::Sftp(sftp) => &mut sftp.auth,
-			Self::Mount(lua) => &mut lua.auth,
-			Self::Hub(lua) => &mut lua.auth,
-			Self::Scope(lua) => &mut lua.auth,
-			Self::View(lua) => &mut lua.auth,
+			Self::Sftp(sftp) => &mut Arc::make_mut(sftp).auth,
+			Self::Mount(lua) | Self::Hub(lua) | Self::Scope(lua) | Self::View(lua) => {
+				&mut Arc::make_mut(lua).auth
+			}
 		}
+	}
+}
+
+impl FromLua for Service {
+	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
+		let t = Table::from_lua(value, lua)?;
+		let kind: Option<LuaString> = t.raw_get("kind")?;
+
+		if kind.is_some() {
+			lua.from_value(Value::Table(t))
+		} else {
+			let sftp: ServiceSftp = lua.from_value(Value::Table(t))?;
+			Ok(Self::Sftp(sftp.into()))
+		}
+	}
+}
+
+impl UserData for Service {
+	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
+		fields.add_cached_field("kind", |_, me| Ok(me.kind().into_str()));
+	}
+
+	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+		methods.add_meta_method(MetaMethod::Index, |lua, me, key: LuaString| {
+			let key = key.as_bytes();
+			match me {
+				Self::Sftp(s) => match &*key {
+					b"host" => lua.create_string(&s.host)?.into_lua(lua),
+					b"user" => lua.create_string(&s.user)?.into_lua(lua),
+					b"port" => s.port.into_lua(lua),
+					b"password" => s.password.as_deref().into_lua(lua),
+					b"key_file" => s.key_file.dyn_path().into_lua(lua),
+					b"key_passphrase" => s.key_passphrase.as_deref().into_lua(lua),
+					b"cert_file" => s.cert_file.dyn_path().into_lua(lua),
+					b"no_cert_verify" => s.no_cert_verify.into_lua(lua),
+					b"identity_agent" => s.identity_agent.dyn_path().into_lua(lua),
+					_ => Ok(Value::Nil),
+				},
+				Self::Mount(s) | Self::Hub(s) | Self::Scope(s) | Self::View(s) => match &*key {
+					b"name" => lua.create_string(&*s.name)?.into_lua(lua),
+					b"args" => Sendable::args_to_table_ref(lua, &s.args)?.into_lua(lua),
+					b"opts" => Sendable::args_to_table_ref(lua, &s.opts)?.into_lua(lua),
+					_ => Ok(Value::Nil),
+				},
+			}
+		});
 	}
 }

--- a/yazi-config/src/vfs/sftp.rs
+++ b/yazi-config/src/vfs/sftp.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 use yazi_fs::path::sanitize_path;
 use yazi_shared::auth::{Auth, AuthArc};
 
-#[derive(Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ServiceSftp {
 	#[serde(skip)]
 	pub auth:           AuthArc,

--- a/yazi-config/src/vfs/vfs.rs
+++ b/yazi-config/src/vfs/vfs.rs
@@ -1,29 +1,34 @@
 use std::io;
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Deserializer};
+use mlua::{ExternalError, IntoLua, IntoLuaMulti, MetaMethod, UserData, UserDataMethods, Value};
+use serde::{Deserialize, Deserializer, de::DeserializeSeed};
 use yazi_codegen::DeserializeOver;
 use yazi_fs::{Xdg, ok_or_not_found};
-use yazi_shared::auth::{Auth, AuthInventory};
+use yazi_shared::auth::{Auth, AuthInventory, Scheme};
 use yazi_shim::toml::DeserializeOverWith;
 
-use super::{Authorities, Service};
+use super::{Authorities, DomainSeed, Service, VfsMatcher};
 use crate::VFS;
 
 #[derive(Deserialize, DeserializeOver)]
 pub struct Vfs {
 	#[serde(flatten)]
-	authorities: Authorities,
+	pub(super) authorities: Authorities,
 }
 
 impl Vfs {
 	pub fn service<P>(auth: &Auth) -> io::Result<P>
 	where
-		P: TryFrom<&'static Service, Error = &'static str>,
+		P: TryFrom<Service, Error = &'static str>,
 	{
 		let Some(value) = VFS.authorities.service(&auth.scheme, &auth.domain) else {
 			return Err(io::Error::other(format!("No such VFS service: {auth}")));
 		};
+
+		if value.kind() != auth.kind {
+			return Err(io::Error::other(format!("VFS service `{auth}` kind changed")));
+		}
 
 		match value.try_into() {
 			Ok(p) => Ok(p),
@@ -41,6 +46,41 @@ impl Vfs {
 impl DeserializeOverWith for Vfs {
 	fn deserialize_over_with<'de, D: Deserializer<'de>>(self, de: D) -> Result<Self, D::Error> {
 		Ok(Self { authorities: self.authorities.deserialize_over_with(de)? })
+	}
+}
+
+impl UserData for &'static Vfs {
+	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+		methods.add_meta_method(MetaMethod::Index, |lua, &me, scheme: Scheme| {
+			match me.authorities.load().get(&scheme) {
+				Some(domains) => domains.clone().into_lua(lua),
+				None => Ok(Value::Nil),
+			}
+		});
+
+		methods.add_meta_method(MetaMethod::NewIndex, |_, &me, (scheme, value): (Scheme, Value)| {
+			match value {
+				t @ Value::Table(_) => {
+					let domains = DomainSeed(&scheme).deserialize(mlua::serde::Deserializer::new(t))?;
+					me.authorities.insert(&scheme, &domains.into());
+				}
+				Value::Nil => me.authorities.remove(&scheme),
+				_ => return Err("expected a table or nil".into_lua_err()),
+			}
+			Ok(())
+		});
+
+		methods.add_meta_method(MetaMethod::Pairs, |lua, &me, ()| {
+			let mut matcher = VfsMatcher::from(&me.authorities);
+			let iter = lua.create_function_mut(move |lua, ()| {
+				if let Some((scheme, domains)) = matcher.next() {
+					(scheme, domains).into_lua_multi(lua)
+				} else {
+					().into_lua_multi(lua)
+				}
+			})?;
+			Ok(iter)
+		});
 	}
 }
 

--- a/yazi-config/src/vfs/vfs_matcher.rs
+++ b/yazi-config/src/vfs/vfs_matcher.rs
@@ -1,0 +1,34 @@
+use std::{mem, sync::Arc};
+
+use hashbrown::{HashMap, hash_map};
+use yazi_shared::auth::Scheme;
+
+use super::{Authorities, DomainsArc};
+
+pub struct VfsMatcher {
+	iter:         hash_map::Iter<'static, Scheme, DomainsArc>,
+	_authorities: Arc<HashMap<Scheme, DomainsArc>>,
+}
+
+impl From<&Authorities> for VfsMatcher {
+	fn from(authorities: &Authorities) -> Self {
+		let authorities = authorities.load_full();
+
+		let iter = unsafe {
+			mem::transmute::<
+				hash_map::Iter<'_, Scheme, DomainsArc>,
+				hash_map::Iter<'static, Scheme, DomainsArc>,
+			>(authorities.iter())
+		};
+
+		Self { iter, _authorities: authorities }
+	}
+}
+
+impl Iterator for VfsMatcher {
+	type Item = (Scheme, DomainsArc);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.iter.next().map(|(scheme, domains)| (scheme.clone(), domains.clone()))
+	}
+}

--- a/yazi-fs/Cargo.toml
+++ b/yazi-fs/Cargo.toml
@@ -63,4 +63,4 @@ ds_parser           = "0.4.0"
 objc2               = { workspace = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-trash = "5.2.7"
+trash = "5.2.8"

--- a/yazi-plugin/src/slim.rs
+++ b/yazi-plugin/src/slim.rs
@@ -7,6 +7,7 @@ pub fn slim_lua(lua: &Lua) -> mlua::Result<()> {
 	globals.raw_set("ui", crate::ui::compose())?;
 	globals.raw_set("ya", crate::utils::compose(true))?;
 	globals.raw_set("fs", crate::fs::compose())?;
+	globals.raw_set("vf", &*yazi_config::VFS)?;
 	globals.raw_set("rt", crate::runtime::compose())?;
 	globals.raw_set("km", crate::keymap::compose())?;
 	globals.raw_set("th", crate::theme::compose().into_lua(lua)?)?;

--- a/yazi-plugin/src/standard.rs
+++ b/yazi-plugin/src/standard.rs
@@ -25,6 +25,7 @@ fn stage_1(lua: &Lua) -> Result<()> {
 	globals.raw_set("ui", crate::ui::compose())?;
 	globals.raw_set("ya", crate::utils::compose(false))?;
 	globals.raw_set("fs", crate::fs::compose())?;
+	globals.raw_set("vf", &*yazi_config::VFS)?;
 	globals.raw_set("ps", crate::pubsub::compose())?;
 	globals.raw_set("rt", crate::runtime::compose())?;
 	globals.raw_set("km", crate::keymap::compose())?;

--- a/yazi-runner/src/provider/provider.rs
+++ b/yazi-runner/src/provider/provider.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, sync::Arc};
 
 use mlua::{ExternalError, FromLua, FromLuaMulti, IntoLua, ObjectLike, Value};
 use tokio::{runtime::Handle, select, sync::mpsc};
@@ -11,7 +11,7 @@ use crate::{LuaCoroutine, Runner, loader::LOADER, provider::{ProvideJob, Provide
 impl Runner {
 	pub async fn provide<T>(
 		&'static self,
-		service: &'static ServiceLua,
+		service: Arc<ServiceLua>,
 		job: ProvideJob,
 	) -> ProvideResult<T>
 	where
@@ -25,7 +25,7 @@ impl Runner {
 
 	async fn provide_do<T>(
 		&'static self,
-		service: &'static ServiceLua,
+		service: Arc<ServiceLua>,
 		job: ProvideJob,
 	) -> ProvideResult<T>
 	where
@@ -56,7 +56,7 @@ impl Runner {
 
 	pub async fn provide_stream<T>(
 		&'static self,
-		service: &'static ServiceLua,
+		service: Arc<ServiceLua>,
 		job: ProvideJob,
 		tx: mpsc::Sender<io::Result<T>>,
 	) where
@@ -69,7 +69,7 @@ impl Runner {
 
 	async fn provide_stream_do<T>(
 		&'static self,
-		service: &'static ServiceLua,
+		service: Arc<ServiceLua>,
 		job: ProvideJob,
 		tx: mpsc::Sender<io::Result<T>>,
 	) -> io::Result<()>

--- a/yazi-shared/src/auth/scheme.rs
+++ b/yazi-shared/src/auth/scheme.rs
@@ -1,12 +1,13 @@
 use std::{fmt, str::FromStr};
 
 use anyhow::{Result, bail};
-use mlua::{FromLua, Lua, LuaString, Value};
+use mlua::{FromLua, IntoLua, Lua, LuaString, Value};
 use serde_with::DeserializeFromStr;
+use strum::EnumIs;
 
 use crate::KebabCasedKey;
 
-#[derive(Clone, Debug, DeserializeFromStr, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeserializeFromStr, EnumIs, Eq, Hash, PartialEq)]
 pub enum Scheme {
 	Regular,
 	Sftp,
@@ -67,5 +68,17 @@ impl Scheme {
 impl FromLua for Scheme {
 	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
 		Ok(LuaString::from_lua(value, lua)?.to_str()?.parse()?)
+	}
+}
+
+impl IntoLua for Scheme {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		lua.create_string(self.as_str())?.into_lua(lua)
+	}
+}
+
+impl IntoLua for &Scheme {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		lua.create_string(self.as_str())?.into_lua(lua)
 	}
 }

--- a/yazi-shared/src/domain/domain.rs
+++ b/yazi-shared/src/domain/domain.rs
@@ -1,6 +1,6 @@
 use std::{borrow::{Borrow, Cow}, fmt::{self, Display, Formatter}, ops::Deref, str};
 
-use mlua::{BorrowedBytes, FromLua, Lua, Value};
+use mlua::{BorrowedBytes, FromLua, IntoLua, Lua, Value};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::{self, IntoDeserializer, Visitor}};
 
 use crate::{BytesExt, data::BytesDeserializer};
@@ -51,6 +51,8 @@ impl Display for Domain<'_> {
 }
 
 impl<'a> Domain<'a> {
+	pub fn to_static(&self) -> Domain<'static> { self.as_ref().to_owned().into() }
+
 	pub(crate) fn into_owned(self) -> Domain<'static> { Domain(Cow::Owned(self.0.into_owned())) }
 
 	pub fn is_catchall(&self) -> bool { *self == Domain::CATCHALL }
@@ -103,4 +105,18 @@ impl FromLua for Domain<'static> {
 	fn from_lua(value: Value, lua: &Lua) -> mlua::Result<Self> {
 		Ok(BorrowedBytes::from_lua(value, lua)?.to_vec().into())
 	}
+}
+
+impl IntoLua for Domain<'_> {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> {
+		match self.0 {
+			Cow::Borrowed(b) => lua.create_string(b)?,
+			Cow::Owned(b) => lua.create_external_string(b)?,
+		}
+		.into_lua(lua)
+	}
+}
+
+impl IntoLua for &Domain<'_> {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> { lua.create_string(&*self)?.into_lua(lua) }
 }

--- a/yazi-shared/src/path/lua.rs
+++ b/yazi-shared/src/path/lua.rs
@@ -1,7 +1,7 @@
-use mlua::{AnyUserData, ExternalError, ExternalResult, Lua, LuaString, MetaMethod, UserData, UserDataFields, UserDataMethods, UserDataRef, Value};
+use mlua::{AnyUserData, ExternalError, ExternalResult, IntoLua, Lua, LuaString, MetaMethod, UserData, UserDataFields, UserDataMethods, UserDataRef, Value};
 use yazi_shim::{OptionExt, log::LOG_LEVEL, mlua::UserDataFieldsExt};
 
-use crate::{path::{PathBufDyn, PathLike, StripPrefixError}, strand::{AsStrand, StrandCow}};
+use crate::{path::{PathBufDyn, PathDyn, PathLike, StripPrefixError}, strand::{AsStrand, StrandCow}};
 
 type PathRef = UserDataRef<PathBufDyn>;
 
@@ -55,6 +55,10 @@ impl PathBufDyn {
 			Err(e @ StripPrefixError::WrongEncoding) => Err(e)?,
 		})
 	}
+}
+
+impl IntoLua for PathDyn<'_> {
+	fn into_lua(self, lua: &Lua) -> mlua::Result<Value> { self.to_owned().into_lua(lua) }
 }
 
 impl UserData for PathBufDyn {

--- a/yazi-shared/src/spec/lua.rs
+++ b/yazi-shared/src/spec/lua.rs
@@ -1,4 +1,4 @@
-use mlua::{UserData, UserDataFields, UserDataRegistry};
+use mlua::{IntoLua, UserData, UserDataFields, UserDataRegistry};
 use yazi_shim::{mlua::UserDataFieldsExt, strum::IntoStr};
 
 use crate::{sendable::Sendable, spec::{Spec, SpecInventory}};
@@ -6,8 +6,8 @@ use crate::{sendable::Sendable, spec::{Spec, SpecInventory}};
 impl UserData for Spec {
 	fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
 		fields.add_cached_field("kind", |_, me| Ok(me.kind.into_str()));
-		fields.add_cached_field("scheme", |lua, me| lua.create_string(&me.scheme));
-		fields.add_cached_field("domain", |lua, me| lua.create_string(&*me.domain));
+		fields.add_cached_field("scheme", |lua, me| (&me.scheme).into_lua(lua));
+		fields.add_cached_field("domain", |lua, me| (&me.domain).into_lua(lua));
 		fields.add_cached_field("data", |lua, me| {
 			me.view.data().map(|d| Sendable::wire_to_value_ref(lua, d)).transpose()
 		});

--- a/yazi-vfs/src/engine/lua/file.rs
+++ b/yazi-vfs/src/engine/lua/file.rs
@@ -1,4 +1,4 @@
-use std::{io::{self, SeekFrom}, pin::Pin, task::{Context, Poll, ready}};
+use std::{io::{self, SeekFrom}, pin::Pin, sync::Arc, task::{Context, Poll, ready}};
 
 use mlua::BString;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
@@ -12,7 +12,7 @@ type Fut<T> = Pin<Box<dyn Future<Output = io::Result<T>> + Send + Sync + 'static
 pub struct File {
 	url:           UrlBuf,
 	pos:           u64,
-	service:       &'static ServiceLua,
+	service:       Arc<ServiceLua>,
 	demand:        Demand,
 	pending_read:  Option<Fut<BString>>,
 	pending_seek:  Option<SeekState>,
@@ -27,7 +27,7 @@ enum SeekState {
 impl File {
 	pub(super) fn new(
 		url: impl Into<UrlBuf>,
-		service: &'static ServiceLua,
+		service: Arc<ServiceLua>,
 		pos: u64,
 		demand: Demand,
 	) -> Self {
@@ -44,22 +44,22 @@ impl File {
 
 	pub(crate) async fn set_len(&self, size: u64) -> io::Result<()> {
 		let url = self.url.clone();
-		Ok(RUNNER.provide(self.service, ProvideJob::SetLen { url, size }).await.ok()?)
+		Ok(RUNNER.provide(self.service.clone(), ProvideJob::SetLen { url, size }).await.ok()?)
 	}
 
 	pub(crate) async fn set_attrs(&self, attrs: yazi_fs::engine::Attrs) -> io::Result<()> {
 		let url = self.url.clone();
-		Ok(RUNNER.provide(self.service, ProvideJob::SetAttrs { url, attrs }).await.ok()?)
+		Ok(RUNNER.provide(self.service.clone(), ProvideJob::SetAttrs { url, attrs }).await.ok()?)
 	}
 
 	pub(crate) async fn metadata(&self) -> io::Result<Cha> {
 		let url = self.url.clone();
-		Ok(RUNNER.provide(self.service, ProvideJob::Metadata { url }).await.0?)
+		Ok(RUNNER.provide(self.service.clone(), ProvideJob::Metadata { url }).await.0?)
 	}
 
 	pub(crate) async fn file(&self) -> io::Result<yazi_fs::file::File> {
 		let url = self.url.clone();
-		Ok(RUNNER.provide(self.service, ProvideJob::File { url }).await.0?)
+		Ok(RUNNER.provide(self.service.clone(), ProvideJob::File { url }).await.0?)
 	}
 
 	pub(crate) async fn into_file(self) -> io::Result<yazi_fs::file::File> {
@@ -83,7 +83,7 @@ impl File {
 		}
 
 		if me.pending_write.is_none() {
-			let (service, len) = (me.service, bytes.len());
+			let (service, len) = (me.service.clone(), bytes.len());
 			let job = ProvideJob::Write { url: me.url.clone(), offset: me.pos, bytes };
 			me.pending_write = Some(Box::pin(async move {
 				RUNNER.provide(service, job).await.ok()?;
@@ -114,7 +114,7 @@ impl AsyncRead for File {
 		}
 
 		if me.pending_read.is_none() {
-			let service = me.service;
+			let service = me.service.clone();
 			let job =
 				ProvideJob::Read { url: me.url.clone(), offset: me.pos, len: buf.remaining() };
 			me.pending_read = Some(Box::pin(async move { Ok(RUNNER.provide(service, job).await.0?) }));
@@ -146,7 +146,7 @@ impl AsyncSeek for File {
 				.map(SeekState::NonBlocking)
 				.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "seek overflow"))?,
 			SeekFrom::End(n) => {
-				let service = me.service;
+				let service = me.service.clone();
 				let job = ProvideJob::Metadata { url: me.url.clone() };
 				SeekState::Blocking(
 					n,

--- a/yazi-vfs/src/engine/lua/lua.rs
+++ b/yazi-vfs/src/engine/lua/lua.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, sync::Arc};
 
 use mlua::FromLua;
 use tokio::sync::mpsc;
@@ -11,7 +11,7 @@ use crate::engine::lua::ReadDir;
 
 pub struct Lua<'a> {
 	pub(crate) url:     Url<'a>,
-	pub(crate) service: &'static ServiceLua,
+	pub(crate) service: Arc<ServiceLua>,
 }
 
 impl<'a> Engine for Lua<'a> {
@@ -55,7 +55,7 @@ impl<'a> Engine for Lua<'a> {
 
 		let (tx, rx) = mpsc::channel(20);
 		tokio::spawn(RUNNER.provide_stream(
-			self.service,
+			self.service.clone(),
 			ProvideJob::CopyTo { from: self.url.into(), to: to.into(), attrs },
 			tx,
 		));
@@ -70,7 +70,7 @@ impl<'a> Engine for Lua<'a> {
 
 		let (tx, rx) = mpsc::channel(20);
 		tokio::spawn(RUNNER.provide_stream(
-			self.service,
+			self.service.clone(),
 			ProvideJob::CopyFrom { from: from.into(), to: self.url.into(), attrs },
 			tx,
 		));
@@ -215,7 +215,7 @@ impl<'a> Lua<'a> {
 	where
 		T: FromLua + Send + 'static,
 	{
-		RUNNER.provide(self.service, job).await
+		RUNNER.provide(self.service.clone(), job).await
 	}
 
 	pub(crate) async fn handles(&self, caps: C) -> io::Result<bool> {

--- a/yazi-vfs/src/engine/sftp/conn.rs
+++ b/yazi-vfs/src/engine/sftp/conn.rs
@@ -5,9 +5,9 @@ use russh::keys::{PrivateKeyWithHashAlg, PublicKeyOrCertificate, agent::AgentIde
 use yazi_config::vfs::ServiceSftp;
 use yazi_fs::engine::local::Local;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(super) struct Conn {
-	pub(super) config: &'static ServiceSftp,
+	pub(super) config: Arc<ServiceSftp>,
 }
 
 macro_rules! cfg_err {
@@ -55,30 +55,27 @@ impl deadpool::managed::Manager for Conn {
 }
 
 impl Conn {
-	pub(super) async fn roll(self) -> io::Result<deadpool::managed::Object<Self>> {
-		use deadpool::managed::PoolError;
+	pub(super) fn pool(config: Arc<ServiceSftp>) -> deadpool::managed::Pool<Self> {
+		let mut pools = super::CONN.lock();
+		if let Some(weak) = pools.get(&config.auth)
+			&& let Some(pool) = weak.upgrade()
+			&& pool.manager().config == config
+		{
+			return pool;
+		}
 
-		let pool = *super::CONN.lock().entry(self.config).or_insert_with(|| {
-			Box::leak(Box::new(
-				deadpool::managed::Pool::builder(self)
-					.runtime(deadpool::Runtime::Tokio1)
-					.max_size(8)
-					.create_timeout(Some(Duration::from_secs(45)))
-					.build()
-					.unwrap(),
-			))
-		});
-
-		pool.get().await.map_err(|e| match e {
-			PoolError::Timeout(_) => io::Error::new(io::ErrorKind::TimedOut, e.to_string()),
-			PoolError::Backend(e) => e,
-			PoolError::Closed | PoolError::NoRuntimeSpecified | PoolError::PostCreateHook(_) => {
-				io::Error::other(e.to_string())
-			}
-		})
+		let auth = config.auth.clone();
+		let pool = deadpool::managed::Pool::builder(Self { config })
+			.runtime(deadpool::Runtime::Tokio1)
+			.max_size(8)
+			.create_timeout(Some(Duration::from_secs(45)))
+			.build()
+			.unwrap();
+		pools.insert(auth, pool.weak());
+		pool
 	}
 
-	async fn connect(self) -> Result<russh::Channel<russh::client::Msg>, russh::Error> {
+	async fn connect(&self) -> Result<russh::Channel<russh::client::Msg>, russh::Error> {
 		let pref = Arc::new(russh::client::Config {
 			inactivity_timeout: Some(std::time::Duration::from_secs(60)),
 			keepalive_interval: Some(std::time::Duration::from_secs(10)),
@@ -104,17 +101,22 @@ impl Conn {
 		Ok(channel)
 	}
 
+	async fn session(
+		&self,
+		pref: Arc<russh::client::Config>,
+	) -> Result<russh::client::Handle<Self>, russh::Error> {
+		russh::client::connect(pref, (self.config.host.as_str(), self.config.port), self.clone()).await
+	}
+
 	async fn connect_by_password(
-		self,
+		&self,
 		pref: Arc<russh::client::Config>,
 	) -> Result<russh::client::Handle<Self>, russh::Error> {
 		let Some(password) = &self.config.password else {
 			return Err(cfg_err!("Password not provided"));
 		};
 
-		let mut session =
-			russh::client::connect(pref, (self.config.host.as_str(), self.config.port), self).await?;
-
+		let mut session = self.session(pref).await?;
 		if session.authenticate_password(&self.config.user, password).await?.success() {
 			Ok(session)
 		} else {
@@ -123,7 +125,7 @@ impl Conn {
 	}
 
 	async fn connect_by_key(
-		self,
+		&self,
 		pref: Arc<russh::client::Config>,
 	) -> Result<russh::client::Handle<Self>, russh::Error> {
 		let key_file = &self.config.key_file;
@@ -137,9 +139,7 @@ impl Conn {
 			.map_err(|e| cfg_err!("Failed to read key file: {e}"))?;
 		let key = russh::keys::decode_secret_key(&key, self.config.key_passphrase.as_deref())?;
 
-		let mut session =
-			russh::client::connect(pref, (self.config.host.as_str(), self.config.port), self).await?;
-
+		let mut session = self.session(pref).await?;
 		let result = session
 			.authenticate_publickey(
 				&self.config.user,
@@ -154,7 +154,7 @@ impl Conn {
 	}
 
 	async fn connect_by_key_and_cert(
-		self,
+		&self,
 		pref: Arc<russh::client::Config>,
 	) -> Result<russh::client::Handle<Self>, russh::Error> {
 		let key_file = &self.config.key_file;
@@ -198,9 +198,7 @@ impl Conn {
 			}
 		}
 
-		let mut session =
-			russh::client::connect(pref, (self.config.host.as_str(), self.config.port), self).await?;
-
+		let mut session = self.session(pref).await?;
 		if session.authenticate_openssh_cert(&self.config.user, Arc::new(key), cert).await?.success() {
 			Ok(session)
 		} else {
@@ -209,7 +207,7 @@ impl Conn {
 	}
 
 	async fn connect_by_agent(
-		self,
+		&self,
 		pref: Arc<russh::client::Config>,
 	) -> Result<russh::client::Handle<Self>, russh::Error> {
 		let identity_agent = &self.config.identity_agent;
@@ -225,9 +223,7 @@ impl Conn {
 
 		let identities = agent.request_identities().await?;
 		let identity_count = identities.len();
-
-		let mut session =
-			russh::client::connect(pref, (self.config.host.as_str(), self.config.port), self).await?;
+		let mut session = self.session(pref).await?;
 
 		let hash_alg = session.best_supported_rsa_hash().await?.flatten();
 		for identity in identities {
@@ -258,12 +254,10 @@ impl Conn {
 	}
 
 	async fn connect_by_none(
-		self,
+		&self,
 		pref: Arc<russh::client::Config>,
 	) -> Result<russh::client::Handle<Self>, russh::Error> {
-		let mut session =
-			russh::client::connect(pref, (self.config.host.as_str(), self.config.port), self).await?;
-
+		let mut session = self.session(pref).await?;
 		if session.authenticate_none(&self.config.user).await?.success() {
 			Ok(session)
 		} else {

--- a/yazi-vfs/src/engine/sftp/mod.rs
+++ b/yazi-vfs/src/engine/sftp/mod.rs
@@ -2,10 +2,7 @@ yazi_macro::mod_flat!(conn demand metadata read_dir sftp);
 
 static CONN: yazi_shim::cell::RoCell<
 	parking_lot::Mutex<
-		hashbrown::HashMap<
-			&'static yazi_config::vfs::ServiceSftp,
-			&'static deadpool::managed::Pool<Conn>,
-		>,
+		hashbrown::HashMap<yazi_shared::auth::AuthArc, deadpool::managed::WeakPool<Conn>>,
 	>,
 > = yazi_shim::cell::RoCell::new();
 

--- a/yazi-vfs/src/engine/sftp/sftp.rs
+++ b/yazi-vfs/src/engine/sftp/sftp.rs
@@ -1,5 +1,6 @@
 use std::{io, sync::Arc};
 
+use deadpool::managed::PoolError;
 use yazi_config::vfs::{ServiceSftp, Vfs};
 use yazi_fs::engine::{Capabilities, DirReader, Engine, FileHolder, Transmit};
 use yazi_sftp::fs::Attrs;
@@ -12,7 +13,8 @@ pub struct Sftp<'a> {
 	url:             Url<'a>,
 	pub(super) path: &'a typed_path::UnixPath,
 
-	config: &'static ServiceSftp,
+	config: Arc<ServiceSftp>,
+	pool:   deadpool::managed::Pool<Conn>,
 }
 
 impl<'a> Engine for Sftp<'a> {
@@ -122,8 +124,9 @@ impl<'a> Engine for Sftp<'a> {
 			return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("Not a SFTP URL: {url}")));
 		};
 
-		let config = Vfs::service::<&ServiceSftp>(auth)?;
-		Ok(Self::Me { url, path: loc.as_inner(), config })
+		let config: Arc<ServiceSftp> = Vfs::service(auth)?;
+		let pool = Conn::pool(config.clone());
+		Ok(Self::Me { url, path: loc.as_inner(), config, pool })
 	}
 
 	async fn read_dir(self) -> io::Result<Self::ReadDir> {
@@ -195,8 +198,11 @@ impl<'a> Engine for Sftp<'a> {
 }
 
 impl<'a> Sftp<'a> {
-	#[inline]
 	pub(super) async fn op(&self) -> io::Result<deadpool::managed::Object<Conn>> {
-		Conn { config: self.config }.roll().await
+		self.pool.get().await.map_err(|e| match e {
+			PoolError::Timeout(_) => io::Error::new(io::ErrorKind::TimedOut, e.to_string()),
+			PoolError::Backend(e) => e,
+			e => io::Error::other(e.to_string()),
+		})
 	}
 }


### PR DESCRIPTION
This PR extends the virtual file system with a dynamic Lua API.

The VFS registry is exposed as `vf`, allowing plugins to register, update, inspect, and remove VFS services at runtime.

Note that this is experimental at the moment. Please file a bug report if you find any weird behavior.

## Demo

Register a custom VFS provider for `demo://test`:

```lua
vf.demo = {
  test = {
    kind = "scope",
    run = "vfs-demo",
  },
}
```

Update a VFS service:

```lua
vf.demo.test = {
  kind = "scope",
  run = "vfs-demo",
}
```

Loop through all VFS services:

```lua
for scheme, domains in pairs(vf) do
  for domain, service in pairs(domains) do
    ya.dbg(scheme, domain, service.kind)
  end
end
```

Remove a VFS service:

```lua
vf.demo.test = nil
```

Remove a VFS scheme:

```lua
vf.demo = nil
```
